### PR TITLE
Expand back-of-book index entries for the least-squares-modelling chapter

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,6 +21,6 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-date-released: 2026-04-29
+date-released: 2026-04-30
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"

--- a/least-squares-modelling/enrichment-topics.rst
+++ b/least-squares-modelling/enrichment-topics.rst
@@ -7,6 +7,9 @@ These topics are not covered in depth in this book, but might be of interest to 
 Nonparametric models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. index::
+	see: locally weighted regression; LOESS
+
 :index:`Nonparametric modelling <single:nonparametric modelling>` is a general model where the relationship between :math:`x` and :math:`y` is of the form: :math:`y = f(x) + \varepsilon`, but the function :math:`f(x)`, i.e. the model, is left unspecified. The model is usually a smooth function.
 
 Consider the example of plotting Prestige (the `Pineo-Porter prestige <https://en.wikipedia.org/wiki/John_Porter_(sociologist)>`_ score) against Income, from the 1971 Canadian census. A snippet of the data is given by:
@@ -33,7 +36,7 @@ The plot on the left is the raw data, while on the right is the raw data with th
 	:scale: 70
 	:alt: fake width
 
-For bivariate cases, the nonparametric model is often called a *scatterplot smoother*. There are several methods to calculate the model; one way is by locally weighted scatterplot smoother (LOESS), described as follows. Inside a fixed subregion along the :math:`x`-axis (called the window):
+For bivariate cases, the nonparametric model is often called a :index:`scatterplot smoother <pair: scatterplot smoother; nonparametric modelling>`. There are several methods to calculate the model; one way is by :index:`locally weighted scatterplot smoother <pair: LOESS; nonparametric modelling>` (LOESS), described as follows. Inside a fixed subregion along the :math:`x`-axis (called the window):
 
 .. TODO: be specific in point 2 below
 
@@ -130,7 +133,9 @@ In this example the two models perform similarly in terms on their :math:`S_E`, 
 Logistic modelling (regression)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. index:: integer variables in least squares, logistic regression
+.. index::
+	single: logistic regression
+	see: logistic modelling; logistic regression
 
 There are many practical cases in engineering modelling where our |y|-variable is a discrete entity. The most common case is pass or failure, naturally coded as |y| = 0 for failure, and |y| = 1 is coded as success. Some examples:
 
@@ -166,7 +171,7 @@ Testing of least-squares models
 
 Before launching into this concept, first step back and understand why we are building least squares models. One objective is to learn more about our systems: (a) what is the effect of one variable on another, or (b) is the effect significant (examine the confidence interval). Another objective is purely predictive: build a model so that we can use it to make predictions. For this last case we must test our model's capability for accurate predictions.
 
-The gold standard is always to have a testing data set available to quantify how good (adequate) your least squares model is. It is important that (a) the test set has no influence on the calculation of the model parameters, and (b) is representative of how the model will be used in the future. We will illustrate this with 2 examples: you need to build a predictive model for product viscosity from 3 variables on your process. You have data available, once per day, for 2006 and 2007 (730 observations).
+The gold standard is always to have a :index:`testing data <pair: testing data; least squares>` set available to quantify how good (adequate) your least squares model is. It is important that (a) the test set has no influence on the calculation of the model parameters, and (b) is representative of how the model will be used in the future. We will illustrate this with 2 examples: you need to build a predictive model for product viscosity from 3 variables on your process. You have data available, once per day, for 2006 and 2007 (730 observations).
 
 	*	Use observation 1, 3, 5, 7, ... 729 to build the least squares model; then use observation 2, 4, 6, 8, ... 730 to test the model.
 	
@@ -174,7 +179,7 @@ The gold standard is always to have a testing data set available to quantify how
 
 In both cases, the testing data has no influence on the model parameters. However the first case is not representative of how the model will be used in the future. The results from the first case are likely to give over-optimistic results, while the second case represents the intended use of the model more closely, and will have more honest results. Find out sooner, rather than later, that the model's long-term performance is not what you expect. It may be that you have to keep rebuilding the model every 3 months, updating the model with the most recent data, in order to maintain it's predictive performance.
 
