### PR TITLE
Add Plotly Python equivalents alongside R blocks in Chapter 3

### DIFF
--- a/process-monitoring/ewma-charts.rst
+++ b/process-monitoring/ewma-charts.rst
@@ -92,7 +92,25 @@ where :math:`\sigma_{\text{Shewhart}}` represents the standard deviation as calc
 
 An interesting implementation can be to show both the Shewhart and EWMA plot on the same chart, with both sets of limits. The EWMA value plotted is actually the one-step ahead prediction of the next :math:`x`-value, which can be informative for slow-moving processes.
 
-The R code here shows one way of calculating the EWMA values for a vector of data. Once you have pasted this function into R, use it as ``ewma(x, lambda=..., target=...)``.
+The code here shows one way of calculating the EWMA values for a vector of data. Once you have defined the function, use it as ``ewma(x, lam=..., target=...)``.
+
+.. code-block:: python
+
+	import numpy as np
+
+	def ewma(x, lam, target=None):
+	    if target is None:
+	        target = x[0]
+	    y = np.zeros(len(x))
+	    y[0] = target
+	    for k in range(1, len(x)):
+	        error = x[k - 1] - y[k - 1]
+	        y[k] = y[k - 1] + lam * error
+	    return y
+
+	# Try using this function now:
+	x = np.array([200, 210, 190, 190, 190, 190])
+	ewma(x, lam=0.3, target=200)
 
 .. code-block:: r
 
@@ -106,7 +124,7 @@ The R code here shows one way of calculating the EWMA values for a vector of dat
 	    }
 	return(y)
 	}
-	
+
 	# Try using this function now:
 	x <- c(200, 210, 190, 190, 190, 190)
 	ewma(x, lambda = 0.3, target = 200)

--- a/process-monitoring/process-monitoring-exercises.rst
+++ b/process-monitoring/process-monitoring-exercises.rst
@@ -40,6 +40,67 @@ Exercises
 
 	Try it yourself:
 
