### PR TITLE
Chapter 1: Plotly Python first, R second; pedagogical time-series example

### DIFF
--- a/data-visualization/bar-plots.rst
+++ b/data-visualization/bar-plots.rst
@@ -18,15 +18,15 @@ Here is some advice for bar plots:
 		:alt:	../figures/visualization/quarterly-profit-barplot.R
 		:align: center
 
-	Use this R code to draw the figures:
-
-	.. dcl:: R
-		:codefile: data-visualization/gists/quarterly-profit-barplots.R
-
-	or this Python code:
+	Use this Python code to draw the figures:
 
 	.. dcl:: python
 		:codefile: data-visualization/gists/quarterly-profit-barplots.py
+
+	or this R code:
+
+	.. dcl:: R
+		:codefile: data-visualization/gists/quarterly-profit-barplots.R
 
 -	Bar plots can be wasteful as each data point is repeated several times:
 

--- a/data-visualization/box-plots.rst
+++ b/data-visualization/box-plots.rst
@@ -22,13 +22,13 @@ The box plot shows the so-called :index:`five-number summary <pair: five-number 
 
 The 25th percentile is the value below which 25% of the observations in the sample are found. The distance from the 3rd to the 1st quartile is also known as the :index:`interquartile range (IQR) <pair: interquartile range; box plot>` and represents the data's spread, similar to the standard deviation.
 
-The following data are thickness measurements of 2-by-6 boards (2-by-6 refers for the thickness and depth of a wooden board), taken at six locations around the edge. Here is a sample of the measurements and a summary of the first 100 boards (code in R and Python respectively):
-
-.. dcl:: R
-	:codefile: data-visualization/gists/board-thickness-boxplot.R
+The following data are thickness measurements of 2-by-6 boards (2-by-6 refers for the thickness and depth of a wooden board), taken at six locations around the edge. Here is a sample of the measurements and a summary of the first 100 boards (code in Python and R respectively):
 
 .. dcl:: python
 	:codefile: data-visualization/gists/board-thickness-boxplot.py
+
+.. dcl:: R
+	:codefile: data-visualization/gists/board-thickness-boxplot.R
 
 .. _visualization_boxplot_example:
 

--- a/data-visualization/data-visualization-exercises.rst
+++ b/data-visualization/data-visualization-exercises.rst
@@ -140,6 +140,18 @@ Exercises
 		:width: 900px
 		:alt: fake width
 
+	.. dcl:: python
+
+		import pandas as pd
+		import plotly.express as px
+
+		data_file = 'http://openmv.net/file/food-texture.csv'
+		food = pd.read_csv(data_file)
+
+		fig = px.scatter_matrix(food, dimensions=food.columns[1:6])
+		fig.show()
+
+
 	.. dcl:: R
 
 		library(car)
@@ -179,6 +191,25 @@ Exercises
 
 	#.	A box plot is an effective way to summarize and compare the data for each day of the week.
 
+		.. dcl:: python
+
+		    import pandas as pd
+		    pd.options.plotting.backend = "plotly"
+
+		    web = pd.read_csv('http://openmv.net/file/website-traffic.csv')
+
+		    # Re-order the days
+		    day_names = ["Saturday", "Sunday", "Monday", "Tuesday",
+		                 "Wednesday", "Thursday", "Friday"]
+		    web["DayOfWeek"] = pd.Categorical(web["DayOfWeek"],
+		                                     categories=day_names,
+		                                     ordered=True)
+		    web = web.sort_values("DayOfWeek")
+
+		    fig = web.plot.box(x="DayOfWeek", y="Visits")
+		    fig.show()
+
+
 		.. dcl:: R
 
 		    web = read.csv('http://openmv.net/file/website-traffic.csv')
@@ -204,6 +235,29 @@ Exercises
 			:align: center
 
 	The best way to draw the time-series plot is to use proper time-based labelling on the x-axis, but we won't cover that topic here. If you are interested, read up about the ``xts`` package (`see the R tutorial <https://learnche.org/4C3/Software_tutorial>`_) and it's plot command. See how it is used in the code below:
+
+		.. dcl:: python
+
+			import pandas as pd
+			pd.options.plotting.backend = "plotly"
+
+			web = pd.read_csv('http://openmv.net/file/website-traffic.csv')
+
+			# Sequence plot of the raw integer index
+			fig = web["Visits"].plot.line(markers=True)
+			fig.update_layout(xaxis_title_text="Sequence order",
+			                  yaxis_title_text="Visits")
+			fig.show()
+
+			# A better plot using a real date axis
+			web["Date"] = pd.to_datetime(web["MonthDay"].str.strip(),
+			                             format="%B %d")
+			web = web.sort_values("Date").set_index("Date")
+			fig = web["Visits"].plot.line()
+			fig.update_xaxes(tickformat="%b")
+			fig.update_layout(yaxis_title_text="Visits")
+			fig.show()
+
 
 		.. dcl:: R
 
