### PR TITLE
Expand back-of-book index for the latent-variable-modelling chapter

### DIFF
--- a/latent-variable-modelling/applications-of-latent-variable-models.rst
+++ b/latent-variable-modelling/applications-of-latent-variable-models.rst
@@ -3,6 +3,17 @@
 Applications of Latent Variable Models
 =====================================================
 
+.. index::
+	pair: applications; latent variable modelling
+	pair: troubleshooting; latent variable modelling
+	pair: process monitoring; latent variable modelling
+	single: multivariate statistical process control (MSPC)
+	see: MSPC; multivariate statistical process control (MSPC)
+	single: soft sensor
+	see: inferential sensor; soft sensor
+	single: model inversion
+	single: new product development
+
 Improved process understanding
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -139,7 +150,7 @@ The general principle in model inversion problems is to manipulate the any degre
 Predictive modelling (inferential sensors)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This section will be expanded soon, but we give an outline here of what inferential sensors are, and how they are built. These sensors also go by the names of software sensors or just soft sensors.
+This section will be expanded soon, but we give an outline here of what :index:`inferential sensors <single: soft sensor>` are, and how they are built. These sensors also go by the names of software sensors or just soft sensors.
 
 The intention of an inferential sensor is to infer a hard-to-measure property, usually a lab measurement or an expensive measurement, using a combination of process data and software-implemented algorithms. 
 
@@ -244,6 +255,11 @@ The usual phase II approach when an alarm is raised is to investigate the variab
 
 Dealing with higher dimensional data structures
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. index::
+	single: multivariate image analysis (MIA)
+	single: image unfolding
+	pair: batch data analysis; latent variable modelling
 
 This section just gives a impression how 3-D and higher dimensional data sets are dealt with. Tools such as PCA and PLS work on two-dimensional matrices. When we receive a 3-dimensional array, such as an image, or a batch data set, then we must unfold that array into a (2D) matrix if we want to use PCA and PLS in the usual manner.
 

--- a/latent-variable-modelling/extracting-value-from-data.rst
+++ b/latent-variable-modelling/extracting-value-from-data.rst
@@ -3,6 +3,13 @@
 Extracting value from data
 ===================================================
 
+.. index::
+	pair: extracting value from data; latent variable modelling
+	single: troubleshooting
+	single: process monitoring; multivariate
+	pair: missing data; latent variable modelling
+	pair: signal-to-noise ratio; latent variable modelling
+
 There are five main areas where engineers use large quantities of data.
 
 	#.	**Improved process understanding**
@@ -130,6 +137,9 @@ These data sets meet all the assumptions required to use the so-called "classica
 
 **Data fusion**
 
+	.. index::
+		single: data fusion
+
 	This is a recent buzz-word that simply means we collect and use data from multiple sources. Imagine the batch system above: we already have data in |Z| recorded by manual entry, data in |X| recorded by sensors on the process, and then |Y|, typically from lab measurements. We might even have a near infrared probe in the reactor that provides a complete spectrum (a vector) at each point in time. The process of combining these data sets together is called data fusion. Each data set is often referred to as a :index:`block <single: block (data set)>`. We prefer to use the term :index:`multiblock` data analysis when dealing with combined data sets.
 
 Issues faced with engineering data
@@ -151,7 +161,7 @@ Issues faced with engineering data
 
 	Engineering systems are usually kept as stable as possible: the ideal being a flat line. Data from such systems have very little signal and high noise. Even though we might record 50 Mb per second from various sensors, computer systems can, and actually do, "throw away" much of the data. This is not advisable from a multivariate data analysis perspective, but the reasoning behind it is hard to fault: much of the data we collect is not very informative. A lot of it is just from constant operation, noise, slow drift or error.
 
-	Finding the interesting signals in these routine data (also known as happenstance data), is a challenge.
+	Finding the interesting signals in these routine data (also known as :index:`happenstance data <single: happenstance data>`), is a challenge.
 
 **Non-causal data**
 

--- a/latent-variable-modelling/principal-component-analysis/algorithms-to-calculate-build-pca-models.rst
+++ b/latent-variable-modelling/principal-component-analysis/algorithms-to-calculate-build-pca-models.rst
@@ -3,12 +3,21 @@
 Algorithms to calculate (build) PCA models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. index::
