### PR TITLE
Revise product development chapter for coherence and tone

### DIFF
--- a/product-development-product-improvement/product-development.rst
+++ b/product-development-product-improvement/product-development.rst
@@ -8,8 +8,7 @@ Product development and product improvement
 	single: product improvement
 	pair: product development; product improvement
 
-This section covers product development, but it is more correctly called product improvement.
-The reason is that new products are seldom developed completely from scratch; products are regularly improved. The following usage examples show:
+Most "product development" is really product improvement: new products are seldom developed from scratch. The usage examples below show what this looks like in practice, and they motivate the rest of the chapter.
 
 Usage examples
 ~~~~~~~~~~~~~~~
@@ -29,15 +28,13 @@ Usage examples
 
 -   *Engineer 2*: Our current top line product is made with 6 different ingredients. Can we reduce this number down by adjusting the ratios or the choices of ingredients?
 
-As these examples show: "product development" actually happens far more frequently than simply the case of a customer coming to ask for *different, entirely new, specifications* to those you currently have in your portfolio or product catalogue. The opposite case of changing these 3 things, in order to keep the *same specifications* is far more common:
+As these examples show, the common case is not a request for entirely new specifications, but a change to one of three things while the specifications stay the same:
 
-    * which ingredients (raw materials) do you use?
-    * which ingredient ratios, specified by mass fraction, do you use?
-    * which conditions do you implement to get the final product?
+    * which ingredients (raw materials) we use,
+    * the ratios in which we combine them, by mass fraction, and
+    * the process conditions used to make the product.
 
-Both cases of creating an entirely new product, or improving an existing product can be considered with the methods described here.
-
-The end goal is "faster development of personalized products and customer-centric development", using the information and databases we have accumulated over the many years of experience with the process.
+The methods in this chapter handle both situations --- a wholly new product and the adaptation of an existing one --- because the underlying problem is the same: pick values for those three groups of variables that produce the desired outcomes, using whatever historical data we have to guide the choice.
 
 The three degrees of freedom
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -106,7 +103,7 @@ Why product development is difficult
 	pair: Design-Build-Test-Learn cycle; product development
 	single: DBTL cycle
 
-Most product development is still done by intuition and trial-and-error. The methods of optimization and mathematical modelling in this chapter can speed that work up considerably, and in some settings can even automate it. But before getting to the methods, it is worth being honest about why the problem is difficult: there are several places where things can go wrong, and a tool that does not address them will not improve on a good engineer's intuition.
+Most product development is still done by intuition and trial-and-error. The methods later in this chapter can speed that work up considerably, but only if they address the things that make the problem difficult in the first place. The challenges below appear in almost every campaign, and a tool that ignores them will not improve on a good engineer's intuition.
 
 We frame each iteration as a Design-Build-Test-Learn (DBTL) cycle, a framing widely used in the biotechnology and autonomous-experimentation literature:
 
@@ -115,7 +112,7 @@ We frame each iteration as a Design-Build-Test-Learn (DBTL) cycle, a framing wid
 	* **Test**: measure the outcomes on the resulting product.
 	* **Learn**: compare the outcomes against the targets, update the model, decide on the next iteration.
 
-We do not get the product right on the first cycle, so we iterate. Even when you work "by eye" from plots, you are using an implicit model of the system; the methods in this chapter make that model explicit so it can be reused, criticized and improved. Six broad areas of difficulty appear in almost every product-development problem.
+We do not get the product right on the first cycle, so we iterate. Even when you work by eye from plots you are running an implicit model of the system; the methods in this chapter make that model explicit, so it can be reused, criticized and improved. Six broad areas of difficulty recur --- one for each stage of the cycle, plus a cross-cutting set that affects the iteration as a whole.
 
 Problems with the specifications
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -208,7 +205,9 @@ The difficulties above tell us what an ideal framework needs to do. Most of thos
 
 	*	**Reports an operating window.** When constraints are active at a solution, the framework names them, so we learn the limits of the system. When constraints are inactive, the directions in which we can move without losing the solution are reported as an :index:`operating window <single: operating window>`, and ideally the solution is parameterised so the SME can fine-tune within that window. Multivariate :ref:`troubleshooting tools <LVM_troubleshooting>` give us the same diagnostic in the latent-variable space.
 
