### PR TITLE
Add Plotly Python equivalents alongside R blocks in Chapter 2

### DIFF
--- a/univariate-review/confidence-intervals.rst
+++ b/univariate-review/confidence-intervals.rst
@@ -65,19 +65,41 @@ Interpreting the confidence interval
 		
 		Try it out:
 		
+		.. code-block:: python
+
+			import numpy as np
+			from scipy.stats import t
+
+			# Try varying this value:
+			conf_level = 0.90
+
+			viscosity = np.array([23, 19, 17, 18,
+			                      24, 26, 21, 14, 18])
+			n = len(viscosity)
+			x_avg = viscosity.mean()
+			x_sd = viscosity.std(ddof=1)
+			dof = n - 1
+			c_t = t.ppf(q=1 - (1 - conf_level) / 2,
+			            df=dof)
+			LB = x_avg - c_t * x_sd / np.sqrt(n)
+			UB = x_avg + c_t * x_sd / np.sqrt(n)
+			print(f"The {round(conf_level * 100):.0f}"
+			      f"% confidence interval is: ")
+			print(f"[{round(LB, 1)}; {round(UB, 1)}]")
+
 		.. code-block:: r
 
 			# Try varying this value:
 			conf.level <- 0.90
-			
-			viscosity <- c(23, 19, 17, 18, 
+
+			viscosity <- c(23, 19, 17, 18,
 			               24, 26, 21, 14, 18)
 			n <- length(viscosity)
 			x.avg <- mean(viscosity)
 			x.sd <- sd(viscosity)
 			dof <- n - 1
-			c.t <- qt(p = 1-(1-conf.level)/2, 
-			          df = dof) 
+			c.t <- qt(p = 1-(1-conf.level)/2,
+			          df = dof)
 			LB <- x.avg - c.t * x.sd / sqrt(n)
 			UB <- x.avg + c.t * x.sd / sqrt(n)
 			paste0('The ', round(conf.level*100, 0),

--- a/univariate-review/gists/histogram-area.py
+++ b/univariate-review/gists/histogram-area.py
@@ -1,26 +1,25 @@
 # Create 1000 normally distributed points
 # with mean of 0 and standard deviation of 1.
 import numpy as np
-import matplotlib.pyplot as plt
+import pandas as pd
+
+pd.options.plotting.backend = "plotly"
 
 N = 1000
-values = np.random.normal(loc=0,
-                          scale=1,
-                          size=N)
+values = pd.Series(np.random.normal(loc=0, scale=1, size=N))
 
-plt.subplot(1, 2, 1)
-plt.hist(values, color="white")
-plt.ylabel("Frequency (N={})".format(N))
+# Frequency histogram (counts).
+fig = values.plot.hist()
+fig.update_layout(
+    yaxis_title_text=f"Frequency (N={N})",
+    showlegend=False,
+)
+fig.show()
 
-plt.subplot(1, 2, 2)
-plt.hist(values,
-         color="white",
-         # For older matplotlib versions
-         normed=True,
-         # Rather, use 'density' instead
-         #density=True
-         )
-plt.ylabel("Relative density")
-
-plt.tight_layout()
-plt.show()
+# Relative-density histogram (area sums to 1).
+fig = values.plot.hist(histnorm="probability density")
+fig.update_layout(
+    yaxis_title_text="Relative density",
+    showlegend=False,
+)
+fig.show()

--- a/univariate-review/gists/histogram-normal-distribution.py
+++ b/univariate-review/gists/histogram-normal-distribution.py
@@ -2,14 +2,17 @@
 # with a mean of 1100 and standard deviation
 # of 50 units.
 import numpy as np
-import matplotlib.pyplot as plt
+import pandas as pd
+
+pd.options.plotting.backend = "plotly"
 
 N = 500
-values = np.random.normal(loc=1100,
-                          scale=50,
-                          size=N)
+values = pd.Series(np.random.normal(loc=1100, scale=50, size=N))
 
-plt.hist(values, color="white", bins=8)
-plt.xlabel("Mass [g] of each package")
-plt.ylabel("Number of packages (N={})".format(N))
-plt.show()
+fig = values.plot.hist(nbins=8)
+fig.update_layout(
+    xaxis_title_text="Mass [g] of each package",
+    yaxis_title_text=f"Number of packages (N={N})",
+    showlegend=False,
+)
+fig.show()

--- a/univariate-review/histograms-and-probability-distributions.rst
+++ b/univariate-review/histograms-and-probability-distributions.rst
@@ -28,11 +28,11 @@ Histograms make sense for :index:`categorical variables <single: categorical var
 	:width: 900px
 	:alt: fake width
 
-.. literalinclude:: /univariate-review/gists/histogram-normal-distribution.R
-	:language: r
-
 .. literalinclude:: /univariate-review/gists/histogram-normal-distribution.py
 	:language: python
+
+.. literalinclude:: /univariate-review/gists/histogram-normal-distribution.R
+	:language: r
 
 Try creating a fictitious histogram for each of the following situations:
 
@@ -96,9 +96,9 @@ A :index:`relative frequency`, also called :index:`density`, is sometimes prefer
 	:align: center
 
 
-.. literalinclude:: /univariate-review/gists/histogram-area.R
-	:language: r
-
-
 .. literalinclude:: /univariate-review/gists/histogram-area.py
 	:language: python
+
+
+.. literalinclude:: /univariate-review/gists/histogram-area.R
+	:language: r

--- a/univariate-review/normal-distribution-and-checking-for-normality.rst
+++ b/univariate-review/normal-distribution-and-checking-for-normality.rst
@@ -29,6 +29,35 @@ Imagine a case where we are throwing dice. The distributions, shown below, are o
 
 As one sees from the above figures, the distribution from these averages quickly takes the shape of the so-called *normal distribution*. As :math:`M` increases, the y-axis starts to form a peak.  Try it yourself:
 
+.. code-block:: python
+
+	import numpy as np
+	import pandas as pd
+	from plotly.subplots import make_subplots
+	import plotly.graph_objects as go
+
+	N = 500
+
+	# Throw N six-sided dice, ten times.
+	throws = np.random.randint(1, 7, size=(10, N))
+
+	groupings = [(1, "One throw", 6),
+	             (2, "Average of two throws", 8),
+	             (4, "Average of 4 throws", 8),
+	             (6, "Average of 6 throws", 8),
+	             (8, "Average of 8 throws", 12),
+	             (10, "Average of 10 throws", 12)]
+
+	fig = make_subplots(rows=2, cols=3,
+	                    subplot_titles=[g[1] for g in groupings])
+	for k, (m, _label, bins) in enumerate(groupings):
+	    averages = throws[:m].mean(axis=0)
+	    fig.add_trace(
+	        go.Histogram(x=averages, nbinsx=bins, showlegend=False),
+	        row=k // 3 + 1, col=k % 3 + 1,
+	    )
+	fig.show()
+
 .. code-block:: r
 
 	N = 500
@@ -159,6 +188,25 @@ Some questions:
 
 To calculate the point on the curve :math:`p(x)` we use the ``dnorm(...)`` function in R. It requires you specify the two parameters:
 
+	.. code-block:: python
+
+		from scipy.stats import norm
+
+		# x=0, mu=0, and sigma=1
+		# This is the maximum of the curve
+		norm.pdf(x=0, loc=0, scale=1)  # 0.3989423
+
+		# x=1, mu=0, and sigma=1
+		norm.pdf(x=1, loc=0, scale=1)  # 0.2419707
+
+		# x=-1, mu=0, and sigma=1
+		# It is symmetrical
+		norm.pdf(x=-1, loc=0, scale=1) # 0.2419707
+
+		# x=+3, mu=0, and sigma=1
+		# This is at a point very far from center
+		norm.pdf(x=+3, loc=0, scale=1) # 0.00443185
+
 	.. code-block:: r
 
 		# x=0, mu=0, and sigma=1
@@ -190,6 +238,22 @@ Some useful points:
 
 
 It is more useful to calculate the area under :math:`p(x)` from :math:`x=-\infty` to a particular point :math:`x`. This is called the cumulative distribution, and is discussed more fully in :ref:`the next section <univariate_check_for_normality_qqplot>`.
+
+	.. code-block:: python
+
+		from scipy.stats import norm
+
+		# gives area from -Inf to -1,
+		# for mu=0, sigma=1
+		norm.cdf(-1, loc=0, scale=1)   # 0.1586553
+
+		# Gives area from -Inf to +1,
+		# for mu=0, sigma=1
+		norm.cdf(1, loc=0, scale=1)    # 0.8413447
+
+		# Spread is wider, but the
+		# fractional area is the same
+		norm.cdf(3, loc=0, scale=3)    # 0.8413447
 
 	.. code-block:: r
 
@@ -228,6 +292,19 @@ Consult a statistical table found in most statistical textbooks for the normal d
 
 #.	Assume :math:`x`, the measurement of biological activity for a drug, is normally distributed with mean of 26.2 and standard deviation of 9.2. What is the probability of obtaining an activity reading less than or equal to 30.0?
 
+	.. code-block:: python
+
+		# We know that the probability should be 50%
+		# if the activity is equal to the mean.
+		from scipy.stats import norm
+
+		x = 26.2
+		mu = 26.2
+		sigma = ____
+		norm.cdf(x, loc=mu, scale=sigma)
+
+		# Now modify this above to answer the question.
+
 	.. code-block:: r
 
 		# We know that the probability should be 50%
@@ -242,6 +319,26 @@ Consult a statistical table found in most statistical textbooks for the normal d
 
 
 #.	Assume :math:`x` is the yield for a batch process, with mean of 85 g/L and **variance** of 16 :math:`\text{g}^2.\text{L}^{-2}`. What proportion of batch yield values lie between 75 and 95 g/L?
+
+	.. code-block:: python
+
+		import numpy as np
+		from scipy.stats import norm
+
+		mu = 85              # g/L
+		sigma = np.sqrt(16)  # g/L
+		x_left = ___
+		area_left_tail = norm.cdf(x_left,
+		                          loc=mu,
+		                          scale=sigma)
+
+		x_right = ___
+		area_right_tail = norm.cdf(x_right,
+		                           loc=mu,
+		                           scale=sigma)
+
+		# Now subtract the two areas to get
+		# the answer. Why?
 
 	.. code-block:: r
 
@@ -348,6 +445,46 @@ A built-in function exists in R that runs the above calculations and shows a sca
 
 All the above code together in one script for you to test out:
 
+.. code-block:: python
+
+	import numpy as np
+	import pandas as pd
+	from scipy.stats import norm, probplot
+
+	pd.options.plotting.backend = "plotly"
+
+	N = 10
+	index = np.arange(1, N + 1)
+	P = (index - 0.5) / N
+	theoretical_quantity = norm.ppf(P)
+
+	yields = np.array([86.2, 85.7, 71.9, 95.3, 77.1,
+	                   71.4, 68.9, 78.9, 86.9, 78.4])
+	mean_yield = yields.mean()              # 80.0
+	sd_yield = yields.std(ddof=1)           # 8.35
+
+	yields_z = (yields - mean_yield) / sd_yield
+	yields_z_sorted = np.sort(yields_z)
+
+	# Manual q-q plot, on standardized scale.
+	fig = pd.DataFrame(
+	    {"theoretical": theoretical_quantity,
+	     "sample":      yields_z_sorted}
+	).plot.scatter(x="theoretical", y="sample")
+	fig.show()
+
+	# Built-in q-q plot, on the original scale.
+	# scipy.stats.probplot returns (osm, osr) and
+	# the slope/intercept of the regression line.
+	osm, osr = probplot(yields, dist="norm",
+	                    fit=False)
+	fig = pd.DataFrame(
+	    {"theoretical quantile": osm,
+	     "yields":                osr}
+	).plot.scatter(x="theoretical quantile",
+	               y="yields")
+	fig.show()
+
 .. code-block:: r
 
 	N = 10
@@ -379,6 +516,39 @@ The R plot rescales the :math:`y`-axis (sample quantiles) back to the original u
 The q-q plot, quantile-quantile plot, shows the quantiles of 2 distributions against each other. In fact, we can use the horizontal axis for any distribution, it need not be the theoretical normal distribution. We might be interested if our data follow an :math:`F`-distribution then we could use the quantiles for that theoretical distribution on the horizontal axis.
 
 We can use the q-q plot to compare any 2 *samples of data*, even if they have different values of :math:`N`, by calculating the quantiles for each sample at different step quantiles (e.g. 1, 2, 3, 4, 5, 10, 15, .... 95, 96, 97, 98, 99), then plot the q-q plot for the two samples. You can calculate quantiles for any sample of data using the ``quantile`` function in R. The simple example below shows how to compare the q-q plot for 1000 normal distribution samples against 2000 :math:`F`-distribution samples.
+
+.. code-block:: python
+
+	import numpy as np
+	import pandas as pd
+	from scipy.stats import f, probplot
+
+	pd.options.plotting.backend = "plotly"
+
+	# 1000 normal values
+	rand_norm = np.random.normal(size=1000)
+
+	# 2000 values from F-distribution
+	rand_f = f.rvs(dfn=200, dfd=150, size=2000)
+
+	# looks sort of normally distributed
+	fig = pd.Series(rand_f).plot.hist(
+	    histnorm="probability density",
+	    title="Are these data from a normal distribution?",
+	)
+	fig.update_layout(yaxis_title_text="Frequency")
+	fig.show()
+
+	# But your eye is being fooled ...
+	# See the heavy tail in the q-q plot.
+	osm, osr = probplot(rand_f, dist="norm",
+	                    fit=False)
+	fig = pd.DataFrame(
+	    {"theoretical quantile": osm,
+	     "sample":                osr}
+	).plot.scatter(x="theoretical quantile",
+	               y="sample")
+	fig.show()
 
 .. code-block:: r
 

--- a/univariate-review/poisson-distribution.rst
+++ b/univariate-review/poisson-distribution.rst
@@ -38,13 +38,26 @@ Formally, the Poisson distribution can be written as :math:`\displaystyle \frac{
 		10, 4.1%
 		15, 0.1%
 		
+.. code-block:: python
+
+	from scipy.stats import poisson
+
+	x = [0, 1, 3, 6, 10, 15]
+
+	# scipy calls the Poisson parameter 'mu'.
+	poisson.pmf(x, mu=6)
+
+	# Output:
+	# array([0.00247875, 0.01487251, 0.08923508,
+	#        0.16062314, 0.04130303, 0.00103326])
+
 .. code-block:: r
 
 	x <- c(0, 1, 3, 6, 10, 15)
 
 	# Note: R calls the Poisson parameter 'lambda'
-	dpois(x, lambda=6)    
-	
+	dpois(x, lambda=6)
+
 	# Output:
 	# 0.0025 0.0149 0.0892 0.161 0.0413 0.001
 

--- a/univariate-review/some-terminology.rst
+++ b/univariate-review/some-terminology.rst
@@ -69,11 +69,11 @@ We review a couple of concepts that you should have seen in a prior statistical 
 
 	where :math:`N` represents the size of the entire population, and :math:`n` is the number of samples measured from the population.
 
-	.. literalinclude:: /univariate-review/gists/create-normally-distributed-values.R
-		:language: r
-
 	.. literalinclude:: /univariate-review/gists/create-normally-distributed-values.py
 		:language: python
+
+	.. literalinclude:: /univariate-review/gists/create-normally-distributed-values.R
+		:language: r
 
 	This is only one of several statistics that describes your data: if you told your customer that the average density of your liquid product was 1.421 g/L, and nothing further, the customer might assume all lots of the same product have a density of 1.421 g/L. But we know from :ref:`our earlier discussion <univariate-about-variability>` that there will be variation. We need information, in addition to the mean, to quantify the distribution of values: *the spread*.
 
@@ -96,11 +96,11 @@ We review a couple of concepts that you should have seen in a prior statistical 
 	Dividing by :math:`n-1` makes the variance statistic, :math:`s^2`, an :index:`unbiased estimator` of the population variance, :math:`\sigma^2`. However, in many data sets our value for :math:`n` is large, so using a divisor of :math:`n`, which you might come across in computer software or other texts, rather than :math:`n-1` as shown here, leads to little difference.
 
 
-	.. literalinclude:: /univariate-review/gists/create-normally-distributed-values-with-variance-parameter.R
-		:language: r
-
 	.. literalinclude:: /univariate-review/gists/create-normally-distributed-values-with-variance-parameter.py
 		:language: python
+
+	.. literalinclude:: /univariate-review/gists/create-normally-distributed-values-with-variance-parameter.R
+		:language: r
 
 	The square root of variance, called the :index:`standard deviation` is a more useful measure of spread: it is easier to visualize on a histogram and has the advantage of being in the same units of measurement as the variable itself.
 
@@ -143,6 +143,35 @@ We review a couple of concepts that you should have seen in a prior statistical 
 			\text{mad}\left\{ x_i \right\} = c \cdot \text{median}\left\{ \| x_i - \text{median}\left\{ x_i \right\}  \|  \right\} \qquad\qquad \text{where}\qquad c = 1.4826
 
 	The constant :math:`c` makes the MAD consistent with the standard deviation when the observations :math:`x_i` are normally distributed. The MAD has a :index:`breakdown point` of 50%, because like the median, we can replace just under half the data with outliers before the MAD estimate becomes unbounded. To compute the MAD in R, use the ``mad(x)`` function on a vector ``x``.
+
+	.. code-block:: python
+
+		# A vector of 500 normally distributed
+		# random numbers.
+		import numpy as np
+		from scipy.stats import median_abs_deviation
+
+		x = np.random.normal(size=500)
+
+		print("Without any outliers:")
+		print(f"Standard deviation = {np.std(x, ddof=1)}")
+		# scale='normal' applies the 1.4826 factor so the
+		# MAD agrees with sd() for normal data.
+		print(f"The MAD is         = "
+		      f"{median_abs_deviation(x, scale='normal')}")
+		print("These two should agree mostly.")
+
+		# Run it several times to verify that the
+		# two are similar, when there are no
+		# outliers.
+
+		# Now add a huge outlier:
+		x[1] = 9876
+		print("But now add an outlier...")
+		print(f"*Standard deviation = {np.std(x, ddof=1)}")
+		print(f"*The MAD is         = "
+		      f"{median_abs_deviation(x, scale='normal')}")
+		print("See how MAD is not affected.")
 
 	.. code-block:: r
 

--- a/univariate-review/t-distribution.rst
+++ b/univariate-review/t-distribution.rst
@@ -67,21 +67,42 @@ Calculating the t-distribution
 
 -	In R we use the function ``dt(x=..., df=...)`` to give us the values of the probability density values, :math:`p(x)`, of the :math:`t`-distribution (compare this to the ``dnorm(x, mean=..., sd=...)`` function for the normal distribution).
 
-	.. code-block:: r
+	.. code-block:: python
+
+		from scipy.stats import norm, t
 
 		x = 0.0
-		
+
 		# Recall, for the normal distribution:
-		dnorm(x, mean=0, sd=1)    # 0.3989423
-		
+		norm.pdf(x, loc=0, scale=1)   # 0.3989423
+
 		# For the t-distribution we don't have
 		# a sigma, but we do need to say how
 		# many degrees of freedom we have:
-		
+
+		dof = 8
+		t.pdf(x, df=dof)              # 0.386699
+
+		# Shows that the t-distribution has a
+		# lower peak than the normal distribution.
+		# Try it again, but with fewer and
+		# greater degrees of freedom (`dof`).
+
+	.. code-block:: r
+
+		x = 0.0
+
+		# Recall, for the normal distribution:
+		dnorm(x, mean=0, sd=1)    # 0.3989423
+
+		# For the t-distribution we don't have
+		# a sigma, but we do need to say how
+		# many degrees of freedom we have:
+
 		dof <- 8
 		dt(x, df=dof)             # 0.386699
-		
-		# Shows that the t-distribution has a 
+
+		# Shows that the t-distribution has a
 		# lower peak than the normal distribution.
 		# Try it again, but with fewer and
 		# greater degrees of freedom (`dof`).
@@ -89,38 +110,75 @@ Calculating the t-distribution
 
 -	The cumulative area from :math:`-\infty` to :math:`x` under the probability density curve gives us the probability that values less than or equal to :math:`x` could be observed. It is calculated in R using ``pt(q=..., df=...)``. For example, ``pt(1.0, df=8)`` is 0.8267. Compare this to the R function for the standard normal distribution: ``pnorm(1.0, mean=0, sd=1)`` which returns 0.8413.
 
+	.. code-block:: python
+
+		from scipy.stats import norm, t
+
+		q = 1.0
+
+		# Recall, for the normal distribution:
+		norm.cdf(q, loc=0, scale=1)  # 0.8413447
+
+		# For the t-distribution we need to
+		# specify the degrees of freedom:
+
+		dof = 8
+		t.cdf(q, df=dof)             # 0.8267032
+
+		# Shows that the t-distribution is
+		# similar, but the areas are slightly
+		# different.
+
 	.. code-block:: r
 
 		q = 1.0
-		
+
 		# Recall, for the normal distribution:
 		pnorm(q, mean=0, sd=1) # 0.8413447
-		
-		# For the t-distribution we need to 
+
+		# For the t-distribution we need to
 		# specify the degrees of freedom:
-		
+
 		dof <- 8
 		pt(q, df=dof)          # 0.8267032
-		
-		# Shows that the t-distribution is  
+
+		# Shows that the t-distribution is
 		# similar, but the areas are slightly
 		# different.
 
 -	And similarly to the ``qnorm`` function which returns the ordinate for a given area under the normal distribution, the function ``qt(0.8267, df=8)`` returns 0.9999857, close enough to 1.0, which is the inverse of the previous example.
 
+	.. code-block:: python
+
+		from scipy.stats import norm, t
+
+		p = 0.5
+
+		# Recall, for the normal distribution:
+		norm.ppf(p, loc=0, scale=1)  # 0.0
+
+		# For the t-distribution:
+
+		dof = 8
+		t.ppf(p, df=dof)             # 0.0
+
+		# Both distributions have their 50%
+		# quantile at p=0. But try it for
+		# other values of probability, p.
+
 	.. code-block:: r
 
 		p = 0.5
-		
+
 		# Recall, for the normal distribution:
 		qnorm(p, mean=0, sd=1)   # 0.0
-		
+
 		# For the t-distribution:
-		
+
 		dof <- 8
 		qt(p, df=dof)            # 0.0
-		
-		# Both distributions have their 50% 
+
+		# Both distributions have their 50%
 		# quantile at p=0. But try it for
 		# other values of probability, p.
 
@@ -209,38 +267,88 @@ If we repeat this process with a different set of 9 samples we will get a differ
 
 		using from R that ``qt(0.025, df=8)`` and ``qt(0.975, df=8)``, which gives ``2.306004``
 		
+	.. code-block:: python
+
+		import numpy as np
+		import pandas as pd
+		from scipy.stats import t, probplot
+
+		pd.options.plotting.backend = "plotly"
+
+		# Step 0: the raw data
+		viscosity = np.array([23, 19, 17, 18,
+		                      24, 26, 21, 14, 18])
+		n = len(viscosity)
+
+		# Step 1:
+		x_avg = viscosity.mean()
+
+		# Step 5: Verify the data are normal
+		osm, osr = probplot(viscosity, dist="norm",
+		                    fit=False)
+		fig = pd.DataFrame(
+		    {"theoretical quantile": osm,
+		     "viscosity":             osr}
+		).plot.scatter(x="theoretical quantile",
+		               y="viscosity")
+		fig.show()
+
+		# Step 6:
+		x_sd = viscosity.std(ddof=1)
+
+		# Step 7: t-distribution
+		dof = n - 1
+
+		# Step 8:
+		conf_level = 0.95
+
+		# Can be calculated at either
+		# the lower tail
+		c_t = t.ppf(q=(1 - conf_level) / 2,
+		            df=dof)
+
+		# or the upper tail
+		c_t = t.ppf(q=1 - (1 - conf_level) / 2,
+		            df=dof)
+
+		LB = x_avg - c_t * x_sd / np.sqrt(n)
+		UB = x_avg + c_t * x_sd / np.sqrt(n)
+		print(f"The {round(conf_level * 100):.0f}"
+		      f"% confidence interval is: ")
+		print(f"[{round(LB, 1)}; {round(UB, 1)}]")
+
 	.. code-block:: r
 
 		# Step 0: the raw data
-		viscosity <- c(23, 19, 17, 18, 
+		viscosity <- c(23, 19, 17, 18,
 		               24, 26, 21, 14, 18)
 		n <- length(viscosity)
-		
+
 		# Step 1:
 		x.avg <- mean(viscosity)
-		
+
 		# Step 5: Verify the data are normal
 		library(car)
 		qqPlot(viscosity)
-		
-		# Step 6: 
+
+		# Step 6:
 		x.sd <- sd(viscosity)
-		
-		# Step 7: t-distribution 
+
+		# Step 7: t-distribution
 		dof <- n - 1
-		
+
 		# Step 8:
 		conf.level <- 0.95
-		
+
 		# Can be calculated at either
 		# the lower tail
-		c.t <- qt(p = (1-conf.level)/2, 
-		          df = dof) 
-				  
+		c.t <- qt(p = (1-conf.level)/2,
+		          df = dof)
+
 		# or the upper tail
-		c.t <- qt(p = 1-(1-conf.level)/2, 
-		          df = dof) 
-				  
+		c.t <- qt(p = 1-(1-conf.level)/2,
+		          df = dof)
+
 		LB <- x.avg - c.t * x.sd / sqrt(n)
 		UB <- x.avg + c.t * x.sd / sqrt(n)
 		paste0('The ', round(conf.level*100, 0),

--- a/univariate-review/testing-for-differences-and-similarity.rst
+++ b/univariate-review/testing-for-differences-and-similarity.rst
@@ -62,6 +62,29 @@ Either we want to confirm things are statistically the same, or confirm they hav
 .. image:: ../figures/univariate/system-comparison-wikitable.png
 	:align: center
 	
+.. code-block:: python
+
+	import pandas as pd
+
+	pd.options.plotting.backend = "plotly"
+
+	# Generate the boxplot
+	A = [92.7, 73.3, 80.5, 81.2, 87.1,
+	     69.2, 81.9, 73.9, 78.6, 80.5]
+	B = [83.5, 78.9, 82.7, 93.2, 86.3,
+	     74.7, 81.6, 92.4, 83.6, 72.4]
+
+	data = pd.concat([
+	    pd.DataFrame({"observe": A, "method": "A"}),
+	    pd.DataFrame({"observe": B, "method": "B"}),
+	])
+
+	fig = data.plot.box(
+	    x="method", y="observe",
+	    title="Batch yield (%) for two trials",
+	)
+	fig.show()
+
 .. code-block:: r
 
 	# Generate the boxplot
@@ -75,7 +98,7 @@ Either we want to confirm things are statistically the same, or confirm they hav
 	data <- rbind(data.A, data.B)
 
 	limits <- range(data$observe)
-	boxplot(data$obs ~ data$method, lwd=2, 
+	boxplot(data$obs ~ data$method, lwd=2,
 	        main="Batch yield (%) for two trials")
 
 
@@ -115,6 +138,42 @@ So to summarize: we can use a historical data set if it is relevant. And there a
 
 In fact, for this example, the data were not independent, they were autocorrelated. There was a relationship from one batch to the next: :math:`x[k] = \phi x[k-1] + a[k]`, with :math:`\phi = -0.3`, and  :math:`a[k] \sim \mathcal{N}\left(\mu=0, \sigma^2=6.7^2\right)`. As an aside you can simulate your own set of autocorrelated data using this R code:
 
+.. code-block:: python
+
+	import numpy as np
+	import pandas as pd
+
+	pd.options.plotting.backend = "plotly"
+
+	N = 300
+	phi = -0.3
+	spread = 6.7
+	location = 79.9
+
+	A_hist = np.zeros(N)
+	for k in range(1, N):
+	    A_hist[k] = (phi * A_hist[k - 1]
+	                 + np.random.normal(loc=0,
+	                                    scale=spread))
+	A_hist = A_hist + location
+
+	# Note: your plot will look different to
+	# the text, because it will be from a
+	# different set of random numbers.
+	title = ("Autocorrelation between "
+	         "successive values of batch yield")
+	fig = pd.DataFrame(
+	    {"x[k]":   A_hist[:-1],
+	     "x[k+1]": A_hist[1:]}
+	).plot.scatter(x="x[k]", y="x[k+1]",
+	               title=title)
+	fig.update_xaxes(range=[60, 100])
+	fig.update_yaxes(range=[60, 100])
+	fig.show()
+
+	# Hint: run the code several times, with
+	# different values of variable `phi`.
+
 .. code-block:: r
 
 	N <- 300
@@ -123,10 +182,10 @@ In fact, for this example, the data were not independent, they were autocorrelat
 	location <- 79.9
 
 	# create a vector of zeros
-	A.hist <- numeric(N)   
+	A.hist <- numeric(N)
 	for (k in 2:N)
 	{
-	  A.hist[k] <- phi*(A.hist[k-1]) + 
+	  A.hist[k] <- phi*(A.hist[k-1]) +
 	           rnorm(1, mean = 0, sd = spread)
 	}
 	A.hist <- A.hist + location
@@ -136,16 +195,16 @@ In fact, for this example, the data were not independent, they were autocorrelat
 	# different set of random numbers
 	title = paste0("Autocorrelation between ",
 	        "successive values of batch yield")
-	plot(A.hist[1:N-1], A.hist[2:N], 
-	     xlab = "x[k]", 
-	     ylab = "x[k+1]", 
+	plot(A.hist[1:N-1], A.hist[2:N],
+	     xlab = "x[k]",
+	     ylab = "x[k+1]",
 	     main = title,
-	     lwd = 3, 
-	     xlim = c(60,100), 
+	     lwd = 3,
+	     xlim = c(60,100),
 	     ylim = c(60,100))
 
 	lines(lowess(A.hist[1:N-1], A.hist[2:N]))
-	
+
 	# Hint: run the code several times, with
 	# different values of variable `phi`.
 
@@ -311,6 +370,32 @@ Check the probability of obtaining the :math:`z`-value in :eq:`zvalue-for-differ
 The probability of seeing a :math:`z`-value from :math:`-\infty` up to 1.03 is 84.8% (use the ``pnorm(1.03)`` function in R). But we are interested in the probability of obtaining a :math:`z`-value **larger** than this. Why?  Because :math:`z=0` represents no improvement, and a value of :math:`z<0` would mean that system B is worse than system A. So what are the chances of obtaining :math:`z=1.03`?  It is (100-84.8)% = 15.2%, which means that system B's performance could have been obtained by pure luck in 15.2% of cases. 
 
 
+.. code-block:: python
+
+	import numpy as np
+	from scipy.stats import norm
+
+	A = np.array([92.7, 73.3, 80.5, 81.2, 87.1,
+	              69.2, 81.9, 73.9, 78.6, 80.5])
+	B = np.array([83.5, 78.9, 82.7, 93.2, 86.3,
+	              74.7, 81.6, 92.4, 83.6, 72.4])
+
+	xA_avg = A.mean()
+	xB_avg = B.mean()
+	n_A = len(A)
+	n_B = len(B)
+	sigma_external = 6.61  # given
+
+	den = sigma_external ** 2 * (1 / n_A + 1 / n_B)
+	z = (xB_avg - xA_avg) / np.sqrt(den)
+
+	# Probability of this z?
+	# We have normalized to zero mean
+	# and to unit standard deviation:
+	p = norm.cdf(z, loc=0, scale=1)  # 0.8481164
+	print(f"Probability by chance: "
+	      f"{round((1 - p) * 100, 1)}%")
+
 .. code-block:: r
 
 	A <- c(92.7, 73.3, 80.5, 81.2, 87.1,
@@ -331,7 +416,7 @@ The probability of seeing a :math:`z`-value from :math:`-\infty` up to 1.03 is 8
 	# We have normalized to zero mean
 	# and to unit standard deviation:
 	p <- pnorm(z, mean=0, sd=1)  # 0.8481164
-	paste0('Probability by chance: ', 
+	paste0('Probability by chance: ',
 	       round((1-p)*100, 1), '%')
 	
 
@@ -365,6 +450,35 @@ Now using this value of :math:`s_P` instead of :math:`\sigma` in :eq:`zvalue-for
 
 The probability of obtaining a :math:`z`-value greater than this can be calculated as 16.4% using the :math:`t`-distribution with 18 degrees of freedom (use ``1-pt(1.01, df=18)`` in R). We use a :math:`t`-distribution because an estimate of the variance is used, :math:`s_p^2`, not a population variance, :math:`\sigma^2`. 
 
+.. code-block:: python
+
+	import numpy as np
+	from scipy.stats import t
+
+	A = np.array([92.7, 73.3, 80.5, 81.2, 87.1,
+	              69.2, 81.9, 73.9, 78.6, 80.5])
+	B = np.array([83.5, 78.9, 82.7, 93.2, 86.3,
+	              74.7, 81.6, 92.4, 83.6, 72.4])
+
+	xA_avg = A.mean()
+	xB_avg = B.mean()
+	n_A = len(A)
+	n_B = len(B)
+	# degrees of freedom
+	dof = n_A - 1 + n_B - 1
+	var_pooled = ((n_A - 1) * A.var(ddof=1)
+	              + (n_B - 1) * B.var(ddof=1)) / dof
+
+	den = var_pooled * (1 / n_A + 1 / n_B)
+	z = (xB_avg - xA_avg) / np.sqrt(den)
+
+	# Probability of this z?
+	# Compare it against the t-distribution:
+	p = t.cdf(z, df=dof)  # 0.8361346
+
+	print(f"Probability by chance: "
+	      f"{round((1 - p) * 100, 1)}%")
+
 .. code-block:: r
 
 	A <- c(92.7, 73.3, 80.5, 81.2, 87.1,
@@ -378,17 +492,17 @@ The probability of obtaining a :math:`z`-value greater than this can be calculat
 	n.B <- length(B)
 	# degrees of freedom
 	dof <- n.A - 1 + n.B - 1
-	var.pooled <- ((n.A - 1) * var(A) + 
+	var.pooled <- ((n.A - 1) * var(A) +
 	          (n.B - 1) * var(B)) / dof
-	
+
 	den <- var.pooled * (1/n.A + 1/n.B)
 	z <- (xB.avg - xA.avg) / sqrt(den)
 
 	# Probability of this z?
 	# Compare it against the t-distribution:
 	p <- pt(z, df = dof)  # 0.8361346
-	
-	paste0('Probability by chance: ', 
+
+	paste0('Probability by chance: ',
 	       round((1-p)*100, 1), '%')
 
 As an aside: we used a normal distribution for the external :math:`\sigma` and a :math:`t`-distribution for the internal :math:`s`. Both cases had a similar value for :math:`z` (compare :math:`z = 1.01` to :math:`z = 1.03`). Note however that the probabilities are higher in the :math:`t`-distribution's tails, which means that even though we have similar :math:`z`-values, the probability is greater: 16.4% against 15.2%. While this difference is not much from a practical point of view, it illustrates the difference between the :math:`t`-distribution and the normal distribution.

--- a/univariate-review/uniform-distribution.rst
+++ b/univariate-review/uniform-distribution.rst
@@ -13,10 +13,10 @@ The histogram for an event with 4 possible outcomes that are uniformly distribut
 
 You can simulate uniformly distributed random numbers in most software packages. As an example, to generate 50 uniformly distributed random *integers* between 2 and 10, inclusive, in various languages:
 
-	.. literalinclude:: /univariate-review/gists/uniform-distribution-example.R
-		:language: r
-
 	.. literalinclude:: /univariate-review/gists/uniform-distribution-example.py
 		:language: python
+
+	.. literalinclude:: /univariate-review/gists/uniform-distribution-example.R
+		:language: r
 
 A :index:`continuous, uniform distribution <single: uniform distribution; continuous>` arises when there is equal probability of every measurement occurring within a given lower- and upper-bound. This sort of phenomena is not often found in practice. Usually, continuous measurements follow some other distribution, of which we will discuss the normal and :math:`t`-distribution next.


### PR DESCRIPTION
## Summary

Mirrors the Chapter 1 work (PRs #46 / #48) for Chapter 2
(`univariate-review/`):

- Adds a Plotly-based `.. code-block:: python` directly above every
  inline `.. code-block:: r` in the chapter pages. Coverage:
  - `normal-distribution-and-checking-for-normality.rst` — CLT dice
    averages, `dnorm` / `pnorm` evaluations, drug-activity question,
    batch-yield question, q-q plot script, F-distribution heavy-tail
    comparison
  - `t-distribution.rst` — `dt` / `pt` / `qt`, viscosity 9-sample CI
  - `poisson-distribution.rst` — `dpois`
  - `testing-for-differences-and-similarity.rst` — yield boxplot,
    autocorrelation simulation, external- and internal-spread
    *z*-tests
  - `some-terminology.rst` — MAD vs std deviation under outliers
  - `confidence-intervals.rst` — varying confidence-level CI
- Reorders the existing R + Python `literalinclude` pairs in the
  chapter to **Python first, R second**, matching the order chosen in
  Chapter 1 (`uniform-distribution.rst`,
  `histograms-and-probability-distributions.rst`,
  `some-terminology.rst`).
- Rewrites the two matplotlib gists (`gists/histogram-area.py`,
  `gists/histogram-normal-distribution.py`) in Plotly via the pandas
  plotting backend, again matching Chapter 1's gist conventions.

The R blocks themselves are unchanged.

### Conscious omission

The figure-generation block in
`statistical-tables-for-the-normal-and-t-distribution.rst` is left
R-only. It's auxiliary "here's how I made this figure" code (`par`,
`layout`, `plot`, `arrows`, `abline`) rather than a pedagogical
example, and a faithful Plotly translation of those imperative calls
would dominate the page. Happy to do it in a follow-up if you'd
rather keep the chapters strictly symmetric.

## Test plan

- [x] `make text` — no new warnings; the 314 pre-existing warnings
      are all `figures/` symlink misses (separate repo).
- [x] `make html` — confirmed the seven new Python blocks on
      `normal-distribution-and-checking-for-normality` render with the
      `highlight-python` Pygments class, and the seven R blocks still
      render with `highlight-r`.
- [x] `make latex` — generates clean.
- [ ] `make latexpdf` — couldn't run locally (`latexmk` not installed
      in the sandbox); reviewer should re-run per `CLAUDE.md`.
- [ ] Eyeball the rendered Python on at least one page after deploy
      to confirm nothing collapsed (`testing-for-differences-and-similarity`
      and `t-distribution` are the longest blocks).



---
_Generated by [Claude Code](https://claude.ai/code/session_01Dnw34bLqr9BVpt7pAFdFev)_