+	pair: algorithms; principal component analysis
+
 The different algorithms used to build a PCA model provide a different insight into the model's structure and how to interpret it. These algorithms are a reflection of how PCA has been used in different disciplines: PCA is called by different names in each area.
 
 .. _LVM-eigenvalue-decomposition:
 
 Eigenvalue decomposition
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. index::
+	single: eigenvalue decomposition
+	single: eigenvalue
+	single: eigenvector
+	single: Lagrange multiplier
 
 .. Note:: The purpose of this section is not the theoretical details, but rather the interesting interpretation of the PCA model that we obtain from an eigenvalue decomposition.
 
@@ -66,6 +75,10 @@ However, we should note that calculating the latent variable model using an eige
 Singular value decomposition
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. index::
+	single: singular value decomposition (SVD)
+	see: SVD; singular value decomposition (SVD)
+
 .. TODO: Provide additional insight here on how this is equivalent to rotation, scaling, rotation: break down the data into these 3 SVD components
 
 The singular value decomposition (SVD), in general, decomposes a given matrix |X| into three other matrices:
@@ -86,6 +99,12 @@ Like the eigenvalue method, the SVD method calculates all principal components p
 
 Non-linear iterative partial least-squares (NIPALS)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. index::
+	single: NIPALS algorithm
+	pair: NIPALS algorithm; principal component analysis
+	single: power algorithm
+	see: power algorithm; NIPALS algorithm
 
 .. ADD arrow diagram, with numeric labels next to arrows, as in the PLS section.
 
@@ -142,7 +161,7 @@ We will show the algorithm here for the :math:`a^\text{th}` component, where :ma
 		
 	For the first component, :math:`\mathbf{X}_{a}` is just the preprocessed raw data. So we can see that the second component is actually calculated on the residuals :math:`\mathbf{E}_1`, obtained after extracting the first component.
 	
-	This is called *deflation*, and nicely shows why each component is orthogonal to the others. Each subsequent component is only seeing variation remaining after removing all the others; there is no possibility that two components can explain the same type of variability.
+	This is called :index:`deflation <single: deflation>`, and nicely shows why each component is orthogonal to the others. Each subsequent component is only seeing variation remaining after removing all the others; there is no possibility that two components can explain the same type of variability.
 	
 	After deflation we go back to step 1 and repeat the entire process for the next component. Just before accepting the new component we can use a test, such as a randomization test, or :ref:`cross-validation <LVM_number_of_components>`, to decide whether to keep that component or not.
 	

--- a/latent-variable-modelling/principal-component-analysis/determining-the-number-of-components-to-use-in-the-model-with-cross-validation.rst
+++ b/latent-variable-modelling/principal-component-analysis/determining-the-number-of-components-to-use-in-the-model-with-cross-validation.rst
@@ -3,6 +3,11 @@
 Determining the number of components to use in the model with cross-validation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. index::
+	single: Q-squared statistic
+	pair: number of components; latent variable modelling
+	single: over-fitting
+
 ..	Any recorded values we have from a system, in |X|, can be broken down into 2 parts: the data structure that is systematic, :math:`\mathbf{TP}'`, and an error component, :math:`\textbf{E}`.
 
 .. The problem of determining "*how many components*" is related to knowing when we have extracted all the systematic variables from the data, |X|, into the latent variable model, :math:`\mathbf{TP}'`. Step back for a minute and think what that means: it says we should stop adding latent variables to the model when there is no more systematic correlation remaining between the variables in |X|. That's all the PCA does: extract the variability in |X|. We should stop adding components when we have extracted, *reproducibly*, all systematic variation.

--- a/latent-variable-modelling/principal-component-analysis/geometric-explanation-of-pca.rst
+++ b/latent-variable-modelling/principal-component-analysis/geometric-explanation-of-pca.rst
@@ -5,6 +5,12 @@ Geometric explanation of PCA
 
 .. index::
 	pair: principal component analysis; latent variable modelling
+	single: principal component analysis (PCA)
+	single: principal component
+	pair: score; principal component analysis
+	pair: loading vector; principal component analysis
+	single: hyperplane
+	pair: residual error; principal component analysis
 
 We refer to a :math:`K`-dimensional space when referring to the data in |X|. We will start by looking at the geometric interpretation of PCA when |X| has 3 columns, in other words a 3-dimensional space, using measurements: :math:`[x_1, x_2, x_3]`.
 