+	.. code-block:: python
+
+		import numpy as np
+		import pandas as pd
+		from scipy.special import gamma
+
+		pd.options.plotting.backend = "plotly"
+
+		data_file = "http://openmv.net/file/batch-yields.csv"
+		batch = pd.read_csv(data_file)
+
+		# Make sure we have the expected data.
+		batch.describe()
+		Yield = batch["Yield"].to_numpy()
+
+		# To get a feel for the data; looks pretty
+		# good, no unusual outliers.
+		pd.Series(Yield).plot.line().show()
+
+		N = len(Yield)
+		N_sub = 5  # subgroup size
+		# Reshape so each column is one subgroup.
+		subgroup = Yield.reshape(N // N_sub, N_sub).T
+		N_groups = subgroup.shape[1]
+		subgroup.shape  # (5, 60)
+
+		subgroup_sd = subgroup.std(axis=0, ddof=1)
+		subgroup_xbar = subgroup.mean(axis=0)
+
+		# Take a look at what these numbers mean.
+		pd.Series(subgroup_xbar).plot.line().update_layout(
+		    yaxis_title_text="Subgroup average").show()
+		pd.Series(subgroup_sd).plot.line().update_layout(
+		    yaxis_title_text="Subgroup spread").show()
+
+		# Report your target value, lower control
+		# limit and upper control limit, showing
+		# the calculations you made.
+		target = subgroup_xbar.mean()
+		Sbar = subgroup_sd.mean()
+
+		# a_n value is from the table when
+		# subgroup size = 5
+		an_num = np.sqrt(2) * gamma(N_sub / 2)
+		an_den = np.sqrt(N_sub - 1) * gamma(N_sub / 2 - 0.5)
+		an = an_num / an_den
+		sigma_estimate = Sbar / an
+		LCL = target - 3 * sigma_estimate / np.sqrt(N_sub)
+		UCL = target + 3 * sigma_estimate / np.sqrt(N_sub)
+		(LCL, target, UCL)
+
+		fig = pd.Series(subgroup_xbar).plot.line(
+		    title="Shewhart chart")
+		fig.update_layout(
+		    yaxis=dict(range=[LCL - 5, UCL + 5],
+		               title_text="Subgroup means"))
+		fig.add_hline(y=target, line_color="green")
+		fig.add_hline(y=UCL, line_color="red")
+		fig.add_hline(y=LCL, line_color="red")
+		fig.show()
+
 	.. code-block:: r
 
 		data_file <- 'http://openmv.net/file/batch-yields.csv'
@@ -180,6 +241,17 @@ Exercises
 .. admonition:: Solution
 
 	The new Cpk value is 1.5. The number of defects per million items at Cpk = 2.0 is 0.00098 (essentially no defects), while at Cpk = 1.5 it is 3.4 defects per million items. You only have to consider one-side of the distribution, since Cpk is by definition for an uncentered process, and deals with the side closest to the specification limits.
+
+	.. code-block:: python
+
+		from scipy.stats import norm
+
+		Cpk = 1.5
+		n_sigma_distance = 3 * Cpk
+		dpm = norm.cdf(-n_sigma_distance,
+		               loc=0,
+		               scale=1) * 1e6
+		print(f"Defects per million = {round(dpm, 3)}")
 
 	.. code-block:: r
 
@@ -573,6 +645,80 @@ Exercises
 
 		.. Source code: ../figures/monitoring/CO2-question.R
 
+	.. code-block:: python
+
+		import numpy as np
+		import pandas as pd
+		from scipy.special import gamma
+		from statsmodels.graphics.tsaplots import plot_acf
+
+		pd.options.plotting.backend = "plotly"
+
+		file = "http://openmv.net/file/gas-furnace.csv"
+		data = pd.read_csv(file)
+		CO2 = data["CO2"].to_numpy()
+		N_raw = len(CO2)
+		N_sub = 6
+
+		# Change N_sub to 10, 15, 20, etc.
+		# At N_sub = 17 we see the
+		# autocorrelation disappear.
+
+		# Plot all the data.
+		pd.Series(CO2).plot.scatter().update_layout(
+		    xaxis_title_text="Sequence order",
+		    yaxis_title_text="CO2: raw data").show()
+
+		# Create the subgroups on ALL the raw data.
+		# Reshape into N_sub rows by N_raw/N_sub
+		# columns; each column is one subgroup.
+		# Calculate the mean and standard deviation
+		# within each subgroup.
+		subgroups = CO2.reshape(N_raw // N_sub, N_sub).T
+		subgroups_S = subgroups.std(axis=0, ddof=1)
+		subgroups_xbar = subgroups.mean(axis=0)
+		ylim = (subgroups_xbar.min() - 3,
+		        subgroups_xbar.max() + 3)
+
+		# Keep adjusting N_sub until you don't see
+		# any autocorrelation between subgroups.
+		plot_acf(subgroups_xbar)
+
+		# Create a function to calculate Shewhart
+		# chart limits.
+		def shewhart_limits(xbar, S, sub_n,
+		                    N_stdev=3):
+		    """Return (LCL, xdb, UCL) which are
+		    N_stdev away from the target, given the
+		    subgroup means xbar, subgroup standard
+		    deviations S, and subgroup size sub_n."""
+		    xdb = xbar.mean()  # x-double-bar
+		    s_bar = S.mean()
+		    num_an = np.sqrt(2) * gamma(sub_n / 2)
+		    den_an = np.sqrt(sub_n - 1) * gamma(
+		        (sub_n - 1) / 2)
+		    an = num_an / den_an
+		    LCL = xdb - N_stdev * s_bar / (
+		        an * np.sqrt(sub_n))
+		    UCL = xdb + N_stdev * s_bar / (
+		        an * np.sqrt(sub_n))
+		    return LCL, xdb, UCL
+
+		LCL, xdb, UCL = shewhart_limits(
+		    subgroups_xbar, subgroups_S, N_sub)
+		(LCL, xdb, UCL)
+
+		# Any points outside these limits?
+		fig = pd.Series(subgroups_xbar).plot.line(
+		    title="Phase I subgroups: round 1")
+		fig.update_layout(
+		    xaxis_title_text="Sequence order",
+		    yaxis=dict(range=ylim))
+		fig.add_hline(y=UCL, line_color="red")
+		fig.add_hline(y=LCL, line_color="red")
+		fig.add_hline(y=xdb, line_color="green")
+		fig.show()
+
 	.. code-block:: r
 
 		file <- 'http://openmv.net/file/gas-furnace.csv'
@@ -704,6 +850,70 @@ Exercises
 		<div style="clear: both;"></div>
 
 	.. Source code: ../figures/monitoring/batch-yield-and-purity-recursive.R
+
+	.. code-block:: python
+
+		import numpy as np
+		import pandas as pd
+		from scipy.special import gamma
+
+		pd.options.plotting.backend = "plotly"
+
+		# Recursively calculate the Shewhart limits,
+		# trimming subgroups outside the limits each
+		# round, until no more points are excluded.
+		file = ("http://openmv.net/file/"
+		        "batch-yield-and-purity.csv")
+		data = pd.read_csv(file)
+		y = data["yield"].to_numpy()
+		variable = "Yield"
+		N = 3
+
+		# No further changes required. The code
+		# below will work for any new data set.
+		# Truncate to the closest multiple of N
+		# so the reshape works.
+		y = y[: (len(y) // N) * N]
+		subgroups = y.reshape(len(y) // N, N).T
+		x_mean = subgroups.mean(axis=0)
+		x_sd = subgroups.std(axis=0, ddof=1)
+		ylim = (x_mean.min() - 5, x_mean.max() + 5)
+
+		num_an = np.sqrt(2) * gamma(N / 2)
+		den_an = np.sqrt(N - 1) * gamma((N - 1) / 2)
+		an = num_an / den_an
+
+		k = 1
+		doloop = True
+		# Prevent infinite loops.
+		while doloop and k < 5:
+		    S = x_sd.mean()
+		    xdb = x_mean.mean()  # x-double-bar
+		    LCL = xdb - (3 * S / (an * np.sqrt(N)))
+		    UCL = xdb + (3 * S / (an * np.sqrt(N)))
+		    print((LCL, UCL))
+
+		    fig = pd.Series(x_mean).plot.line(
+		        title=f"Phase I subgroups: round {k}")
+		    fig.update_layout(
+		        xaxis_title_text="Sequence order",
+		        yaxis=dict(range=ylim))
+		    fig.add_hline(y=UCL, line_color="red")
+		    fig.add_hline(y=LCL, line_color="red")
+		    fig.add_hline(y=xdb, line_color="green")
+		    fig.show()
+
+		    if not ((x_mean < LCL).any()
+		            or (x_mean > UCL).any()):
+		        # Finally! No more points to exclude.
+		        doloop = False
+		    k += 1
+
+		    # Keep only subgroups whose mean falls
+		    # inside the current control limits.
+		    keep = (x_mean >= LCL) & (x_mean <= UCL)
+		    x_sd = x_sd[keep]
+		    x_mean = x_mean[keep]
 
 	.. code-block:: r
 

--- a/process-monitoring/shewhart-charts.rst
+++ b/process-monitoring/shewhart-charts.rst
@@ -116,6 +116,60 @@ The overall average is :math:`\overline{\overline{x}} = 238.8` and :math:`\overl
 	
 In source code:
 
+.. code-block:: python
+
+	import numpy as np
+	from scipy.special import gamma
+
+	# Given information (but calculate yourself
+	# from http://openmv.net/info/rubber-colour)
+	xbar = np.array([245, 239, 239, 241, 241, 241, 238,
+	                 238, 236, 248, 233, 236, 246, 253,
+	                 227, 231, 237, 228, 239, 240],
+	                dtype=float)
+
+	# Number of measurements per subgroup
+	N_sub = 5
+
+	# Average of the 20 standard deviations
+	# of the 20 subgroups
+	S = 9.28
+
+	# xdb = x double bar = overall mean =
+	#       mean of the means
+	xdb = xbar.mean()
+
+	num_an = np.sqrt(2) * gamma(N_sub / 2)
+	den_an = np.sqrt(N_sub - 1) * gamma((N_sub - 1) / 2)
+	an = num_an / den_an
+
+	LCL = xdb - (3 * S / (an * np.sqrt(N_sub)))
+	UCL = xdb + (3 * S / (an * np.sqrt(N_sub)))
+	print(f"Control limits: [{round(LCL, 2)}; "
+	      f"{round(UCL, 2)}]")
+
+	print(f"Number > UCL: {(xbar > UCL).sum()}")
+	print(f"Number < LCL: {(xbar < LCL).sum()}")
+
+	# Exclude the one subgroup above the UCL.
+	# Do this by setting it to NaN (missing).
+	xbar[xbar > UCL] = np.nan
+
+	# Calculate the mean, ignoring NaN.
+	xdb = np.nanmean(xbar)
+
+	# 'S' will change also. If you download the
+	# raw data (link above), you can prove
+	# that the new 'S' will be:
+	S = 9.68
+
+	# 'an' and N_sub will not change.
+
+	LCL = xdb - (3 * S / (an * np.sqrt(N_sub)))
+	UCL = xdb + (3 * S / (an * np.sqrt(N_sub)))
+	print(f"Control limits: [{round(LCL)}; "
+	      f"{round(UCL)}]")
+
 .. code-block:: r
 
 	# Given information (but calculate yourself
@@ -127,7 +181,7 @@ In source code:
 	# Number of measurements per subgroup
 	N.sub = 5
 
-	# Average of the 20 standard deviations 
+	# Average of the 20 standard deviations
 	# of the 20 subgroups
 	S = 9.28
 
@@ -231,14 +285,27 @@ The table highlights that :math:`\beta` is a function of the amount by which the
 :math:`\beta` when :math:`n=4`  0.9936 0.9772 0.9332 0.8413 0.5000 0.1587
 ==============================  ====== ====== ====== ====== ====== ======
 
+.. code-block:: python
+
+	import numpy as np
+	from scipy.stats import norm
+
+	delta = 1
+	n = 4
+	beta = (norm.cdf(+3 - delta * np.sqrt(n))
+	        - norm.cdf(-3 - delta * np.sqrt(n)))
+
+	print(f"When delta={delta} and n={n} "
+	      f"then beta = {round(beta, 4)}")
+
 .. code-block:: r
-	
+
 	delta <- 1
 	n <- 4
-	beta <- pnorm(+3 - delta*sqrt(n)) - 
+	beta <- pnorm(+3 - delta*sqrt(n)) -
 	        pnorm(-3 - delta*sqrt(n))
 
-	paste0('When delta=', delta, ' and n=', n, 
+	paste0('When delta=', delta, ' and n=', n,
 	       ' then beta = ', round(beta, 4))
 
 .. _monitoring_shewart_chart_slugishness:


### PR DESCRIPTION
## Summary

Mirrors the Chapter 1 / Chapter 2 work (PRs #46, #48, #51) for
Chapter 3 (`process-monitoring/`). Adds a Python block immediately
above every inline `.. code-block:: r` in the chapter pages.

**Coverage (7 blocks across 3 files):**

- `shewhart-charts.rst`
  - Rubber-colour iterative Shewhart limits — uses
    `scipy.special.gamma` for the *aₙ* factor and `np.nanmean` for
    the post-exclusion mean (matching the R `na.rm=TRUE` semantics).
  - Type-II β calculation via `scipy.stats.norm.cdf`.
- `ewma-charts.rst`
  - The EWMA helper, translated as a Python function with the same
    signature (`x`, `lam`, `target`). Argument is `lam` rather than
    `lambda` to avoid the Python keyword.
- `process-monitoring-exercises.rst` (4 blocks)
  - Batch-yields Shewhart construction (Plotly).
  - Cpk → defects-per-million (`norm.cdf`).
  - CO₂ furnace Shewhart with autocorrelation (uses
    `statsmodels.graphics.tsaplots.plot_acf` for the ACF; same
    `shewhart_limits` helper as the R version).
  - The recursive limit-trimming loop, with the boolean-mask trim
    instead of the two-step R indexing trick.

The R blocks themselves are unchanged.

### Conscious omission

The four `.. literalinclude::` references into
`figures/monitoring/...` (boards, aeration-rate, plastic-sheet,
Kappa-number) stay R-only. Those R sources live in the separate
figures repo and aren't checked out here, so faithful Python ports
would need access to those files first. Happy to do them in a
follow-up if you want symmetry with Chapter 1's exercises commit.

## Test plan

- [x] `make text` — no new warnings (the 314 pre-existing warnings
      are all `figures/` symlink misses).
- [x] `make html` — confirmed `highlight-python` and `highlight-r`
      Pygments classes both appear twice on
      `_build/html/process-monitoring/shewhart-charts`.
- [x] `make latex` — clean.
- [ ] `make latexpdf` — couldn't run locally (`latexmk` not in the
      sandbox); reviewer should re-run per `CLAUDE.md`.
- [ ] After deploy, eyeball the longest block (CO₂ furnace Shewhart
      in `process-monitoring-exercises`) to confirm nothing collapsed.



---
_Generated by [Claude Code](https://claude.ai/code/session_01Dnw34bLqr9BVpt7pAFdFev)_