-The remainder of this chapter shows how the methods already developed in the book --- :ref:`designed experiments <SECTION-design-analysis-experiments>`, :ref:`response surface methods <DOE-RSM>` and :ref:`latent variable models <SECTION_latent_variable_modelling>`, together with standard and Bayesian optimization --- deliver against these properties. Three more goals --- handling **large** data sets, **transfer learning** across manufacturing sites, and a formal proof of **permutation invariance** --- are sometimes asked of a product-development framework. The methods here cope with each of them informally (the latent-variable methods scale to large :math:`N`, mean-centring and scaling are insensitive to row order in practice, and a model trained on one site can be re-fit at another), but a rigorous treatment is beyond this chapter's scope.
+The remainder of this chapter shows how the methods already developed in the book --- :ref:`designed experiments <SECTION-design-analysis-experiments>`, :ref:`response surface methods <DOE-RSM>` and :ref:`latent variable models <SECTION_latent_variable_modelling>`, together with standard and Bayesian optimization --- deliver against these properties.
+
+Three further goals are sometimes asked of a product-development framework but are not treated rigorously here: handling **large** data sets, **transfer learning** across manufacturing sites, and a formal proof of **permutation invariance**. The methods we use cope with each of them informally --- latent-variable models scale to large :math:`N`, mean-centring and scaling are insensitive to row order in practice, and a model trained on one site can be re-fit at another --- but a careful treatment is left to the literature.
 
 Data needed for product development
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/product-development-product-improvement/product-development.rst
+++ b/product-development-product-improvement/product-development.rst
@@ -163,9 +163,14 @@ Scope of the problem
 
 Before working through any specific method, it helps to lay out what an ideal framework for data-driven product development should look like. The fifteen features below are the design goals we hold the methods later in this chapter against. None of them is unique to a particular algorithm; together they tell us which combinations of methods are worth assembling.
 
-A. The tool is **guided by the** :index:`subject matter expert <pair: subject matter expert; product development>` (SME) to accelerate the process; it is not intended to replace them. It will allow them to more rapidly prototype and test alternatives, and guide them. The expert also plays an active role: for example, constraints can be specified by the expert and the tool can help them understand the tradeoffs by providing alternative solutions that they select from.
+.. index::
+	pair: subject matter expert; product development
+	single: multi-objective optimization
+	single: key performance indicator
 
-B. It is :index:`multi-objective <single: multi-objective optimization>`. Multiple goals and targets can be taken along, each with different weights and prioritization if needed. For example, if a certain target objective is poorly explained by the data, then it can be down weighted, but not ignored. We should not have to build models for each outcome variable: we must be able to handle multiple :index:`key performance indicators <single: key performance indicator>` (KPIs), even highly correlated ones and also high-dimensional ones (such as vectors).
+A. The tool is **guided by the subject matter expert** (SME) to accelerate the process; it is not intended to replace them. It will allow them to more rapidly prototype and test alternatives, and guide them. The expert also plays an active role: for example, constraints can be specified by the expert and the tool can help them understand the tradeoffs by providing alternative solutions that they select from.
+
+B. It is **multi-objective**. Multiple goals and targets can be taken along, each with different weights and prioritization if needed. For example, if a certain target objective is poorly explained by the data, then it can be down weighted, but not ignored. We should not have to build models for each outcome variable: we must be able to handle multiple key performance indicators (KPIs), even highly correlated ones and also high-dimensional ones (such as vectors).
 
 C. We must be able to **handle missing data**. Our knowledge regarding physical and chemical properties of the materials is incomplete; we might only have partial results, or loss of data might have occurred. We might have results from earlier experiments, while later experiments may have extra or more sophisticated measurements. In all of these cases we should use the data we have available, and not have to discard rows or columns of incomplete knowledge. (:ref:`PCA <SECTION_PCA>` and :ref:`PLS <SECTION_PLS>` models tolerate missing values natively.)
 
@@ -179,11 +184,16 @@ G. It must allow for **learning and interpretation** by the expert. The model re
 
 H. It should be able to handle **high-dimensional data**, even if many of the measured data are affected by random noise, or are unrelated to the problem. As we will not always know upfront what is important, if we do happen to add more information in our models, then we should not be penalized. It is acceptable to learn iteratively that certain data are uninteresting. (This is one of the central reasons we lean on :ref:`latent variable methods <SECTION_latent_variable_modelling>` later in the chapter.) See the prior point.
 
-I. It should provide guidance to **fill in the spaces of unknown knowledge**. It is therefore both sequential and active. The expert can influence where future experiments should be done, to help expand the model's predictive power, or the model actively indicates the regions where experimental input is needed (the standard :index:`exploit and explore tradeoff <single: explore-exploit tradeoff>`).
+.. index::
+	single: explore-exploit tradeoff
+	single: operating window
+	single: transfer learning
 
-J. An :index:`operating window <single: operating window>` for the solution is provided. When constraints are active at a solution, these should be reported, to learn the limits of the system. Conversely, inactive constraints are also insightful, since these provide an operating window within which we can move without changing the optimization result too much. Even better is if a parameterized solution is presented, allowing the user to fine-tune the solution based on tuneable parameters.
+I. It should provide guidance to **fill in the spaces of unknown knowledge**. It is therefore both sequential and active. The expert can influence where future experiments should be done, to help expand the model's predictive power, or the model actively indicates the regions where experimental input is needed (the standard explore-and-exploit tradeoff).
 
-K. The method should **enable** :index:`transfer learning <single: transfer learning>` across different manufacturing sites, lines, or even different products. For example, a new product can be developed on site A, and then transferred to site B, using data from both sites, to learn the transferable knowledge, and ignore the regions of operation which have no impact.
+J. An **operating window** for the solution is provided. When constraints are active at a solution, these should be reported, to learn the limits of the system. Conversely, inactive constraints are also insightful, since these provide an operating window within which we can move without changing the optimization result too much. Even better is if a parameterized solution is presented, allowing the user to fine-tune the solution based on tuneable parameters.
+
+K. The method should enable **transfer learning** across different manufacturing sites, lines, or even different products. For example, a new product can be developed on site A, and then transferred to site B, using data from both sites, to learn the transferable knowledge, and ignore the regions of operation which have no impact.
 
 L. Different conditions must be handled. Extending an existing product from one matrix to another (e.g. from a liquid to a gel) or when used at different settings (e.g. high or low temperature, pH etc) it will alter the outcomes. So modelling to predict and handle these cases is desirable.
 
