### PR TITLE
Add citation year range, release date, and CLAUDE.md

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,5 +21,6 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
+date-released: 2026-04-29
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# Repository instructions for Claude Code
+
+These instructions apply to any Claude Code session working in this
+repository. Follow them in addition to the normal workflow.
+
+## Bump the citation date whenever you plan a PR
+
+This repository ships citation metadata in two places:
+
+- `CITATION.cff` — the `date-released:` field
+- `README.md` — the suggested attribution line, which carries a year range
+  ending in the most recent update (e.g. `2010–2026`)
+
+**Whenever you are planning a pull request that contains substantive changes
+(content edits, new sections, build changes, anything beyond a pure
+typo / link fix), update both fields before committing:**
+
+1. Set `CITATION.cff` `date-released:` to today's date (`YYYY-MM-DD`).
+2. Update the trailing year of the year range in the README's suggested
+   attribution line to the current year, if it isn't already.
+
+If you skip this step, GitHub's "Cite this repository" button will keep
+showing a stale year and reusers of the book will undercredit the latest
+revision.
+
+## Where the canonical version lives
+
+The release version is `pyproject.toml` `version`. There is no `version.txt`.
+If you need to bump the version, edit `pyproject.toml`.
+
+## Build verification before claiming a build change works
+
+If a PR touches the build (`Makefile`, `pyproject.toml`, `conf.py`,
+`my-extensions/`, `sphinx_rtd_theme_kgdmod/`, or anything imported by them),
+verify locally that **both** `make html` and `make latexpdf` still succeed
+before opening the PR. A broken HTML build is usually obvious; a broken
+LaTeX build often only surfaces in the PDF.
+
+## Figures repository
+
+Figures live in a separate repo (<https://github.com/kgdunn/figures>) and are
+symlinked in as `figures/`. If a content change references a new or modified
+figure, open a parallel PR there and link the two PRs in the descriptions.
+
+## Style for RST source
+
+See `CONTRIBUTING.md` for the full RST style notes. Key points:
+
+- Hard-wrap lines at ~100 characters.
+- Use `:ref:` with explicit labels for cross-references, not raw section
+  names.
+- Use `:math:` / `.. math::` for equations.
+- Use `.. code-block:: <lang>` so the LaTeX backend syntax-highlights
+  correctly.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ your derivative work under the same terms.
 
 Suggested attribution:
 
-> Dunn, K. G. *Process Improvement using Data.* learnche.org/pid (CC BY-SA 4.0).
+> Dunn, K. G. (2010–2026). *Process Improvement using Data.* learnche.org/pid (CC BY-SA 4.0).
 
 Machine-readable citation metadata is available in
 [`CITATION.cff`](CITATION.cff).


### PR DESCRIPTION
## Why

Following up on #25: the citation metadata had no year, which undercredits a book that has been updated continuously since 2010. GitHub's "Cite this repository" button rendered without a year for the same reason.

## What changed

- **`README.md`** — suggested attribution now reads `Dunn, K. G. (2010–2026). …`
- **`CITATION.cff`** — added `date-released: 2026-04-29` so the GitHub citation widget shows the current year and APA/BibTeX exports include it.
- **`CLAUDE.md`** (new) — documents the policy for future Claude Code sessions: bump both fields whenever a substantive PR is planned, so the citation doesn't go stale again. Also captures a few other repository conventions (canonical version source, build verification expectations, figures-repo coordination, RST style pointer).

## Test plan

- [ ] After merge, confirm GitHub's "Cite this repository" button on the repo home page shows 2026 in the rendered APA / BibTeX
- [ ] Verify `CITATION.cff` parses (GitHub will surface a validation error in the UI if it doesn't)
- [ ] Confirm CLAUDE.md is picked up by future Claude Code sessions in this repo

https://claude.ai/code/session_01Wcjsa4LABJTCK4bYcf8FEh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wcjsa4LABJTCK4bYcf8FEh)_