-How do we quantify this predictive performance?  A common way is to calculate the root mean square of the prediction error (:index:`RMSEP`), this is very similar to the :ref:`standard error <standard-error-section>` that we saw earlier for regression models. Assuming the errors are centered at zero and follow a normal distribution, the RMSEP can be interpreted as the standard deviation of the prediction residuals. It is important the RMSEP be calculated only from new, unseen testing data. By contrast, you might see the term RMSEE (root mean square error of estimation), which is the RMSEP, but calculated from the training (model-building) data. The :index:`RMSEE` :math:`\approx S_E` = standard error; the small difference being due to the denominator used (:math:`n` versus :math:`n-k`).
+How do we quantify this predictive performance?  A common way is to calculate the root mean square of the prediction error (:index:`RMSEP`), this is very similar to the :ref:`standard error <standard-error-section>` that we saw earlier for regression models. Assuming the errors are centered at zero and follow a normal distribution, the RMSEP can be interpreted as the standard deviation of the prediction residuals. It is important the RMSEP be calculated only from new, unseen testing data. By contrast, you might see the term RMSEE (root mean square error of estimation), which is the RMSEP, but calculated from the :index:`training data <pair: training data; least squares>` (model-building data). The :index:`RMSEE` :math:`\approx S_E` = standard error; the small difference being due to the denominator used (:math:`n` versus :math:`n-k`).
 
 .. math::
 

--- a/least-squares-modelling/investigating-an-existing-linear-model.rst
+++ b/least-squares-modelling/investigating-an-existing-linear-model.rst
@@ -22,7 +22,7 @@ The assumption of normally distributed errors
 
 We look for normally distributed errors because if they are non-normal, then the standard error, :math:`S_E` and the other variances that depend on :math:`S_E`, such as :math:`\mathcal{V}(b_1)`, could be inflated, and their interpretation could be in doubt. This might, for example, lead us to infer that a slope coefficient is not important when it actually is.
 
-This is one of the easiest assumptions to verify: use a :ref:`q-q plot <univariate_check_for_normality_qqplot>` to assess the distribution of the residuals. Do *not* plot the residuals in sequence or some other order to verify normality - it is extremely difficult to see that. A q-q plot highlights very clearly when tails from the residuals are too heavy. A histogram may also be used, but for real data sets, the choice of bin width can dramatically distort the interpretation - rather use a q-q plot. Some code for R:
+This is one of the easiest assumptions to verify: use a :index:`q-q plot <pair: q-q plot; residuals>` (see the :ref:`univariate review <univariate_check_for_normality_qqplot>`) to assess the distribution of the residuals. Do *not* plot the residuals in sequence or some other order to verify normality - it is extremely difficult to see that. A q-q plot highlights very clearly when tails from the residuals are too heavy. A histogram may also be used, but for real data sets, the choice of bin width can dramatically distort the interpretation - rather use a q-q plot. Some code for R:
 
 .. code-block:: s
 
@@ -93,12 +93,16 @@ This problem reveals itself by showing a fan shape across the plot; an example i
 	:width: 900px
 	:alt: fake width
 
-To counteract this problem one can use weighted least squares, with smaller weights on the high-variance observations, i.e. apply a weight inversely proportional to the variance. Weighted least squares minimizes: :math:`f(\mathrm{b}) = \sum_i^n{(w_ie_i)^2}`, with different weights, :math:`w_i` for each error term. More on this topic can be found in the book by Draper and Smith (p 224 to 229, 3rd edition).
+To counteract this problem one can use :index:`weighted least squares <pair: weighted least squares; WLS>`, with smaller weights on the high-variance observations, i.e. apply a weight inversely proportional to the variance. Weighted least squares minimizes: :math:`f(\mathrm{b}) = \sum_i^n{(w_ie_i)^2}`, with different weights, :math:`w_i` for each error term. More on this topic can be found in the book by Draper and Smith (p 224 to 229, 3rd edition).
 
 .. _LS-autocorrelation-test:
 
 Lack of independence in the data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. index::