@@ -221,21 +231,15 @@ As just mentioned, there are 3 groups of things you can change:
 The "desired outcome"
 ~~~~~~~~~~~~~~~~~~~~~~
 
-This is a specification of what you want to achieve. Your end goal. It is often given as a vector of one or more specifications. For example: you might need to achieve a given viscosity, melting point and product density. These 3 numbers jointly defind the expectations.
+This is a specification of what you want to achieve. Your end goal. It is often given as a vector of one or more specifications. For example: you might need to achieve a given viscosity, melting point and product density. These 3 numbers jointly define the expectations.
 
 .. index::
 	single: sigmoid function
 	single: Gompertz function
 
-Some entries in the desired outcome vector might simply be given as constraints. For example, "an *elongation* value of 15 or lower is acceptable, or a *shelf-life* of 30 days or greater is acceptable. This is more of a yes/no constraint: it is either met, or it is not. It creates a discontinuity in our system when we specify it as an equation later on. Discontinuities are often undesirable from a mathematical modelling and optmization perspective. However these can be dealt with by converting them to a smoothed version, such as by using a sigmoid function or a `Gompertz function <https://en.wikipedia.org/wiki/Gompertz_function>`_.
+Some entries in the desired outcome vector might simply be given as constraints. For example, an *elongation* value of 15 or lower is acceptable, or a *shelf-life* of 30 days or greater is acceptable. This is more of a yes/no constraint: it is either met, or it is not. It creates a discontinuity in our system when we specify it as an equation later on. Discontinuities are often undesirable from a mathematical modelling and optimization perspective. However these can be dealt with by converting them to a smoothed version, such as by using a sigmoid function or a `Gompertz function <https://en.wikipedia.org/wiki/Gompertz_function>`_.
 
 Finally, sometimes the desired outcome is a very large vector, such as time series showing the change of the product, such as elongation in a controlled experiments, or a pH over time. It can also be a spectrum, such as an NIR spectrum. The number of entries in this long vector are highly correlated. So the first step in such a situation is to use a :ref:`principal component model <SECTION_PCA>` and understand the true lower dimensional space that the output space has. Then these, far smaller number of components, are used as a specification. Therefore the methods of product design are applicable in this case too.
-
-The "rank"
-~~~~~~~~~~~
-
-More to come.
-
 
 Data needed for product development
 ====================================

--- a/product-development-product-improvement/product-development.rst
+++ b/product-development-product-improvement/product-development.rst
@@ -40,7 +40,7 @@ Both cases of creating an entirely new product, or improving an existing product
 The end goal is "faster development of personalized products and customer-centric development", using the information and databases we have accumulated over the many years of experience with the process.
 
 Product design uses every chapter of this book
-================================================
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. index::
 	pair: five uses of data; product development
@@ -73,7 +73,7 @@ Product design and improvement is not a sixth area. It is what happens when we d
 The chapter therefore does not introduce many new techniques: it shows how to assemble the methods you already know into a single workflow that designs and improves products.
 
 Why product development is difficult
-=====================================
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. index::
 	pair: Design-Build-Test-Learn cycle; product development
@@ -91,7 +91,7 @@ We frame each iteration as a Design-Build-Test-Learn (DBTL) cycle, a framing wid
 We do not get the product right on the first cycle, so we iterate. Even when you work "by eye" from plots, you are using an implicit model of the system; the methods in this chapter make that model explicit so it can be reused, criticized and improved. Six broad areas of difficulty appear in almost every product-development problem.
 
 Problems with the specifications
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 	*	The targets are usually correlated. As one increases, so does another. A specification that treats them as independent (or constrains one and lets the other float) ignores this structure and will mislead the optimization.
 
@@ -104,7 +104,7 @@ Problems with the specifications
 	*	Closeness to a lab-scale specification is not the same as robustness in production or in the customer's hands. An optimum found in the lab can perform poorly at full scale.
 
 Problems in the Design step
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 	*	The first iteration has little or no data, so the search direction has to come from prior knowledge or :ref:`screening designs <DOE-saturated-screening-designs>`.
 
@@ -121,7 +121,7 @@ Problems in the Design step
 	*	Model inversion is non-unique. Solving :math:`x + y = 4` has infinitely many solutions, and product design almost always has more inputs (manipulated variables) than outputs (targets), so the inverse problem is underdetermined.
 
 Problems in the Build step
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 	*	How repeatable can you run the same recipe? Without good control here an apparent improvement may just be experimental noise, and a move to a new operating region cannot be distinguished from drift.
 
