### PR TITLE
Expand back-of-book index entries for the process-monitoring chapter

### DIFF
--- a/process-monitoring/cusum-charts.rst
+++ b/process-monitoring/cusum-charts.rst
@@ -3,6 +3,9 @@
 CUSUM charts
 ==============
 
+.. index::
+	see: cumulative sum; CUSUM
+
 We :ref:`showed earlier <monitoring_sluggish_shewhart_chart>` that the Shewhart chart is not too sensitive to detecting shifts in the mean. Depending on the subgroup size, :math:`n`, we showed that it can take several consecutive samples before a warning or action limit is triggered. The cumulative sum chart, or :index:`CUSUM chart <pair: CUSUM; process monitoring>`, allows more rapid detection of these shifts away from a target value, :math:`T`.
 
 The following equation shows how this chart works.
@@ -32,7 +35,7 @@ The CUSUM chart is extremely sensitive to small changes. The example chart is sh
 
 This figure also shows how the CUSUM chart is used with the 2 masks. Notice that there are no lower and upper bounds for :math:`S_t`. A process that is on target will show a "wandering" value of :math:`S`, moving up and down. In fact, as the second row in the figure shows, a surprising amount of movement up and down occurs even when the process is in control.
 
-What is of interest however is a persistent change in slope in the CUSUM chart. The angle of the superimposed V-mask is the control limit: the narrower the mouth of the mask, the more sensitive the CUSUM chart is to deviations from the target. Both the type I and II error are set by the angle of the V and the leading distance (the distance from the short vertical line to the apex of the V).
+What is of interest however is a persistent change in slope in the CUSUM chart. The angle of the superimposed :index:`V-mask` is the control limit: the narrower the mouth of the mask, the more sensitive the CUSUM chart is to deviations from the target. Both the type I and II error are set by the angle of the V and the leading distance (the distance from the short vertical line to the apex of the V).
 
 The process is considered in control as long as all points are within the arms of the V shape.  The mask in the second row of the plot shows "in control" behaviour, while the mask in the fourth row detects the process mean has shifted, and an alarm should be raised.
 

--- a/process-monitoring/other-types-of-monitoring-charts.rst
+++ b/process-monitoring/other-types-of-monitoring-charts.rst
@@ -1,6 +1,15 @@
 Other types of monitoring charts
 ================================
 
+.. index::
+	pair: S chart; process monitoring
+	pair: R chart; process monitoring
+	pair: p chart; process monitoring
+	pair: np chart; process monitoring
+	pair: EWMV chart; process monitoring
+	see: range chart; R chart
+	see: exponentially weighted moving variance; EWMV chart
+
 You may encounter other charts in practice:
 
 	*	The *S chart* is for monitoring the subgroup's standard deviation. Take the group of :math:`n` samples and show their standard deviation on a Shewhart-type chart. The limits for the chart are calculated using similar correction factors as were used in the derivation for the :math:`\overline{x}` Shewhart chart. This chart has a LCL :math:`\geq 0`.

--- a/process-monitoring/process-capability.rst
+++ b/process-monitoring/process-capability.rst
@@ -22,7 +22,10 @@ Purchasers of your product may request a :index:`process capability ratio` (PCR)
 	
 	\text{PCR} = \frac{\text{Upper specification limit} - \text{Lower specification limit}}{6\sigma} = \frac{\text{USL} - \text{LSL}}{6\sigma}
 	
-Since the population standard deviation, :math:`\sigma`, is not known, an estimate of it is used. Note that the :index:`lower specification limit` (LSL) and :index:`upper specification limit` (USL) are **not the same** as the lower control limit (LCL) and upper control limit (UCL) as were calculated for the Shewhart chart. The LSL and USL are the tolerance limits required by your customers, or set from your internal specifications. 
+.. index::
+	see: tolerance limits; specification limits
+
+Since the population standard deviation, :math:`\sigma`, is not known, an estimate of it is used. Note that the :index:`lower specification limit` (LSL) and :index:`upper specification limit` (USL) are **not the same** as the lower control limit (LCL) and upper control limit (UCL) as were calculated for the Shewhart chart. The LSL and USL are the tolerance limits required by your customers, or set from your internal specifications.
 
 Interpretation of the PCR:
 	
@@ -75,9 +78,13 @@ Processes are not very often centered between their upper and lower specificatio
 		
 The |xdb| term would be the process target from a Shewhart chart, or simply the actual average operating point. Notice that |Cpk| is a one-sided ratio, only the side closest to the specification is reported. So even an excellent process with C\ :sub:`p` = 2.0 that is running off-center will have a lower |Cpk|.
 