+	single: autocorrelation
+	see: WLS; weighted least squares
 
 .. youtube:: https://www.youtube.com/watch?v=7fd8Qu1i3Dk&list=PLHUnYbefLmeOPRuT1sukKmRyOVd4WSxJE&index=26
 
@@ -126,7 +130,7 @@ Here are some examples of the autocorrelation plot: in the first case you would 
 	:scale: 70
 	:alt: fake width
 
-Another test for autocorrelation is the Durbin-Watson test. For more on this test see the book by Draper and Smith (Chapter 7, 3rd edition); in R you can use the ``durbinWatsonTest(model)`` function in ``library(car)``. Try generating autocorrelation of varying strength (positive, e.g. ``phi_long = 0.80`` and negative, e.g. ``phi_long = -0.75``) in the code below. Inspect the plots which are generated as a result, especially the time order plot: get a feeling for what a strong and weak positive/negative correlation looks like in the time order.
+Another test for autocorrelation is the :index:`Durbin-Watson test <pair: Durbin-Watson test; autocorrelation>`. For more on this test see the book by Draper and Smith (Chapter 7, 3rd edition); in R you can use the ``durbinWatsonTest(model)`` function in ``library(car)``. Try generating autocorrelation of varying strength (positive, e.g. ``phi_long = 0.80`` and negative, e.g. ``phi_long = -0.75``) in the code below. Inspect the plots which are generated as a result, especially the time order plot: get a feeling for what a strong and weak positive/negative correlation looks like in the time order.
 
 .. dcl:: R
 

--- a/least-squares-modelling/least-squares-model-analysis.rst
+++ b/least-squares-modelling/least-squares-model-analysis.rst
@@ -16,6 +16,9 @@ In order to perform the second part we need to make a few assumptions about the 
 The variance breakdown
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. index::
+	pair: F-statistic; least squares
+
 .. youtube:: https://www.youtube.com/watch?v=xIjAD_6nXto&list=PLHUnYbefLmeOPRuT1sukKmRyOVd4WSxJE&index=21
 
 Recall that :ref:`variability <univariate-about-variability>` is what makes our data interesting. Without variance (i.e. just flat lines) we would have nothing to do. The :index:`analysis of variance` is just a tool to show how much variability in the :math:`y`-variable is explained by:
@@ -159,7 +162,10 @@ Derivation of :math:`R^2`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
-.. index:: R2 (correlation coefficient)
+.. index::
+	single: R-squared
+	see: R²; R-squared
+	see: coefficient of determination; R-squared
 
 .. To use this derivation you have to work in deviation variables (x-mean(x)) and (y-mean(y)). Too early in the notes to do that.
 	.. image:: ../figures/least-squares/angle-between-two-vectors.png
@@ -197,7 +203,7 @@ How **good**, or how suitable a model is *for a particular purpose* is almost ne
 - use testing data to verify the model's predictive performance,
 - using cross-validation tools (we will see this topic later on) to see how well the model performs on new, unseen and unused testing data.
 
-We will see later on that :math:`R^2` can be arbitrarily increased by adding terms to the linear model, as we will see in the section on :ref:`multiple linear regression (MLR) <LS_multiple_X_MLR>`. So sometimes you will see the adjusted :math:`R^2` used to account for the :math:`k` terms used in the model:
+We will see later on that :math:`R^2` can be arbitrarily increased by adding terms to the linear model, as we will see in the section on :ref:`multiple linear regression (MLR) <LS_multiple_X_MLR>`. So sometimes you will see the :index:`adjusted R-squared <single: adjusted R-squared>` used to account for the :math:`k` terms used in the model:
 
 .. math::
 