@@ -130,7 +130,7 @@ Problems in the Build step
 	*	Is the lab system a faithful proxy for how the customer actually uses the product? A product that is robust on the bench and fails in customer hands has not really been improved.
 
 Problems in the Test step
-~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 	*	Measurement reproducibility. Outputs sometimes shift between iterations because of uncontrolled factors. We would like to eliminate those factors, or at least correct for them.
 
@@ -139,7 +139,7 @@ Problems in the Test step
 	*	Sensory and slow lab measurements cannot be done on every experiment. A taste panel, or a 5-day shelf-life test, will not keep up with a fast iteration loop. :ref:`Inferential sensors <LVM_inferential_sensors>` and other surrogate measurements speed up the cycle, but they introduce their own error.
 
 Problems in the Learn step
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 	*	Which way do we go next: explore an unexamined region, or exploit the neighbourhood of the current best result? And how should the balance shift as we accumulate cycles?
 
@@ -148,7 +148,7 @@ Problems in the Learn step
 	*	When do we drop old data; when is a surprising point an :ref:`outlier <LS-studentized-residuals>` and not the next ah-ha result; and how do we use the model's predictive uncertainty to decide where to sample next?
 
 Problems with the cycle itself
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 	*	When do we stop? The obvious case is when the goal is reached, but we also need to detect diminishing returns, and to recognize when no feasible solution exists.
 
@@ -159,7 +159,7 @@ Problems with the cycle itself
 The remainder of this chapter describes how the methods already developed in the book --- :ref:`designed experiments <SECTION-design-analysis-experiments>`, :ref:`response surface methods <DOE-RSM>` and :ref:`latent variable models <SECTION_latent_variable_modelling>`, together with standard and Bayesian optimization --- address most of these issues.
 
 Scope of the problem
-=====================
+~~~~~~~~~~~~~~~~~~~~~
 
 Before working through any specific method, it helps to lay out what an ideal framework for data-driven product development should look like. The fifteen features below are the design goals we hold the methods later in this chapter against. None of them is unique to a particular algorithm; together they tell us which combinations of methods are worth assembling.
 
@@ -211,10 +211,10 @@ O. Allow for **model inversion**: we do not only want to predict an outcome from
 These are ambitious goals. Let us explore how we can achieve most of these in the next sections.
 
 Important concepts
-===================
+~~~~~~~~~~~~~~~~~~~
 
 What are the "Degrees of freedom"?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. index::
 	single: degrees of freedom; in product development
@@ -229,7 +229,7 @@ As just mentioned, there are 3 groups of things you can change:
 
 
 The "desired outcome"
-~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^
 
 This is a specification of what you want to achieve. Your end goal. It is often given as a vector of one or more specifications. For example: you might need to achieve a given viscosity, melting point and product density. These 3 numbers jointly define the expectations.
 
@@ -242,7 +242,7 @@ Some entries in the desired outcome vector might simply be given as constraints.
 Finally, sometimes the desired outcome is a very large vector, such as time series showing the change of the product, such as elongation in a controlled experiments, or a pH over time. It can also be a spectrum, such as an NIR spectrum. The number of entries in this long vector are highly correlated. So the first step in such a situation is to use a :ref:`principal component model <SECTION_PCA>` and understand the true lower dimensional space that the output space has. Then these, far smaller number of components, are used as a specification. Therefore the methods of product design are applicable in this case too.
 
 Data needed for product development
-====================================
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. index::
 	pair: data organization; product development
@@ -261,7 +261,7 @@ The methods later in this chapter operate on four data tables that fit together.
 The matrix :math:`\mathbf{D}` shares columns with :math:`\mathbf{F}`. The matrices :math:`\mathbf{F}`, :math:`\mathbf{Z}` and :math:`\mathbf{Y}` share rows: row :math:`i` of each describes the same experiment.
 
 The property database :math:`\mathbf{D}`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This is the most heterogeneous of the four. Each column of :math:`\mathbf{D}` is a candidate building block --- an oil, a fat, a binder, a filler, a polymer --- and the rows are properties: molecular weight, melting point, viscosity at a given shear rate, surface tension, NIR absorbance at each wavelength, and so on. Some practitioners prefer the transposed layout (one material per row, properties as columns); either is fine, as long as you stay consistent.
 