+.. index::
+	single: six-sigma process
+	see: 6-sigma; six-sigma process
+
 It is the |Cpk| value that is requested by your customer. Values of 1.3 are usually a minimum requirement, while 1.67 and higher are requested for health and safety-critical applications. A value of |Cpk| :math:`\geq 2.0` is termed a six-sigma process, because the distance from the current operating point, |xdb|, to the closest specification is at least :math:`6\sigma` units.
 
-You can calculate that a shift of :math:`1.5\sigma` from process center will introduce only 3.4 defects per million. This shift would reduce your |Cpk| from 2.0 to 1.5.
+You can calculate that a shift of :math:`1.5\sigma` from process center will introduce only 3.4 :index:`defects per million`. This shift would reduce your |Cpk| from 2.0 to 1.5.
 
 .. Note:: It must be emphasized that |Cpk| and C\ :sub:`p` numbers are only useful for a process which is stable. Furthermore the assumption of normally distributed samples is also required to interpret the |Cpk| value.
 

--- a/process-monitoring/process-monitoring-exercises.rst
+++ b/process-monitoring/process-monitoring-exercises.rst
@@ -291,7 +291,7 @@ Exercises
 
 .. admonition:: Question
 
-	Describe how a monitoring chart could be used to prevent over-control of a batch-to-batch process. (A batch-to-batch process is one where a batch of materials is processed, followed by another batch, and so on).
+	Describe how a monitoring chart could be used to prevent :index:`over-control` of a batch-to-batch process. (A batch-to-batch process is one where a batch of materials is processed, followed by another batch, and so on).
 
 .. admonition:: Solution
 
@@ -569,7 +569,7 @@ Exercises
 
 		Another is to use a larger subgroup size. Use the `autocorrelation function <https://en.wikipedia.org/wiki/Autocorrelation>`_, and the corresponding ``acf(...)`` function in R to verify the degree of relationship. Using this function we can see the raw data are unrelated after the 17th lag, so we could use subgroups of that size. However, even then we see the Shewhart chart showing frequent violation, though fewer than before.
 
-		Yet another alternative is to use an EWMA chart, which takes the autocorrelation into account. However, the EWMA chart limits are found from the assumption that the subgroup means (or raw data, if subgroup size is 1), are independent.
+		Yet another alternative is to use an EWMA chart, which takes the :index:`autocorrelation` into account. However, the EWMA chart limits are found from the assumption that the subgroup means (or raw data, if subgroup size is 1), are independent.
 
 		So we are finally left with the conclusion that perhaps there data really are not from in control operation, or, if they are, we must manually adjust the limits to be wider.
 

--- a/process-monitoring/shewhart-charts.rst
+++ b/process-monitoring/shewhart-charts.rst
@@ -7,6 +7,9 @@ Shewhart charts
 
 .. youtube:: https://www.youtube.com/watch?v=8Ln3emiwQzU&list=PLHUnYbefLmeOPRuT1sukKmRyOVd4WSxJE&index=61
 
+.. index::
+	single: Shewhart, Walter
+
 A :index:`Shewhart chart <pair: Shewhart chart; process monitoring>`, named after Walter Shewhart from Bell Telephone and Western Electric, monitors that a process variable remains on target and within given upper and lower limits. It is a monitoring chart for *location*. It answers the question whether the variable's :index:`location <single: location (process monitoring)>` is stable over time. It does not track anything else about the measurement, such as its standard deviation. Looking ahead: :ref:`we show later <monitoring_shewart_chart_slugishness>` that a pure Shewhart chart needs extra rules to help monitor the location of a variable effectively.
 
 The defining characteristics of a Shewhart chart are: a target, upper and lower control limits (:index:`UCL <single: upper control limit>` and :index:`LCL <single: lower control limit>`). These action limits are defined so that no action is required as long as the variable plotted remains within the limits. In other words a special cause is not likely present if the points remain within the UCL and LCL.
@@ -57,7 +60,7 @@ The derivation in equation :eq:`shewhart-theoretical` requires knowing the popul
 
 .. index:: ! phase 1 (monitoring charts)
 