@@ -280,6 +334,29 @@ Exercises
 
 	#.	You could use the following code to plot the data:
 
+		.. dcl:: python
+			:height: 800px
+
+			import pandas as pd
+			pd.options.plotting.backend = "plotly"
+
+			data_file = 'http://openmv.net/file/room-temperature.csv'
+			roomtemp = pd.read_csv(data_file)
+			roomtemp.describe()
+
+			fig = roomtemp[["FrontLeft", "FrontRight",
+			                "BackLeft", "BackRight"]].plot.line(
+			    color_discrete_sequence=["blue", "royalblue",
+			                             "black", "dimgray"],
+			)
+			fig.update_layout(
+			    yaxis_range=[290, 300],
+			    xaxis_title_text="Sequence order",
+			    yaxis_title_text="Room temperature [K]",
+			)
+			fig.show()
+
+
 		.. dcl:: R
 			:height: 800px
 
@@ -354,6 +431,22 @@ Exercises
 .. admonition:: Solution
 
 	#.	The following code will load the data, and plot a boxplot for the first 100 rows:
+
+		.. dcl:: python
+
+			import pandas as pd
+			pd.options.plotting.backend = "plotly"
+
+			data_file = 'http://openmv.net/file/six-point-board-thickness.csv'
+			boards = pd.read_csv(data_file)
+			boards.describe()
+
+			# Ignore the first date/time column; use only Pos1...Pos6
+			first100 = boards.iloc[:100, 1:7]
+			fig = first100.plot.box()
+			fig.update_layout(yaxis_title_text="Thickness [mils]")
+			fig.show()
+
 
 		.. dcl:: R
 

--- a/data-visualization/gists/board-thickness-boxplot.py
+++ b/data-visualization/gists/board-thickness-boxplot.py
@@ -1,14 +1,17 @@
 import pandas as pd
-import matplotlib.pyplot as plt
+
+pd.options.plotting.backend = "plotly"
 
 all_boards = pd.read_csv("http://openmv.net/file/six-point-board-thickness.csv")
 boards = all_boards.iloc[0:100, 1:7]
 
-# Look at the start and end of the data
+# Look at the start and end of the data.
 # Examine and summarize your data before
-# doing anything else
+# doing anything else.
 boards.head()
 boards.tail()
 boards.describe()
-ax = boards.plot.box(fontsize=16)
-plt.show()
+
+fig = boards.plot.box()
+fig.update_layout(yaxis_title_text="Thickness [mils]")
+fig.show()

--- a/data-visualization/gists/quarterly-profit-barplots.py
+++ b/data-visualization/gists/quarterly-profit-barplots.py
@@ -1,22 +1,30 @@
 import pandas as pd
-import matplotlib.pyplot as plt
+
+pd.options.plotting.backend = "plotly"
 
 labels = ["2008 Q1", "Q2", "Q3", "Q4", "2009 Q1", "Q2", "Q3", "Q4"]
-profit = (
-    pd.DataFrame(
-        data=[45, 32, 67, 23, 42, 56, 64, 92],
-        index=labels,
-        columns=["Quarterly profit ($ '000)"]
-    )
-    + 40
-)
+profit = pd.DataFrame(
+    data=[45, 32, 67, 23, 42, 56, 64, 92],
+    index=labels,
+    columns=["Quarterly profit ($ '000)"],
+) + 40
 
-# # Draw a bar-plot
-ax = profit.plot.bar(color='lightgrey')
-ax.set_ylabel("Quarterly profit ($ '000)")
-plt.show()
+# Draw a bar plot.
+fig = profit.plot.bar()
+fig.update_traces(
+    text=profit["Quarterly profit ($ '000)"],
+    textposition="outside",
+)
+fig.update_layout(
+    yaxis_title_text="Quarterly profit ($ '000)",
+    showlegend=False,
+)
+fig.show()
 
 # Now rather use a line plot.
-ax = profit.plot.line(marker="o")
-ax.set_ylabel("Quarterly profit ($ '000)")
-plt.show()
+fig = profit.plot.line(markers=True)
+fig.update_layout(
+    yaxis_title_text="Quarterly profit ($ '000)",
+    showlegend=False,
+)
+fig.show()