@@ -278,21 +278,21 @@ A few practical points:
 	*	**Vector-valued properties belong in :math:`\mathbf{D}`** as consecutive rows: a particle-size distribution, a thermogravimetric trace, an NIR spectrum. Such blocks are highly correlated and are a natural fit for a :ref:`principal component model <SECTION_PCA>`.
 
 The recipe :math:`\mathbf{F}`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Each row of :math:`\mathbf{F}` is one experiment or one product, and each column is a building block, aligned with the columns of :math:`\mathbf{D}`. The entries in a row are mass fractions and typically sum to 1.
 
 The rows in :math:`\mathbf{F}` need not be products that you sell. Intermediate blends, side experiments and customer trials all belong, as long as each row has a corresponding outcome in :math:`\mathbf{Y}`. It is also useful to split :math:`\mathbf{F}` into sub-blocks --- a binders block, a fats block, a starches block --- so that the model can later assess the effect of each material family separately.
 
 The process conditions :math:`\mathbf{Z}`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The matrix :math:`\mathbf{Z}` has the same number of rows as :math:`\mathbf{F}` and one column per process condition: temperature, pressure, mixing speed, residence time, addition order. Discrete settings (a stirrer that is off, low or high) are :ref:`one-hot encoded <LVM-using-indicator-variables>`. Recipe steps that may or may not be applied are stored as 0/1 indicators.
 
 It is tempting to leave :math:`\mathbf{Z}` out when only the recipe varies during a campaign. Resist that temptation. Conditions that look constant in a campaign --- ambient humidity, operator, raw-material lot number, the calibration date of the analyser --- routinely turn out, after the fact, to have driven a result. If they were never recorded, that diagnosis is impossible. (When such effects *are* expected and we want to remove them by design, we can plan the campaign with :ref:`blocking <DOE_blocking_section>`.) The correct rule is: store the suspected covariates as well as the obvious controlled variables, even if you do not plan to vary them.
 
 The quality outcomes :math:`\mathbf{Y}`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Each row of :math:`\mathbf{Y}` is the same experiment as the corresponding row of :math:`\mathbf{F}` and :math:`\mathbf{Z}`. The columns are the key performance indicators (KPIs): viscosity, melting point, shelf life, taste-panel score, and so on. Vector outcomes (such as a release-rate curve) can also be stored in :math:`\mathbf{Y}` as consecutive columns; if they are highly correlated, summarize them with a few principal components first.
 
@@ -301,7 +301,7 @@ The crucial design rule for :math:`\mathbf{Y}` is to capture, at minimum, the sa
 As with :math:`\mathbf{D}`, capture provenance for every entry: who measured the value, where, when, in which units, and with which protocol. Two viscosity numbers measured with different geometries are not the same measurement.
 
 How the four tables fit together
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 	*	:math:`\mathbf{D}` and :math:`\mathbf{F}` share columns. Every ingredient appearing in any recipe must have a property column in :math:`\mathbf{D}`. A new, unseen ingredient can later be added to :math:`\mathbf{D}` and then used in :math:`\mathbf{F}`, provided its properties lie within the correlation structure of the existing materials.
 

--- a/product-development-product-improvement/product-development.rst
+++ b/product-development-product-improvement/product-development.rst
@@ -106,6 +106,11 @@ Problems with the specifications
 Problems in the Design step
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. index::
+	single: model inversion
+	pair: model inversion; product development
+	see: inverse approach; model inversion
+
 	*	The first iteration has little or no data, so the search direction has to come from prior knowledge or :ref:`screening designs <DOE-saturated-screening-designs>`.
 
 	*	When experiments can run in parallel (e.g. on a robotic platform), how many points, where in the input space, and with how many replicates?
@@ -156,59 +161,27 @@ Problems with the cycle itself
 
 	*	Storage and provenance. How do we name experiments, record ratios and units, and capture covariates (ambient humidity, operator, lot numbers, raw-material amounts that were "constant") that we did not think mattered until the day they did? Model versioning, input-data lineage and a clear audit trail are part of this discipline.
 
-The remainder of this chapter describes how the methods already developed in the book --- :ref:`designed experiments <SECTION-design-analysis-experiments>`, :ref:`response surface methods <DOE-RSM>` and :ref:`latent variable models <SECTION_latent_variable_modelling>`, together with standard and Bayesian optimization --- address most of these issues.
-
-Scope of the problem
-~~~~~~~~~~~~~~~~~~~~~
-
-Before working through any specific method, it helps to lay out what an ideal framework for data-driven product development should look like. The fifteen features below are the design goals we hold the methods later in this chapter against. None of them is unique to a particular algorithm; together they tell us which combinations of methods are worth assembling.
+What we ask of an ideal framework
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. index::
 	pair: subject matter expert; product development
 	single: multi-objective optimization
 	single: key performance indicator
-
-A. The tool is **guided by the subject matter expert** (SME) to accelerate the process; it is not intended to replace them. It will allow them to more rapidly prototype and test alternatives, and guide them. The expert also plays an active role: for example, constraints can be specified by the expert and the tool can help them understand the tradeoffs by providing alternative solutions that they select from.
-
-B. It is **multi-objective**. Multiple goals and targets can be taken along, each with different weights and prioritization if needed. For example, if a certain target objective is poorly explained by the data, then it can be down weighted, but not ignored. We should not have to build models for each outcome variable: we must be able to handle multiple key performance indicators (KPIs), even highly correlated ones and also high-dimensional ones (such as vectors).
-
-C. We must be able to **handle missing data**. Our knowledge regarding physical and chemical properties of the materials is incomplete; we might only have partial results, or loss of data might have occurred. We might have results from earlier experiments, while later experiments may have extra or more sophisticated measurements. In all of these cases we should use the data we have available, and not have to discard rows or columns of incomplete knowledge. (:ref:`PCA <SECTION_PCA>` and :ref:`PLS <SECTION_PLS>` models tolerate missing values natively.)
-
-D. It should **not be dependent on the specific training dataset** and therefore unable to generalize to new ingredients, other properties, new experiments or other conditions used to create the product. Another way of saying this is that it should not be `transductive <https://en.wikipedia.org/wiki/Transduction_(machine_learning)>`_, but rather inductive.
-
-E. It should be able to handle **small data**, particularly small sets of experimentally acquired data that iteratively and sequentially become available. We should not need large amounts of data to get good results as long as we have well-designed experimental data which is strategically chosen to give the most information.
-
-F. It should however be able to handle **large data**. If we do have large quantities of data, then it should be able to handle these as well.
-
-G. It must allow for **learning and interpretation** by the expert. The model results should be understandable, confirm prior knowledge, and generate new insights not yet known to the experts.
-
-H. It should be able to handle **high-dimensional data**, even if many of the measured data are affected by random noise, or are unrelated to the problem. As we will not always know upfront what is important, if we do happen to add more information in our models, then we should not be penalized. It is acceptable to learn iteratively that certain data are uninteresting. (This is one of the central reasons we lean on :ref:`latent variable methods <SECTION_latent_variable_modelling>` later in the chapter.) See the prior point.
-
-.. index::
-	single: explore-exploit tradeoff
 	single: operating window