-Let's take a look at phase 1, the step where we are building the monitoring chart's limits from historical data. Create a new variable |xdb| :math:`= \displaystyle \frac{1}{K} \sum_{k=1}^{K}{ \overline{x}_k}`, where :math:`K` is the number of :math:`\overline{x}` samples we have available to build the monitoring chart, called the :index:`phase 1 <single: phase 1 (monitoring charts)>` data. Note that |xdb| is sometimes called the *grand mean*. Alternatively, just set |xdb| to the desired target value for :math:`x` or use a long portion of stable data to estimate a suitable target
+Let's take a look at phase 1, the step where we are building the monitoring chart's limits from historical data. Create a new variable |xdb| :math:`= \displaystyle \frac{1}{K} \sum_{k=1}^{K}{ \overline{x}_k}`, where :math:`K` is the number of :math:`\overline{x}` samples we have available to build the monitoring chart, called the :index:`phase 1 <single: phase 1 (monitoring charts)>` data. Note that |xdb| is sometimes called the :index:`grand mean <see: grand mean; mean>`. Alternatively, just set |xdb| to the desired target value for :math:`x` or use a long portion of stable data to estimate a suitable target
 
 The next hurdle is :math:`\sigma`. Define :math:`s_k` to be the standard deviation of the :math:`n` values in the :math:`k^\text{th}` subgroup. We do not show it here, but for a subgroup of :math:`n` samples, an unbiased estimator of :math:`\sigma` is given by :math:`\displaystyle \frac{\overline{S}}{a_n}`, where :math:`\overline{S} =  \displaystyle \frac{1}{K} \displaystyle \sum_{k=1}^{K}{s_k}` is simply the average standard deviation calculated from :math:`K` subgroups. Values for :math:`a_n` are looked up from a table, or using the formula below, and depend on the number of samples we use within each subgroup.
 
@@ -176,7 +179,19 @@ Judging the chart's performance
 
 There are 2 ways to :index:`judge performance of a monitoring chart <single: monitoring chart assessment>`. In particular here we discuss the Shewhart chart:
 
-.. rubric:: 1. Error probability. 
+.. rubric:: 1. Error probability.
+
+.. index::
+	single: type I error
+	single: type II error
+	pair: type I error; type II error
+	see: false alarm; type I error
+	see: false positive; type I error
+	see: producer's risk; type I error
+	see: false rejection rate; type I error
+	see: false negative; type II error
+	see: consumer's risk; type II error
+	see: false acceptance rate; type II error
 
 We define two types of errors, Type I and Type II, which are a function of the lower and upper control limits (LCL and UCL).
 
@@ -243,6 +258,9 @@ The :index:`average run length` (ARL) is defined as the average number of sequen
 Extensions to the basic Shewhart chart to help monitor stability of the location
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. index::
+	single: center line
+
 The :index:`Western Electric rules`: we saw above how sluggish the Shewhart chart is in detecting a small shift in the process mean, from :math:`\mu` to :math:`\mu + \Delta\sigma`. The **Western Electric rules** are an attempt to more rapidly detect a process shift, by raising an alarm when these *improbable* events occur:
 
 #. Two out of 3 points lie beyond :math:`2\sigma` on the same side of the centre line
@@ -253,10 +271,14 @@ However, an alternative chart, the CUSUM chart is more effective at detecting a 
 
 **Adding robustness**: the phase I derivation of a monitoring chart is iterative. If you find a point that violates the LCL and UCL limits, then the approach is to remove that point, and recompute the LCL and UCL values. That is because the LCL and UCL limits would have been biased up or down by these unusual points :math:`\overline{x}_k` points.
 
-	This iterative approach can be tiresome with data that has spikes, missing values, outliers, and other problems typical of data pulled from a process database (:index:`historian <single: data historian>`). Robust monitoring charts are procedures to calculate the limits so the LCL and UCL are resistant to the effect of outliers. For example, a robust procedure might use the medians and MAD instead of the mean and standard deviation. An examination of various robust procedures, especially that of the interquartile range, is given in the paper by D. M. Rocke, `Robust Control Charts <https://dx.doi.org/10.2307/1268815>`_, *Technometrics*, **31** (2), p 173 - 184, 1989.
+	This iterative approach can be tiresome with data that has spikes, missing values, outliers, and other problems typical of data pulled from a process database (:index:`historian <single: data historian>`). :index:`Robust monitoring charts <single: robust monitoring chart>` are procedures to calculate the limits so the LCL and UCL are resistant to the effect of outliers. For example, a robust procedure might use the medians and MAD instead of the mean and standard deviation. An examination of various robust procedures, especially that of the interquartile range, is given in the paper by D. M. Rocke, `Robust Control Charts <https://dx.doi.org/10.2307/1268815>`_, *Technometrics*, **31** (2), p 173 - 184, 1989.
 
 	*Note*: do not use robust methods to calculate the values plotted on the charts during phase 2, only use robust methods to calculate the chart limits in phase 1!
 	