--- a/data-visualization/gists/scatter-plot-example.py
+++ b/data-visualization/gists/scatter-plot-example.py
@@ -1,27 +1,34 @@
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
 
-# Plot of temperature vs vapour pressure
+pd.options.plotting.backend = "plotly"
+
+# Plot of temperature vs vapour pressure.
 data_file = "http://openmv.net/file/distillation-tower.csv"
 distillation = pd.read_csv(data_file)
-ax = distillation.plot.scatter(x="Temp9",
-                               y="VapourPressure",
-                               marker="o", s=20)
-ax.set_xlabel("Temperature (F)")
-ax.set_ylabel("Vapour pressure (kPa)")
-plt.show()
+fig = distillation.plot.scatter(x="Temp9", y="VapourPressure")
+fig.update_layout(
+    xaxis_title_text="Temperature (F)",
+    yaxis_title_text="Vapour pressure (kPa)",
+)
+fig.show()
 
-# Plot of white hairs vs BMD
-#    Osteoporosis (fake) data: number of white
-#    hairs per square inch vs bone mineral
-#    density (measurement of osteoporosis)
-#    vs kg/m^3 (1500 kg/m3 is typical)
+# Plot of white hairs vs BMD.
+#   Osteoporosis (fake) data: number of white
+#   hairs per square inch vs bone mineral
+#   density (measurement of osteoporosis)
+#   in kg/m^3 (1500 kg/m3 is typical).
 N = 50
-white_hairs = np.random.normal(loc=500, scale=150, size=N)
-bone_mineral_density = -0.25 * white_hairs + 1550 + np.random.normal(loc=0, scale=25, size=N)
-fig2, ax2 = plt.subplots(nrows=1, ncols=1)
-ax2.plot(white_hairs, bone_mineral_density, "o", ms=10)
-ax2.set_xlabel("Number of white hairs per square inch of scalp")
-ax2.set_ylabel("Bone mineral density (kg/m$^3$) [measure of osteoporosis]")
-plt.show()
+white_hairs = np.round(np.random.normal(loc=500, scale=150, size=N))
+bone_mineral_density = (
+    -0.25 * white_hairs + 1550 + np.random.normal(loc=0, scale=25, size=N)
+)
+osteo = pd.DataFrame(
+    {"white_hairs": white_hairs, "bone_mineral_density": bone_mineral_density}
+)
+fig = osteo.plot.scatter(x="white_hairs", y="bone_mineral_density")
+fig.update_layout(
+    xaxis_title_text="Number of white hairs per square inch of scalp",
+    yaxis_title_text="Bone mineral density (kg/m^3) [measure of osteoporosis]",
+)
+fig.show()

--- a/data-visualization/gists/time-series-plot.py
+++ b/data-visualization/gists/time-series-plot.py
@@ -1,0 +1,47 @@
+import pandas as pd
+import plotly.graph_objects as go
+
+pd.options.plotting.backend = "plotly"
+
+# Real ammonia concentrations from a waste-water treatment plant.
+waste = pd.read_csv("https://openmv.net/file/ammonia.csv")
+
+# Give the x-axis real time units rather than raw integer indices.
+# The CSV ships without a timestamp; attach an hourly index that
+# starts at the beginning of 2010 so the time axis is meaningful.
+waste.index = pd.date_range(
+    start="2010-01-01", periods=len(waste), freq="h"
+)
+
+# A clean line plot of the raw signal, with month/year tick labels.
+fig = waste["Ammonia"].plot.line()
+fig.update_layout(
+    xaxis_title_text="Date",
+    yaxis_title_text="Ammonia [mmol/L]",
+    width=800,
+    height=400,
+    showlegend=False,
+)
+fig.update_xaxes(tickformat="%b %Y")
+fig.show()
+
+# Overlay a 5-day rolling mean to separate signal from noise.
+rolling = waste["Ammonia"].rolling("5D", center=True).mean()
+fig = go.Figure()
+fig.add_trace(go.Scatter(x=waste.index, y=waste["Ammonia"], name="Ammonia"))
+fig.add_trace(
+    go.Scatter(
+        x=waste.index,
+        y=rolling,
+        name="5-day rolling mean",
+        line_color="black",
+    )
+)
+fig.update_layout(
+    xaxis_title_text="Date",
+    yaxis_title_text="Ammonia [mmol/L]",
+    width=800,
+    height=400,
+)
+fig.update_xaxes(tickformat="%b %Y")
+fig.show()