@@ -224,7 +230,9 @@ Assumptions required for analysis of the least squares model
 
 .. index::
 	pair: least squares; assumptions for
-	
+	single: constant error variance
+	see: homoscedasticity; constant error variance
+
 .. youtube:: https://www.youtube.com/watch?v=Qls1R2HOzy0&list=PLHUnYbefLmeOPRuT1sukKmRyOVd4WSxJE&index=22
 
 Recall that the population (true) model is :math:`y_i = \beta_0 + \beta_1 x_i + \epsilon_i` and :math:`b_0` and :math:`b_1` are our estimates of the model's coefficients, and :math:`\mathrm{e}` be the estimate of the true error :math:`\epsilon`. Note we are assuming imperfect knowledge of the :math:`y_i` by lumping all errors into :math:`e_i`. For example, measurement error, structural error (we are not sure the process follows a linear structure), inherent randomness, and so on.
@@ -310,7 +318,7 @@ where :math:`j` is an index for all data points used to build the least squares 
 
 #.	What do we use for the numerator term :math:`\mathcal{V}\{y_i\}`?
 
-	-	This term represents the variance of the :math:`y_i` values at a given point :math:`x_i`. If (a) there is no evidence of lack-of-fit, and (b) if |y| has the same error at all levels of |x|, then we can write that :math:`\mathcal{V}\{y_i\}` = :math:`\mathcal{V}\{e_i\}  = \dfrac{\sum{e_i^2}}{n-k}`, where :math:`n` is the number of data points used, and :math:`k` is the number of coefficients estimated (2 in this case). The :math:`n-k` quantity is the degrees of freedom.
+	-	This term represents the variance of the :math:`y_i` values at a given point :math:`x_i`. If (a) there is no evidence of :index:`lack-of-fit`, and (b) if |y| has the same error at all levels of |x|, then we can write that :math:`\mathcal{V}\{y_i\}` = :math:`\mathcal{V}\{e_i\}  = \dfrac{\sum{e_i^2}}{n-k}`, where :math:`n` is the number of data points used, and :math:`k` is the number of coefficients estimated (2 in this case). The :math:`n-k` quantity is the degrees of freedom.
 
 Now for the variance of :math:`b_0 = \overline{\mathrm{y}} - b_1 \overline{\mathrm{x}}`. The only terms with error are :math:`b_1`, and :math:`\overline{\mathrm{y}}`. So we can derive that:
 

--- a/least-squares-modelling/least-squares-models-with-a-single-x-variable.rst
+++ b/least-squares-modelling/least-squares-models-with-a-single-x-variable.rst
@@ -1,8 +1,13 @@
 Least squares models with a single x-variable
 ======================================================
 
-.. index:: 
+.. index::
 	pair:	derivation; least squares
+	pair:	slope; least squares
+	pair:	intercept; least squares
+	single: ordinary least squares (OLS)
+	see:    OLS; ordinary least squares (OLS)
+	see:    predicted value; fitted value
 
 The general linear least squares model is a very useful tool (in the right circumstances), and it is the workhorse for a number of algorithms in data analysis.
 