-	single: transfer learning
+	single: explore-exploit tradeoff
 
-I. It should provide guidance to **fill in the spaces of unknown knowledge**. It is therefore both sequential and active. The expert can influence where future experiments should be done, to help expand the model's predictive power, or the model actively indicates the regions where experimental input is needed (the standard explore-and-exploit tradeoff).
+The difficulties above tell us what an ideal framework needs to do. Most of those properties --- handling correlated and high-dimensional outputs, tolerating missing data, working from small experimental sets, balancing exploration against exploitation, supporting model inversion --- are addressed directly by the methods later in this chapter and the cross-references above. Four further properties cut across the whole cycle and are worth stating explicitly:
 
-J. An **operating window** for the solution is provided. When constraints are active at a solution, these should be reported, to learn the limits of the system. Conversely, inactive constraints are also insightful, since these provide an operating window within which we can move without changing the optimization result too much. Even better is if a parameterized solution is presented, allowing the user to fine-tune the solution based on tuneable parameters.
+	*	**Guided by the subject matter expert.** The tool accelerates the expert; it does not replace them. The SME specifies constraints, vetoes infeasible suggestions, and chooses between alternative solutions when the inversion is non-unique.
 
-K. The method should enable **transfer learning** across different manufacturing sites, lines, or even different products. For example, a new product can be developed on site A, and then transferred to site B, using data from both sites, to learn the transferable knowledge, and ignore the regions of operation which have no impact.
+	*	**Inductive, not transductive.** The model must generalize to new ingredients, conditions and properties --- not just interpolate within the training set. This is why we represent the recipe through a property database (the :math:`\mathbf{D}` matrix in the next section), rather than as a categorical choice between named materials. See the `transduction <https://en.wikipedia.org/wiki/Transduction_(machine_learning)>`_ entry for the contrast with the inductive case.
 
-L. Different conditions must be handled. Extending an existing product from one matrix to another (e.g. from a liquid to a gel) or when used at different settings (e.g. high or low temperature, pH etc) it will alter the outcomes. So modelling to predict and handle these cases is desirable.
+	*	**Interpretable.** The results must be understandable to the expert: they should confirm prior knowledge where it exists, and surface new insight where it does not. Score and loading plots from :ref:`PCA <SECTION_PCA>` and :ref:`PLS <SECTION_PLS>` are the workhorses here, which is one reason we lean on :ref:`latent variable methods <SECTION_latent_variable_modelling>` for the rest of the chapter.
 
-M. It is **permutation invariant**. The order in which we acquire experimental data or present the data to our models should not alter the outcomes we achieve.
+	*	**Reports an operating window.** When constraints are active at a solution, the framework names them, so we learn the limits of the system. When constraints are inactive, the directions in which we can move without losing the solution are reported as an :index:`operating window <single: operating window>`, and ideally the solution is parameterised so the SME can fine-tune within that window. Multivariate :ref:`troubleshooting tools <LVM_troubleshooting>` give us the same diagnostic in the latent-variable space.
 
-N. **Handling different scales** should also be accommodated; cheap experiments at a smaller scale being combined with sparse data at a larger scale (e.g. customer trials).
-
-.. index::
-	single: model inversion
-	pair: model inversion; product development
-	see: inverse approach; model inversion
-
-O. Allow for **model inversion**: we do not only want to predict an outcome from upstream information, but also to use the inverse approach: to predict upstream settings for a given set of performance outcomes. This inverse approach is in many cases non-unique: there are multiple upstream settings that can give the same performance outcome. The system should indicate when multiple solutions are possible (the rank of the input space exceeds the output space) and as such there are directions in input space which are unrelated to the output, giving us extra degrees of freedom.
-
-These are ambitious goals. Let us explore how we can achieve most of these in the next sections.
+The remainder of this chapter shows how the methods already developed in the book --- :ref:`designed experiments <SECTION-design-analysis-experiments>`, :ref:`response surface methods <DOE-RSM>` and :ref:`latent variable models <SECTION_latent_variable_modelling>`, together with standard and Bayesian optimization --- deliver against these properties. Three more goals --- handling **large** data sets, **transfer learning** across manufacturing sites, and a formal proof of **permutation invariance** --- are sometimes asked of a product-development framework. The methods here cope with each of them informally (the latent-variable methods scale to large :math:`N`, mean-centring and scaling are insensitive to row order in practice, and a model trained on one site can be re-fit at another), but a rigorous treatment is beyond this chapter's scope.
 
 Important concepts
 ~~~~~~~~~~~~~~~~~~~