--- a/data-visualization/relational-graphs-scatter-plots.rst
+++ b/data-visualization/relational-graphs-scatter-plots.rst
@@ -14,13 +14,13 @@ The unspoken intention of a scatter plot is usually to ask the reader to draw a 
 
 This source code generates similar, but not identical, figures to those shows here in the text.
 
-.. dcl:: R
-	:codefile: data-visualization/gists/scatter-plot-example.R
-
-The equivalent code in Python:
-
 .. dcl:: python
 	:codefile: data-visualization/gists/scatter-plot-example.py
+
+The equivalent code in R:
+
+.. dcl:: R
+	:codefile: data-visualization/gists/scatter-plot-example.R
 
 Strive for graphical excellence by doing the following:
 

--- a/data-visualization/time-series-plots.rst
+++ b/data-visualization/time-series-plots.rst
@@ -24,6 +24,11 @@ Here are some tips for effective time-series plots:
 
 	This plot, found on the Internet, shows a computer's CPU temperature with time. There are several problems with the plot, but the key issue here is the *x*-axis. This plot is probably the result of poor default settings in the software, but as you will start to realize, bad defaults are very common in most software packages. They waste your time when you have to repeatedly modify the charts, especially if you are just starting out with exploring the data. Good software will sensibly label the time-based axis for you.
 
+	The Python code below shows how to do this correctly: a real ``pd.DatetimeIndex``, a Plotly time axis formatted with month/year tick labels, and a rolling-mean overlay that helps separate signal from noise.
+
+	.. dcl:: python
+		:codefile: data-visualization/gists/time-series-plot.py
+
 .. AU: The last sentence in the following paragraph seemed a little convoluted. Please verify edits.
 
 -	When plotting more than one trajectory (a vector of values) against time, it is helpful if the lines do not cross or jumble too much. This allows you to clearly see the relationship with other variables. The use of a second *y*-axis on the right-hand side is helpful when plotting two trajectories, but when plotting three or more trajectories that are in the same numeric range, it is better to use several :index:`parallel axes <pair: parallel axes; visualization>`.


### PR DESCRIPTION
## Summary

Chapter 1 (data-visualization) now leads with Python (Plotly) and follows with R for every code example. The matplotlib-based gists are replaced with Plotly versions using the pandas plotting backend, mirroring the conventions in the companion `kgdunn/python-basic-notebooks` repo. A new Python-only time-series example demonstrates proper x-axis labelling — the explicit counter-example to the poorly-labelled CPU-temperature screenshot in the chapter.

## Changes

### Python gists (rewritten matplotlib → Plotly)
- `data-visualization/gists/board-thickness-boxplot.py`
- `data-visualization/gists/quarterly-profit-barplots.py`
- `data-visualization/gists/scatter-plot-example.py`

### New Python gist
- `data-visualization/gists/time-series-plot.py` — loads the openmv.net ammonia dataset, attaches a `pd.DatetimeIndex`, formats the time axis with `%b %Y`, and overlays a 5-day rolling mean to separate signal from noise.

### RST updates (Python first, R second)
- `box-plots.rst`, `bar-plots.rst`, `relational-graphs-scatter-plots.rst` — `.. dcl::` directives reordered, surrounding prose updated to match.
- `data-visualization-exercises.rst` — every existing inline `.. dcl:: R` block now has a Plotly Python equivalent immediately above it (food-texture scatter matrix, website-traffic boxplot, website-traffic time series, room-temperature trajectories, six-point board boxplot).
- `time-series-plots.rst` — adds the new pedagogical Python block after the bad-CPU-temperature screenshot, so readers see the bad example, then the prose tip, then a working snippet that does it correctly.

### Conventions used (from `python-basic-notebooks`)
- `pd.options.plotting.backend = "plotly"` then `df.plot.box / .bar / .line / .scatter`
- `fig.update_layout(xaxis_title_text=..., yaxis_title_text=...)` for axis labels
- `go.Figure() + add_trace` only when overlays are needed
- No matplotlib imports anywhere

## Test plan

- [ ] `make setup && make html && make serve` — open `/data-visualization/` and confirm Python blocks render before R blocks on box-plots, bar-plots, scatter-plots and exercises pages.
- [ ] Time-series page renders the new Python example with month/year tick labels (e.g. "Jan 2010"), not raw integers.
- [ ] Each rewritten `.py` runs standalone with `pandas`, `plotly`, `numpy` and produces a Plotly figure in the browser.
- [ ] Optional: `make latexpdf` to confirm the `dcl` LaTeX path renders the new ordering without errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqGYhM2FQKE8DUFsXibDvK)_