### PR TITLE
Replace Sphinx default search with Pagefind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
 	cp -R $(BUILDDIR)/text/* $(BUILDDIR)/html/_sources/
+	npx -y pagefind --site $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/sphinx_rtd_theme_kgdmod/searchbox.html
+++ b/sphinx_rtd_theme_kgdmod/searchbox.html
@@ -1,9 +1,18 @@
 {%- if builder != 'singlehtml' %}
 <div role="search">
-  <form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get">
-    <input type="text" name="q" placeholder="Search the book" />
-    <input type="hidden" name="check_keywords" value="yes" />
-    <input type="hidden" name="area" value="default" />
-  </form>
+  <link rel="stylesheet" href="{{ pathto('pagefind/pagefind-ui.css', 1) }}" />
+  <script src="{{ pathto('pagefind/pagefind-ui.js', 1) }}"></script>
+  <div id="pagefind-search"></div>
+  <script>
+    window.addEventListener('DOMContentLoaded', function () {
+      new PagefindUI({
+        element: "#pagefind-search",
+        showSubResults: true,
+        showImages: false,
+        resetStyles: false,
+        placeholder: "Search the book"
+      });
+    });
+  </script>
 </div>
 {%- endif %}


### PR DESCRIPTION
## Summary
- Sphinx's built-in client-side search is slow and ranks poorly on this large, math-heavy book. Pagefind runs as a post-build step over the generated HTML — no RST, conf.py, or Python dependency changes required.
- Mount Pagefind UI in the sidebar `searchbox.html` (replaces the old `<form>` posting to `search.html`).
- Append `npx -y pagefind --site _build/html` to the `html` Makefile target so the index is regenerated alongside every HTML build.

The existing Sphinx-generated `search.html` is left in place but becomes unused. `_build/*` is already in `.gitignore`, so the generated `pagefind/` directory is excluded automatically. `copy-html.sh` rsyncs `_build/html/` so deploy needs no change.

Tradeoff: like every text-search engine, Pagefind does not index math content (LaTeX is stripped from rendered HTML). This is unchanged from the prior behaviour.

## Test plan
- [ ] `make html` completes and prints Pagefind's "indexed N pages" line (expect ~110).
- [ ] `_build/html/pagefind/pagefind-ui.js` exists and is non-empty.
- [ ] Run `python start_server.py`, open `http://localhost:8080/`, and verify:
  - [ ] Multi-word phrase ("least squares regression") returns relevant chapters.
  - [ ] Common term ("variance") ranks substantive chapters above passing mentions.
  - [ ] Heading matches outrank body matches.
  - [ ] Terms inside `.. question::` blocks are indexed.
  - [ ] Result previews highlight the matched term.
- [ ] After deploy via `copy-html.sh`, `https://learnche.org/pid/pagefind/pagefind-ui.js` returns 200 and search works on the live site.

https://claude.ai/code/session_01L6L9Tov5FujeojBdooNoo5

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6L9Tov5FujeojBdooNoo5)_