+.. index::
+	single: warning limits
+	single: action limits
+
 **Warning limits**: it is common to see warning limits on a monitoring chart at :math:`\pm 2 \sigma`, while the :math:`\pm 3\sigma` limits are called the action limits. Real-time computer systems usually use a colour scheme to distinguish between the warning state and the action state. For example, the chart background changes from green, to orange to red as the deviations from target become more severe.
 
 .. _monitoring_adjust_limits:
@@ -269,6 +291,9 @@ However, an alternative chart, the CUSUM chart is more effective at detecting a 
 
 Mistakes to avoid
 ~~~~~~~~~~~~~~~~~~~~~~~
+
+.. index::
+	single: specification limits
 
 .. TODO: check if the assumption of independence within each subgroup is required
 

--- a/process-monitoring/what-is-process-monitoring-about.rst
+++ b/process-monitoring/what-is-process-monitoring-about.rst
@@ -87,6 +87,13 @@ Discuss one of these unit operations with your colleague. Which variables would 
 In-control vs out-of-control
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. index::
+	single: in-control
+	single: out-of-control
+	pair: in-control; out-of-control
+	see: stable operation; in-control
+	see: unstable operation; out-of-control
+
 Every book on quality control gives a slightly different viewpoint, or uses different terminology for these terms.
 
 In this book we will take "in-control" to mean that the behaviour of the process is stable over time. Note though, that in-control *does not* mean the variable of interest meets the specifications required by the customer, or set by the plant personnel. All that "in control" means is that there are no **special causes** in the data, i.e. the process is stable. A :index:`special cause`, or an :index:`assignable cause` is an event that occurs to move the process, or destabilize it. Process monitoring charts aim to detect such events. The opposite of "special cause" operation is :index:`common cause` operation, or stable process operation.


### PR DESCRIPTION
## Summary

Continues the chapter-by-chapter audit of the Sphinx back-of-book index (#34 covered `univariate-review/`). This PR audits `process-monitoring/` for terms used in prose but missing from the index, plus mirror partners and synonym cross-references.

Notable additions:

- **what-is-process-monitoring-about**: `in-control` / `out-of-control` mirror pair with `see:` from "stable operation" / "unstable operation"
- **shewhart-charts**: `Shewhart, Walter` as named author; `type I error` / `type II error` paired, with `see:` cross-refs for all the prose synonyms (false alarm, false positive, producer's risk, false rejection rate, false negative, consumer's risk, false acceptance rate); `specification limits` umbrella term; `warning limits` and `action limits`; `center line`; `grand mean` (`see: grand mean; mean`); `robust monitoring chart`
- **cusum-charts**: `V-mask`; `see: cumulative sum; CUSUM`
- **other-types-of-monitoring-charts**: `S chart`, `R chart`, `p chart`, `np chart`, `EWMV chart` (this file previously had zero index entries), all paired with `process monitoring`; `see:` refs for "range chart" and "exponentially weighted moving variance"
- **process-capability**: `see: tolerance limits; specification limits`; `six-sigma process`; `defects per million`
- **process-monitoring-exercises**: `over-control`; `autocorrelation`

No prose changes beyond what was needed to host the new `:index:` roles.

## Test plan

- [x] `sphinx-build -b html` (basic theme, to bypass an unrelated theme rendering error on `master`) produces `_build/html-basic/genindex` containing every new entry.
- [x] Spot-checked rendered genindex for: `Shewhart, Walter`, `type I error` / `type II error`, the six `see:` synonyms, `in-control` / `out-of-control`, `S/R/p/np/EWMV chart`, `V-mask`, `over-control`, `six-sigma process`, `defects per million`, `tolerance limits`, `cumulative sum`.
- [x] No new Sphinx warnings caused by the index edits. Pre-existing warnings (missing figures, q-and-a extension, sidebar-in-topic, theme rendering) are unaffected.
- [x] CITATION.cff `date-released:` already at today's date (2026-04-29); README year range already `2010–2026`. No metadata bump needed.

https://claude.ai/code/session_01NnPotcNpn4iCUXMrptvPfP

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnPotcNpn4iCUXMrptvPfP)_