--- a/latent-variable-modelling/principal-component-analysis/hotellings-t2-statistic.rst
+++ b/latent-variable-modelling/principal-component-analysis/hotellings-t2-statistic.rst
@@ -3,6 +3,11 @@
 Hotelling's T²
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. index::
+	single: Hotelling's T-squared statistic
+	see: T-squared statistic; Hotelling's T-squared statistic
+	pair: Hotelling's T-squared statistic; principal component analysis
+
 The final quantity from a PCA model that we need to consider is called Hotelling's |T2| value. Some PCA models will have many components, :math:`A`, so an initial screening of these components using score scatterplots will require reviewing :math:`A(A-1)/2` scatterplots. The |T2| value for the :math:`i^\text{th}` observation is defined as:
 
 .. math::

--- a/latent-variable-modelling/principal-component-analysis/interpreting-score-plots-and-loading-plots.rst
+++ b/latent-variable-modelling/principal-component-analysis/interpreting-score-plots-and-loading-plots.rst
@@ -5,6 +5,7 @@ Interpreting score plots
 
 .. index::
 	pair: interpret score plot; latent variable modelling
+	single: score plot
 
 Before summarizing some points about how to interpret a score plot, let's quickly repeat what a score value is. There is one score value for each observation (row) in the data set, so there are are :math:`N` score values for the first component, another :math:`N` for the second component, and so on.
 
@@ -48,14 +49,14 @@ It shows how the process was operating in region A, then moved to region B and f
 
 **Outliers**
 
-Outliers are readily detected in a score plot, and using the equation below we can see why. Recall that the data in |X| have been centered and scaled, so the :math:`x`-value for a variable that is operating at the mean level will be roughtly zero. An observation that is at the mean value for all :math:`K` variables will have a score vector of :math:`\mathbf{t}_i = [0, 0, \ldots, 0]`. An observation where many of the variables have values far from their average level is called a multivariate outlier. It will have one or more score values that are far from zero, and will show up on the outer edges of the score scatterplots. 
+Outliers are readily detected in a score plot, and using the equation below we can see why. Recall that the data in |X| have been centered and scaled, so the :math:`x`-value for a variable that is operating at the mean level will be roughtly zero. An observation that is at the mean value for all :math:`K` variables will have a score vector of :math:`\mathbf{t}_i = [0, 0, \ldots, 0]`. An observation where many of the variables have values far from their average level is called a :index:`multivariate outlier <single: multivariate outlier>`. It will have one or more score values that are far from zero, and will show up on the outer edges of the score scatterplots. 
 
 Sometimes all it takes is for one variable, :math:`x_{i,k}` to be far away from its average to cause :math:`t_{i,a}` to be large:
 
 .. math:: 
 	t_{i,a} = x_{i,1}\,\, p_{1,a} + x_{i,2} \,\, p_{2,a} + \ldots + x_{i,k} \,\, p_{k,a} + \ldots + x_{i,K} \,\, p_{K,a} 
 	
-But usually it is a combination of more than one :math:`x`-variable. There are :math:`K` terms in this equation, each of which *contribute* to the score value. A bar plot of each of these :math:`K` terms, :math:`x_{i,k} \,\, p_{k,a}`, is called a contribution plot. It shows which variable(s) most contribute to the large score value.
+But usually it is a combination of more than one :math:`x`-variable. There are :math:`K` terms in this equation, each of which *contribute* to the score value. A bar plot of each of these :math:`K` terms, :math:`x_{i,k} \,\, p_{k,a}`, is called a :index:`contribution plot <single: contribution plot>`. It shows which variable(s) most contribute to the large score value.
 
 As an example from the :ref:`food texture data <LVM_food_texture_example>` from earlier, we saw that observation 33 had a large negative :math:`\mathbf{t}_1` value. From :ref:`that prior equation <LVM_eqn_LVM_t1_food_texture>`:
 
@@ -103,7 +104,10 @@ A continuous 3rd variable can be implied using a varying colour scheme, going fr
 
 Interpreting loading plots
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	
+
+.. index::
+	single: loading plot
+
 Recall that the :index:`loadings plot <pair: loadings plot, interpretation of; latent variable modelling>` is a plot of the direction vectors that define the model. Returning back to a previous illustration:
 
 .. image:: ../../figures/pca/geometric-PCA-8-both-components-with-plane.png

--- a/latent-variable-modelling/principal-component-analysis/interpreting-the-residuals.rst
+++ b/latent-variable-modelling/principal-component-analysis/interpreting-the-residuals.rst
@@ -2,6 +2,10 @@
 Interpreting the residuals
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. index::
+	pair: residuals; principal component analysis
+	pair: R-squared; principal component analysis
+
 We consider three types of residuals: residuals within each row of |X|, called squared prediction errors (SPE); residuals for each column of |X|, called :math:`R^2_k` for each column, and finally residuals for the entire matrix |X|, usually just called :math:`R^2` for the model.
 
 .. _LVM-interpreting-SPE-residuals:

--- a/latent-variable-modelling/principal-component-analysis/more-about-the-direction-vectors-loadings.rst
+++ b/latent-variable-modelling/principal-component-analysis/more-about-the-direction-vectors-loadings.rst
@@ -1,6 +1,11 @@
 More about the direction vectors (loadings)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. index::
+	single: loadings (P matrix)
+	single: direction vector
+	see: direction vector; loadings (P matrix)
+
 The direction vectors |p1|, :math:`\mathbf{p}_2` and so on, are each :math:`K \times 1` unit vectors. These are vectors in the original coordinate space (the :math:`K`-dimensional real-world) where the observations are recorded.
 
 But these direction vectors are also our link to the latent-variable coordinate system. These direction vectors create a (hyper)plane that is embedded inside the :math:`K`-dimensional space of the :math:`K` original variables. You will see the terminology of *loadings* - this is just another name for these direction vectors:

--- a/latent-variable-modelling/principal-component-analysis/pca-example-analysis-of-spectral-data.rst
+++ b/latent-variable-modelling/principal-component-analysis/pca-example-analysis-of-spectral-data.rst
@@ -3,6 +3,11 @@
 PCA example: analysis of spectral data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. index::
+	pair: spectral data example; latent variable modelling
+	single: chemometrics
+	single: spectroscopy
+
 A data set, `available on the dataset website <http://openmv.net/info/tablet-spectra>`_, contains data on 460 tablets, measured at 650 different wavelengths.
 
 .. image:: ../../figures/examples/tablet-spectra/pharma-spectra.png

--- a/latent-variable-modelling/principal-component-analysis/pca-example-food-texture-analysis.rst
+++ b/latent-variable-modelling/principal-component-analysis/pca-example-food-texture-analysis.rst
@@ -3,6 +3,9 @@
 PCA example: Food texture analysis
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. index::
+	pair: food texture example; latent variable modelling
+
 Let's take a look at an example to consolidate and extend the ideas introduced so far. This `data set is from a food manufacturer <http://openmv.net/info/food-texture>`_ making a pastry product. Each sample (row) in the data set is taken from a batch of product where 5 quality attributes are measured:
 
 	#.	Percentage oil in the pastry

--- a/latent-variable-modelling/principal-component-analysis/predicted-values-for-each-observation.rst
+++ b/latent-variable-modelling/principal-component-analysis/predicted-values-for-each-observation.rst
@@ -54,7 +54,11 @@ Once we have the predicted value for an observation, we are also interested in t
 					   &= \mathbf{x}'_i - \mathbf{x}'_i \mathbf{P} \mathbf{P}' \\
 					   &= \mathbf{x}'_i \left(I_{K \times K} - \mathbf{P} \mathbf{P}' \right)
 