--- a/product-development-product-improvement/product-development.rst
+++ b/product-development-product-improvement/product-development.rst
@@ -127,13 +127,13 @@ Problems with the specifications
 
 	*	Closeness to a lab-scale specification is not the same as robustness in production or in the customer's hands. An optimum found in the lab can perform poorly at full scale.
 
-Problems in the Design step
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 .. index::
 	single: model inversion
 	pair: model inversion; product development
 	see: inverse approach; model inversion
+
+Problems in the Design step
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 	*	The first iteration has little or no data, so the search direction has to come from prior knowledge or :ref:`screening designs <DOE-saturated-screening-designs>`.
 

--- a/product-development-product-improvement/product-development.rst
+++ b/product-development-product-improvement/product-development.rst
@@ -39,6 +39,33 @@ Both cases of creating an entirely new product, or improving an existing product
 
 The end goal is "faster development of personalized products and customer-centric development", using the information and databases we have accumulated over the many years of experience with the process.
 
+The three degrees of freedom
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. index::
+	single: degrees of freedom; in product development
+
+The usage examples above already named the three things we can change. Each Design step in a product-development cycle is a choice over these three groups, and the rest of the chapter keeps coming back to them, so it is worth pinning the vocabulary down explicitly.
+
+1.	**Select the ingredients.** This is a discrete choice: either an ingredient is in the recipe, or it is not. The candidate set is usually a catalogue or database of materials. In many of the usage examples above this degree of freedom is actually fixed --- regulatory constraints, validation cost, or the risk of unexpected side-reactions mean we have to keep using what we already use.
+
+2.	**Adjust the ratios of the ingredients.** This is a continuous choice constrained to a simplex: the mass fractions sum to 1, so reducing one ingredient forces another to increase. This sum-to-one structure is exactly what :ref:`mixture designs <DOE-mixture-designs>` are built to handle.
+
+3.	**Choose the process conditions.** Temperature, pH, residence time, addition order, and the on/off state of optional steps. This is usually where the most degrees of freedom live, and where the historical data has the most correlation: temperature and flow rate, for example, are rarely independent in the historical record even when they are independent on paper.
+
+Specifying the desired outcome
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The desired outcome is the end goal: a vector of one or more specifications. A simple case is three scalars --- a viscosity, a melting point, a density --- that jointly define what "good" means.
+
+.. index::
+	single: sigmoid function
+	single: Gompertz function
+
+Some entries are inequalities rather than targets: an *elongation* of 15 or lower is acceptable, a *shelf-life* of 30 days or greater is acceptable. These are yes/no constraints, and they introduce a discontinuity into the objective. Discontinuities are awkward for the optimizers later in the chapter, so we replace each one with a smoothed indicator --- a sigmoid or a `Gompertz function <https://en.wikipedia.org/wiki/Gompertz_function>`_ --- that approximates the cliff but stays differentiable.
+
+The desired outcome is sometimes a very long vector: a release-rate curve, a pH trajectory, an NIR spectrum. The entries in such a vector are heavily correlated, so we do not work with them directly. The first step is a :ref:`principal component model <SECTION_PCA>` of the output space; the few scores that explain it become the specification, and the rest of the methodology proceeds unchanged.
+
 Product design uses every chapter of this book
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -182,37 +209,6 @@ The difficulties above tell us what an ideal framework needs to do. Most of thos
 	*	**Reports an operating window.** When constraints are active at a solution, the framework names them, so we learn the limits of the system. When constraints are inactive, the directions in which we can move without losing the solution are reported as an :index:`operating window <single: operating window>`, and ideally the solution is parameterised so the SME can fine-tune within that window. Multivariate :ref:`troubleshooting tools <LVM_troubleshooting>` give us the same diagnostic in the latent-variable space.
 
 The remainder of this chapter shows how the methods already developed in the book --- :ref:`designed experiments <SECTION-design-analysis-experiments>`, :ref:`response surface methods <DOE-RSM>` and :ref:`latent variable models <SECTION_latent_variable_modelling>`, together with standard and Bayesian optimization --- deliver against these properties. Three more goals --- handling **large** data sets, **transfer learning** across manufacturing sites, and a formal proof of **permutation invariance** --- are sometimes asked of a product-development framework. The methods here cope with each of them informally (the latent-variable methods scale to large :math:`N`, mean-centring and scaling are insensitive to row order in practice, and a model trained on one site can be re-fit at another), but a rigorous treatment is beyond this chapter's scope.