@@ -153,7 +158,7 @@ Now divide the first line through by :math:`n` (the number of data pairs we are 
 
 #.	What does it mean that :math:`\sum_i{(\hat{y}_i e_i)} =  \hat{y}^T e = 0`
 
-		-	The fitted values are uncorrelated with the residuals.
+		-	The :index:`fitted values <pair: fitted value; least squares>` are uncorrelated with the residuals.
 
 #.	How could the denominator term for :math:`b_1` equal zero?  And what would that mean?
 

--- a/least-squares-modelling/multiple-linear-regression.rst
+++ b/least-squares-modelling/multiple-linear-regression.rst
@@ -47,7 +47,7 @@ To help the discussion below it is useful to omit the least squares model's inte
 	\overline{y} &= b_0 + b_1 \overline{x} \\
 	y_i - \overline{y} &= 0 +b_1(x_i - \overline{x}) \qquad \text{by subtracting the previous lines from each other}
 
-This indicates that if we fit a model where the |x| and |y| vectors are first mean-centered, i.e. let :math:`x = x_\text{original} - \text{mean}\left(x_\text{original} \right)` and :math:`y = y_\text{original} - \text{mean}\left(y_\text{original} \right)`, then we still estimate the same slope for :math:`b_1`, but the intercept term is zero. All we gain from this is simplification of the subsequent analysis. Of course, if you need to know what :math:`b_0` was, you can use the fact that :math:`b_0 = \overline{y} - b_1 \overline{x}`. Nothing else changes: the :math:`R^2, S_E, S_E(b_1)` and all other model interpretations remain the same. You can easily prove this for yourself.
+This indicates that if we fit a model where the |x| and |y| vectors are first :index:`mean-centered <pair: mean-centering; least squares>`, i.e. let :math:`x = x_\text{original} - \text{mean}\left(x_\text{original} \right)` and :math:`y = y_\text{original} - \text{mean}\left(y_\text{original} \right)`, then we still estimate the same slope for :math:`b_1`, but the intercept term is zero. All we gain from this is simplification of the subsequent analysis. Of course, if you need to know what :math:`b_0` was, you can use the fact that :math:`b_0 = \overline{y} - b_1 \overline{x}`. Nothing else changes: the :math:`R^2, S_E, S_E(b_1)` and all other model interpretations remain the same. You can easily prove this for yourself.
 
 So in the rest of the this section we will omit the model's intercept term, since it can always be recovered afterwards.
 
@@ -187,8 +187,10 @@ In the prior example, we could say: the effect of substrate concentration on yie
 Integer (dummy, indicator) variables in the model
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. index:: 
+.. index::
 	pair: integer variables; least squares
+	see: dummy variable; integer variables
+	see: indicator variable; integer variables
 
 .. youtube:: https://www.youtube.com/watch?v=TrhG-XhnBK4&list=PLHUnYbefLmeOPRuT1sukKmRyOVd4WSxJE&index=30
 

--- a/least-squares-modelling/outliers-discrepancy-leverage-and-influence-of-the-observations.rst
+++ b/least-squares-modelling/outliers-discrepancy-leverage-and-influence-of-the-observations.rst
@@ -32,10 +32,10 @@ Can we quantify how much *influence* these *discrepancies* have on the model; an
 Leverage
 ~~~~~~~~~~~~~~
 
-.. index:: 
+.. index::
 	pair: leverage; least squares
 
-Leverage measures how much each observation contributes to the model's prediction of :math:`\hat{y}_i`. It is also called the hat value, :math:`h_i`, and simply measures how far away the data point is from the center of the model, but it takes the model's correlation into account:
+Leverage measures how much each observation contributes to the model's prediction of :math:`\hat{y}_i`. It is also called the :index:`hat value <see: hat value; leverage>`, :math:`h_i`, and simply measures how far away the data point is from the center of the model, but it takes the model's correlation into account:
 
 	.. math::
 
@@ -75,7 +75,9 @@ Influence
 
 The :index:`influence <pair: influence; least squares>` of each data point can be quantified by seeing how much the model changes when we omit that data point. The influence of a point is a combination its leverage and its discrepancy. In model A, the square point had large discrepancy but low leverage, so its influence on the model parameters (slope and intercept) was small. For model C, the square point had high leverage, but low discrepancy, so again the change in the slope and intercept of the model was small. However model B had both large discrepancy and high leverage, so its influence is large.
 
-.. index:: Cook's D-statistic
+.. index::
+	single: Cook's D-statistic
+	see: Cook's distance; Cook's D-statistic
 
 ..
 


### PR DESCRIPTION
## Summary

Continues the chapter-by-chapter back-of-book index audit (data-visualization #24, univariate-review #34, process-monitoring #35). Audited the `least-squares-modelling/` chapter for terms used in prose but missing from the Sphinx index, and extended the existing `single:` / `pair:` / `see:` convention to surface key concepts and mirror partner concepts.

### Notable additions per file

- **`least-squares-models-with-a-single-x-variable.rst`** — `pair: slope; least squares`, `pair: intercept; least squares`, and `single: ordinary least squares (OLS)` on the intro block; `see:` from "OLS" and "predicted value"; inline `pair: fitted value; least squares` at first prose mention.
- **`least-squares-model-analysis.rst`** — replace the awkwardly-typed `R2 (correlation coefficient)` with a clean `single: R-squared` plus `see:` redirects from "R²" and "coefficient of determination"; add `single: adjusted R-squared`, `pair: F-statistic; least squares`, `single: constant error variance` (with `see: homoscedasticity`), and an inline `lack-of-fit` role.
- **`investigating-an-existing-linear-model.rst`** — `pair: q-q plot; residuals`, `pair: weighted least squares; WLS`, `single: autocorrelation`, `pair: Durbin-Watson test; autocorrelation`.
- **`outliers-discrepancy-leverage-and-influence-of-the-observations.rst`** — `see: Cook's distance; Cook's D-statistic`; inline `see: hat value; leverage` so "hat value" routes to the existing leverage entry.
- **`multiple-linear-regression.rst`** — `see:` redirects for "dummy variable" and "indicator variable" → integer variables; inline `pair: mean-centering; least squares`.
- **`enrichment-topics.rst`** — `pair: scatterplot smoother; nonparametric modelling`, `pair: LOESS; nonparametric modelling`, `see: locally weighted regression; LOESS`; clean up the muddled `index:: integer variables in least squares, logistic regression` comma-list to a clean `single: logistic regression` plus `see: logistic modelling`; `pair: training data; least squares` and `pair: testing data; least squares`.

### Out of scope (intentional)

- **No author entries.** The only candidates (Box and Jenkins, Cleveland, Rousseeuw, Draper and Smith, Fox) appear only in bibliographic-style references; per the audit's conservative default and the existing `Walter Shewhart` precedent (which is named directly in defining prose), these don't warrant inclusion.
- **No author entries for eponymous methods** (Cook, Anscombe, Durbin, Watson) — the prose names only the statistic/test, not the people.
- Terms not actually used in prose are skipped: `multicollinearity`, `VIF`, `heteroscedasticity` (we use "non-constant error variance"), `normal equations`, `design matrix`, `hat matrix` as a matrix entity.

Per `CLAUDE.md`, `CITATION.cff` `date-released` is bumped to today (2026-04-30). The README year range already ends in 2026.

## Test plan

- [x] `make html` parses all `least-squares-modelling/` doctrees cleanly with no new warnings (only pre-existing missing-figure and missing-include warnings, which exist on `master`).
- [x] No new errors from the new `.. index::` blocks or inline `:index:` roles.
- [ ] Spot-check `_build/html/genindex` once the site builds in CI: confirm new terms (R-squared, adjusted R-squared, slope, intercept, OLS, F-statistic, autocorrelation, Durbin-Watson test, weighted least squares, mean-centering, scatterplot smoother, LOESS, logistic regression, training data, testing data, fitted value, lack-of-fit, constant error variance) are listed and link to the intended paragraphs.
- [ ] Spot-check that the `see:` redirects (`OLS → ordinary least squares`, `R² → R-squared`, `coefficient of determination → R-squared`, `homoscedasticity → constant error variance`, `WLS → weighted least squares`, `dummy variable / indicator variable → integer variables`, `Cook's distance → Cook's D-statistic`, `hat value → leverage`, `locally weighted regression → LOESS`, `logistic modelling → logistic regression`) appear correctly in `genindex`.

The pre-existing `sphinx-book-theme` rendering error and missing-figure warnings on `master` are unrelated to the index edits.

https://claude.ai/code/session_01ContinuingTheChapterByChapterIndex

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCa4raGHWkwWndEYNJL8kS)_