-The residual *length* or *distance* is the sum of squares of this residual, then we take the square root to form a distance. Technically the *squared prediction error* (SPE) is just the sum of squares for each observation, but often we refer to the square root of this quantity as the SPE as well. Some software packages will scale the root of the SPE by some value; you will see this referred to as the DModX, distance to the model plane for |X|. 
+The residual *length* or *distance* is the sum of squares of this residual, then we take the square root to form a distance. Technically the :index:`squared prediction error <single: squared prediction error (SPE)>` (SPE) is just the sum of squares for each observation, but often we refer to the square root of this quantity as the SPE as well. Some software packages will scale the root of the SPE by some value; you will see this referred to as the :index:`DModX <single: DModX>`, distance to the model plane for |X|.
+
+.. index::
+	see: SPE; squared prediction error (SPE)
+	see: distance to model; DModX 
 
 .. math::
 	\text{SPE}_i &= \sqrt{\mathbf{e}'_{i,A} \mathbf{e}_{i,A}} \\

--- a/latent-variable-modelling/principal-component-analysis/preprocessing-the-data-before-building-a-model.rst
+++ b/latent-variable-modelling/principal-component-analysis/preprocessing-the-data-before-building-a-model.rst
@@ -3,6 +3,11 @@
 Preprocessing the data before building a model
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. index::
+	pair: preprocessing; latent variable modelling
+	single: unit-variance scaling
+	see: unit-variance scaling; autoscaling
+
 The previous sections of this chapter considered the interpretation of a PCA latent variable model. From this section onwards we return to filling important gaps in our knowledge. There are 3 major steps to building any latent variable models:
 
 	#.	Preprocessing the data 
@@ -14,6 +19,9 @@ We discuss the first step in this section, and the next two steps after that.
 There are a number of possibilities for data preprocessing. We mainly discuss centering and scaling in this section, but outline a few other tools first. These steps are usually univariate, i.e. they are applied separately to each column in the raw data matrix |Xraw|. We call the matrix of preprocessed data |X|, this is the matrix that is then presented to the algorithm to build the latent variable model. Latent variable algorithms seldom work on the raw data.
 
 **Transformations**
+
+	.. index::
+		pair: transformations; preprocessing
 
 	The columns in |Xraw| can be transformed: log, square-root and various powers (-1, -0.5, 0.5, 2) are popular options. These are used to reduce the effect of extreme measurements (e.g. log transforms), or because the transformed variable is known to be more correlated with the other variables. An example of this is in a distillation column: the inverse temperature is known to more correlated to the vapour pressure, which we know from first-principles modelling. Using the untransformed variable will lead to an adequate model, but the transformed variable, e.g. using the inverse temperature, can lead to a better model.
 	
@@ -37,7 +45,7 @@ There are a number of possibilities for data preprocessing. We mainly discuss ce
 
 **Dealing with outliers**
 
-	Users often go through a phase of pruning outliers prior to building a latent variable model.  There are often *uninteresting* outliers, for example when a temperature sensor goes off-line and provides a default reading of 0.0 instead of its usual values in the range of 300 to 400K.  The automated tools used to do this are known by names such as trimming and winsorizing. These tools remove the upper and lower :math:`\alpha` percent of the column's tails on the histogram. But care should be taken with these automated approaches, since the most interesting observations are often in the outliers. 
+	Users often go through a phase of pruning outliers prior to building a latent variable model.  There are often *uninteresting* outliers, for example when a temperature sensor goes off-line and provides a default reading of 0.0 instead of its usual values in the range of 300 to 400K.  The automated tools used to do this are known by names such as :index:`trimming <single: trimming>` and :index:`winsorizing <single: winsorizing>`. These tools remove the upper and lower :math:`\alpha` percent of the column's tails on the histogram. But care should be taken with these automated approaches, since the most interesting observations are often in the outliers. 
 
 	The course of action when removing outliers is to always mark their values as missing just for that variable in |Xraw|, rather than removing the entire row in |Xraw|. We do this because we can use the algorithms to calculate the latent variable model when missing data are present within a row.
 

--- a/latent-variable-modelling/principal-component-analysis/testing-the-pca-model.rst
+++ b/latent-variable-modelling/principal-component-analysis/testing-the-pca-model.rst
@@ -16,6 +16,9 @@ The last step of testing, interpreting and using the model is where one will spe
 Using an existing PCA model
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. index::
+	pair: using model on new data; principal component analysis
+
 In this section we outline the process required to use an existing PCA model. What this means is that you have already calculated the model and validated its usefulness. Now you would like to use the model on a new observation, which we call :math:`\mathbf{x}'_{\text{new, raw}}`. The method described below can be efficiently applied to many new rows of observations by converting the row vector notation to matrix notation.
 
 	#.	Preprocess your vector of new data in the same way as you did when you built the model. For example, if you took the log transform of a certain variable, then you must do so for the corresponding entry in :math:`\mathbf{x}'_{\text{new, raw}}`. Also apply mean centering and scaling, using the mean centering and scaling information you calculated when you originally built the model.

--- a/latent-variable-modelling/principal-components-regression.rst
+++ b/latent-variable-modelling/principal-components-regression.rst
@@ -3,6 +3,12 @@
 Principal Component Regression (PCR)
 =======================================
 
+.. index::
+	single: principal component regression (PCR)
+	see: PCR; principal component regression (PCR)
+	pair: principal component regression (PCR); latent variable modelling
+	single: collinearity
+
 Principal component regression (PCR) is an alternative to multiple linear regression (MLR) and has many advantages over MLR.
 
 In :ref:`multiple linear regression <LS_multiple_X_MLR>` we have two matrices (blocks): :math:`\mathbf{X}`, an :math:`N \times K` matrix whose columns we relate to the single vector, :math:`\mathbf{y}`, an :math:`N \times 1` vector, using a model of the form: :math:`\mathbf{y} = \mathbf{Xb}`. The solution vector :math:`\mathbf{b}` is found by solving :math:`\mathbf{b} = \left(\mathbf{X'X}\right)^{-1}\mathbf{X'y}`. The variance of the estimated solution is given by :math:`\mathcal{V}(\mathbf{b}) = \left(\mathbf{X'X}\right)^{-1}S_E^2`.

--- a/latent-variable-modelling/projection-to-latent-structures/analysis-of-designed-experiments-using-pls-models.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/analysis-of-designed-experiments-using-pls-models.rst
@@ -3,6 +3,9 @@
 Analysis of designed experiments using PLS models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. index::
+	pair: designed experiments; projection to latent structures (PLS)
+
 .. NOTE: you already have some of these ideas in the section "LVM-preprocessing": combine them; cross reference them?
 
 Data from a designed experiment, particularly factorial experiments, will have independent columns in |X|. These data tables are adequately analyzed using :ref:`multiple linear regression <LS_multiple_X_MLR>` (MLR) least squares models. 

--- a/latent-variable-modelling/projection-to-latent-structures/coefficient-plots-in-pls.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/coefficient-plots-in-pls.rst
@@ -1,6 +1,10 @@
 Coefficient plots in PLS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. index::
+	single: coefficient plot
+	pair: coefficient plot; projection to latent structures (PLS)
+
 After building an initial PLS model one of the most informative plots to investigate are plots of the :math:`\mathbf{r:c}` vectors: using either bar plots or scatter plots. (The notation :math:`\mathbf{r:c}` implies we superimpose a plot of :math:`\mathbf{r}` on a plot of :math:`\mathbf{c}`.) These plots show the relationship between variables in |X|, between variables in |Y|, as well as the latent variable relationship between these two spaces. The number of latent variables, |A|, is much smaller number than the original variables, :math:`K + M`, effectively compressing the data into a small number of informative plots.
 
 There are models where the number of components is of moderate size, around |A| = 4 to 8, in which case there are several combinations of :math:`\mathbf{r:c}` plots to view. If we truly want to understand how all the |X| and |Y| variables are related, then we must spend time investigating all these plots. However, the coefficient plot can be a useful compromise if one wants to learn, in a single plot,how the |X| variables are related to the |Y| variables using *all* |A| *components*.

--- a/latent-variable-modelling/projection-to-latent-structures/conceptual-mathematical-and-geometric-interpretation-of-pls.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/conceptual-mathematical-and-geometric-interpretation-of-pls.rst
@@ -3,6 +3,11 @@
 A conceptual explanation of PLS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. index::
+	pair: X-space; projection to latent structures (PLS)
+	pair: Y-space; projection to latent structures (PLS)
+	pair: inner relation; projection to latent structures (PLS)
+
 Now that you are comfortable with the concept of a latent variable using PCA and PCR, you can interpret PLS as a latent variable model, but one that has a different objective function. In PCA the objective function was to calculate each latent variable so that it best explains the available variance in :math:`\mathbf{X}_a`, where the subscript |A| refers to the matrix :math:`\mathbf{X}` *before* extracting the :math:`a^\text{th}` component.
 
 In PLS, we also find these latent variables, but we find them so they best explain :math:`\mathbf{X}_a` and best explain :math:`\mathbf{Y}_a`, and so that these latent variables have the strongest possible relationship between :math:`\mathbf{X}_a` and :math:`\mathbf{Y}_a`.
@@ -71,7 +76,12 @@ As this shows then, maximizing the covariance between :math:`\mathbf{t}'_a` and 
 
 These scores, :math:`\mathbf{t}'_a` and :math:`\mathbf{u}_a`, are found subject to the constraints that :math:`\mathbf{\mathbf{w}'_a \mathbf{w}_a} = 1.0` and :math:`\mathbf{\mathbf{c}'_a \mathbf{c}_a} = 1.0`. This is similar to PCA, where the loadings :math:`\mathbf{p}_a` were constrained to unit length. In PLS we constrain the loadings for |X|, called :math:`\mathbf{w}_a`, and the loadings for |Y|, called :math:`\mathbf{c}_a`, to unit length.
 
-The above is a description of one variant of PLS, `known as SIMPLS <https://dx.doi.org/10.1016/0169-7439(93)85002-X>`_ (simple PLS). 
+The above is a description of one variant of PLS, `known as SIMPLS <https://dx.doi.org/10.1016/0169-7439(93)85002-X>`_ (simple PLS).
+
+.. index::
+	single: SIMPLS
+	pair: weight vector (w, c); projection to latent structures (PLS)
+	pair: scores (t, u); projection to latent structures (PLS)
 
 .. _LVM_PLS_geometric_interpretation:
 

--- a/latent-variable-modelling/projection-to-latent-structures/how-the-pls-model-is-calculated.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/how-the-pls-model-is-calculated.rst
@@ -4,6 +4,10 @@
 How the PLS model is calculated
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. index::
+	pair: NIPALS algorithm; projection to latent structures (PLS)
+	pair: deflation; projection to latent structures (PLS)
+
 This section assumes that you are comfortable with the :ref:`NIPALS algorithm for calculating a PCA model <LVM_PCA_NIPALS_algorithm>` from |X|. The NIPALS algorithm proceeds in exactly the same way for PLS, except we iterate through both blocks of |X| and |Y|.
 
 .. figure:: ../../figures/pls/NIPALS-iterations-PLS.png

--- a/latent-variable-modelling/projection-to-latent-structures/index.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/index.rst
@@ -4,13 +4,22 @@
 Introduction to Projection to Latent Structures (PLS)
 ========================================================
 
+.. index::
+	single: projection to latent structures (PLS)
+	pair: projection to latent structures (PLS); latent variable modelling
+	single: X-block
+	single: Y-block
+	pair: predictor block; projection to latent structures (PLS)
+	pair: response block; projection to latent structures (PLS)
+	single: multivariate calibration
+
 Projection to Latent Structures (PLS) is the first step we will take to extending latent variable methods to using more than one block of data. In the PLS method we divide our variables (columns) into two blocks: called |X| and |Y|. 
 
 Learning how to choose which variables go in each block will become apparent later, but for now you may use the rule of thumb that says |X| takes the variables which are always available when using the model, while |Y| takes the variables that are *not always available*. Both |X| and |Y| must be available when building the model, but later, when using the model, only |X| is required. As you can guess, one of the major uses of PLS is for predicting variables in |Y| using variables in |X|, but this is not its only purpose as a model. It is a very good model for process understanding and troubleshooting.
 
 PLS can be used for process monitoring and for optimizing the performance of a process. It is also widely used for new product development, or for improving existing products. In all these cases the |Y| block most often contains the outcome, or quality properties.
 
-However, PLS is most commonly used for prediction. And this is also a good way to introduce PLS. In (chemical) engineering processes we use it to develop software sensors (also known as inferential sensors) that predict time-consuming lab measurement in real-time, using the on-line data from our processes. In laboratories we use spectral data (e.g. NIR spectra) to predict the composition of a liquid; this is known as the calibration problem; once calibrated with samples of known composition we can predict the composition of future samples.
+However, PLS is most commonly used for prediction. And this is also a good way to introduce PLS. In (chemical) engineering processes we use it to develop software sensors (also known as inferential sensors) that predict time-consuming lab measurement in real-time, using the on-line data from our processes. In laboratories we use spectral data (e.g. NIR spectra) to predict the composition of a liquid; this is known as the :index:`calibration problem <single: multivariate calibration>`; once calibrated with samples of known composition we can predict the composition of future samples.
 
 But why use the PLS method at all?
 

--- a/latent-variable-modelling/projection-to-latent-structures/interpreting-pls-scores-and-loadings.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/interpreting-pls-scores-and-loadings.rst
@@ -16,6 +16,11 @@ The only difference that must be remembered is that these scores have a differen
 Interpreting the loadings in PLS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. index::
+	pair: loadings; projection to latent structures (PLS)
+	single: r weights (W*)
+	see: W-star; r weights (W*)
+
 :ref:`Like with the loadings from PCA <LVM_interpreting_loadings>`, :math:`\mathbf{p}_a`,we interpret the loadings :math:`\mathbf{w}_a` from PLS in the same way. Highly correlated variables have similar weights in the loading vectors and appear close together in the loading plots of all dimensions. 
 
 We tend to refer to the PLS loadings, :math:`\mathbf{w}_a`, as weights; this is for reasons that will be explained soon.

--- a/latent-variable-modelling/projection-to-latent-structures/pls-exercises.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-exercises.rst
@@ -2,6 +2,10 @@
 PLS Exercises
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. index::
+	pair: exercises; projection to latent structures (PLS)
+	pair: cheddar cheese example; projection to latent structures (PLS)
+
 .. _LVM-cheddar-cheese-example:
 
 The taste of cheddar cheese

--- a/latent-variable-modelling/what-is-a-latent-variable.rst
+++ b/latent-variable-modelling/what-is-a-latent-variable.rst
@@ -3,6 +3,8 @@ What is a latent variable?
 
 .. index::
 	pair: latent variable modelling; what is a latent variable
+	single: latent variable
+	single: latent variable modelling
 
 We will take a look at what a latent variable is conceptually, geometrically, and mathematically.
 
@@ -61,7 +63,7 @@ and suitable values for each of the weights are :math:`p_{1,1} = p_{2,1} = p_{3,
 
 .. _LVM_linear_combination:
 
-Mathematically the correct way to say this is that :math:`t_1` is a *linear combination* of the raw measurements (:math:`x_1, x_2, x_3` and :math:`x_4`) given by the weights (:math:`p_{1,1}, p_{2,1}, p_{3,1}, p_{4,1}`).
+Mathematically the correct way to say this is that :math:`t_1` is a :index:`linear combination <single: linear combination>` of the raw measurements (:math:`x_1, x_2, x_3` and :math:`x_4`) given by the weights (:math:`p_{1,1}, p_{2,1}, p_{3,1}, p_{4,1}`).
 
 **Geometrically**
 


### PR DESCRIPTION
## Summary

Audit-style review of the `latent-variable-modelling/` subtree that fills genuine gaps in the back-of-book Sphinx index (the one built from `.. index::` directives, surfaced via `html_use_index = True`). Continues the chapter-by-chapter index review initiated in #35, #36, and #37.

The chapter previously had only a handful of entries — primarily for references/readings, exercises, indicator/dummy variables, centering/scaling/autoscaling, contribution plots, scree plot, and linking/brushing. Several canonical concepts that the chapter actually defines were entirely absent from the index.

### Canonical-definition entries added

- **Top-level concepts:** `latent variable`, `latent variable modelling`, `principal component analysis (PCA)`, `principal component regression (PCR)` (file had **no** index directives at all), `projection to latent structures (PLS)`, `Hotelling's T-squared statistic` (file had no entry), `squared prediction error (SPE)` and `DModX`, `multivariate calibration`, `principal component`, `direction vector`, `loadings (P matrix)`.
- **Algorithms:** `NIPALS algorithm`, `eigenvalue decomposition`, `singular value decomposition (SVD)`, `Lagrange multiplier`, `power algorithm`, `deflation` (PCA + PLS), `SIMPLS`.
- **Diagnostics & plots:** `score plot`, `loading plot`, `contribution plot`, `coefficient plot`, `multivariate outlier`, `Q-squared statistic`, `over-fitting`, R-squared in PCA.
- **PLS-specific:** `X-block`, `Y-block`, `predictor block`, `response block`, `X-space`, `Y-space`, `inner relation`, weight vectors `(w, c)`, scores `(t, u)`, `r weights (W*)` with see-from `W-star`.
- **Applications:** `multivariate statistical process control (MSPC)`, `soft sensor` (with `see: inferential sensor; soft sensor`), `model inversion`, `new product development`, `multivariate image analysis (MIA)`, `image unfolding`, `troubleshooting`, batch data analysis pair.
- **Data setup:** `data fusion`, `happenstance data`, `multivariate process monitoring`, missing data and signal-to-noise pairs, `unit-variance scaling` (see: autoscaling), preprocessing transformations, `trimming`, `winsorizing`.
- **Worked-example labels:** food texture, spectral data, cheddar cheese (mirroring the existing `pair: exercises; latent variable modelling` style).
- **See/seealso cross-references:** `SPE → squared prediction error`, `SVD → singular value decomposition`, `PCR → principal component regression`, `T-squared → Hotelling's T-squared`, `power algorithm → NIPALS`, `direction vector → loadings`, `inferential sensor → soft sensor`.

Followed the existing chapter convention (`pair: <topic>; latent variable modelling`) where it fit naturally and used `single:` for canonical standalone terms. Did **not** invent author entries for surname-eponymous methods (Hotelling, Wold, Geladi, etc.), per the convention from earlier chapters — only authors named in body prose would qualify and the LVM chapter mostly cites them in references rather than introducing them by name in the running text.

CITATION.cff `date-released:` is already at today's date (2026-04-30) and the README year-range already ends in 2026, so no metadata bumps were needed.

## Test plan

- [ ] `make html` builds without new warnings; the genindex page renders the new entries.
- [ ] Spot-check that "Hotelling's T-squared statistic", "principal component regression", "NIPALS", "SPE", and "soft sensor" all appear in the back-of-book index.
- [ ] Verify see-cross-references render (e.g. `SVD` → singular value decomposition).
- [ ] No `.html`-suffixed paths or other URL-suffix changes were introduced.

https://claude.ai/code/session_01EGyoh69KnJ2dJqXak1pSz8

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGyoh69KnJ2dJqXak1pSz8)_