-
-Important concepts
-~~~~~~~~~~~~~~~~~~~
-
-What are the "Degrees of freedom"?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. index::
-	single: degrees of freedom; in product development
-
-As just mentioned, there are 3 groups of things you can change:
-
-1. **Select your ingredients**. This is a discrete choice: either you use an ingredient or raw materials, or you do not. It is a yes/no selection. You might have a whole catalogue, or database, of materials that you can select from. In many of the cases described in the "Usage examples" above this degree of freedom is actually fixed. In other words, you cannot change the ingredient choice and you must keep using what you already use. This is often due to regulations, or the fact that introducing new ingredients will be too expensive to test and validate and might lead to unexpected side-reactions or interactions.
-
-2. **Adjust the ratios of the ingredients**. This is a sliding parameter: for example you can go from 45% weight fraction of material A, to 41% weight fraction, but remember by using less material A, the weight fractions of other materials change. The total weight fractions always add up to 1.0, so there is a constraint in the system, and adjusting one material will force the other material ratio to also be adjusted. This sum-to-one structure is exactly what :ref:`mixture designs <DOE-mixture-designs>` are built to handle.
-
-3. **Use different process conditions**. This group is where often you have the most degrees of freedom. You can adjust process settings used to make the product quite easily, such as temperature, pH, duration of certain steps, and order in which you add ingredients and complete the manufacturing steps. Because of the diversity of the options here, you might need to spend quite some time thinking about the process, and seeing what freedom you practically and economically have. Like the prior group, the ratios, this group of degrees of freedom also has some correlations in the historical data. For example, you might not be able to independently increase temperature in the process, without adjusting flow rate.
-
-
-The "desired outcome"
-^^^^^^^^^^^^^^^^^^^^^^
-
-This is a specification of what you want to achieve. Your end goal. It is often given as a vector of one or more specifications. For example: you might need to achieve a given viscosity, melting point and product density. These 3 numbers jointly define the expectations.
-
-.. index::
-	single: sigmoid function
-	single: Gompertz function
-
-Some entries in the desired outcome vector might simply be given as constraints. For example, an *elongation* value of 15 or lower is acceptable, or a *shelf-life* of 30 days or greater is acceptable. This is more of a yes/no constraint: it is either met, or it is not. It creates a discontinuity in our system when we specify it as an equation later on. Discontinuities are often undesirable from a mathematical modelling and optimization perspective. However these can be dealt with by converting them to a smoothed version, such as by using a sigmoid function or a `Gompertz function <https://en.wikipedia.org/wiki/Gompertz_function>`_.
-
-Finally, sometimes the desired outcome is a very large vector, such as time series showing the change of the product, such as elongation in a controlled experiments, or a pH over time. It can also be a spectrum, such as an NIR spectrum. The number of entries in this long vector are highly correlated. So the first step in such a situation is to use a :ref:`principal component model <SECTION_PCA>` and understand the true lower dimensional space that the output space has. Then these, far smaller number of components, are used as a specification. Therefore the methods of product design are applicable in this case too.
 
 Data needed for product development
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

The product development chapter (`product-development-product-improvement/product-development.rst`) was assembled from blog posts and notes over several commits, and the seams show: ideas repeat across sections, two of the seven sections are competing taxonomies of the *same* problems, one subsection is a `More to come.` placeholder, and the prose drifts between casual blog tone and textbook tone within the same page.

This PR cleans the chapter up so it reads in the voice of the rest of the book. It is being landed in **incremental commits** so each change is reviewable on its own:

1. **Mechanical fixes** (this commit): typos (`defind`, `optmization`), an unmatched quotation mark, the `More to come` stub, and four inline `:index:` directives moved into proper `.. index::` blocks.
2. **Heading hierarchy** (next): demote interior sections from `===` (sibling of the chapter title) to `~~~` so the chapter has one H1 and proper H2 children.
3. **Consolidate duplicate problem lists**: merge `Why product development is difficult` (6 buckets) and `Scope of the problem` (15 desiderata A–O) into one section, since they restate the same difficulties in different words. Desiderata K, F, M (transfer learning, large data, permutation invariance) are kept but explicitly flagged as future / aspirational, since the chapter does not deliver against them.
4. **Re-order sections** so the reader meets the data tables (D, F, Z, Y) before the abstract desiderata, and the DBTL cycle is the organizing spine throughout.
5. **Tone pass**: bring the few blog-voice paragraphs in line with the book's house style (short topic sentences, "we"/"you", `.. index::` blocks above sections).

Date-released in `CITATION.cff` and the year range in `README.md` are already at `2026-04-30` / `2026`; no bump needed.

## Test plan

- [ ] `make text` succeeds with no warnings and no errors
- [ ] No remaining `More to come`, `defind`, `optmization`, or unmatched quote in the chapter
- [ ] All `:ref:` cross-references in the chapter still resolve
- [ ] Chapter renders with one H1 and a proper H2 hierarchy (no orphan / sibling-of-title sections)
- [ ] The four references in the closing References section still render with working DOIs

https://claude.ai/code/session_019XgKwaPBB5E1KrV4d68hKa

---
_Generated by [Claude Code](https://claude.ai/code/session_019XgKwaPBB5E1KrV4d68hKa)_