### PR TITLE
Add Python equivalents alongside R blocks in Chapter 4

### DIFF
--- a/least-squares-modelling/covariance-and-correlation.rst
+++ b/least-squares-modelling/covariance-and-correlation.rst
@@ -73,13 +73,51 @@ Use this to calculate the covariance between temperature and pressure by breakin
 	
 	-	Next multiply the two vectors, element-by-element, to calculate a new vector :math:`(T - \overline{T}) (p - \overline{p})`.
 
+		.. code-block:: python
+
+			import numpy as np
+
+			temp = np.array([273, 285, 297, 309, 321, 333,
+			                 345, 357, 369, 381])
+			pres = np.array([1600, 1670, 1730, 1830, 1880,
+			                 1920, 2000, 2100, 2170, 2200])
+			humidity = np.array([42, 48, 45, 49, 41, 46,
+			                     48, 48, 45, 49])
+
+			temp_centered = temp - temp.mean()
+			pres_centered = pres - pres.mean()
+			product = temp_centered * pres_centered
+
+			# numpy does element-by-element multiplication.
+			print(product)
+			# [16740 10080  5400  1440   180
+			#     60  1620  5700 10920 15660]
+
+			# Average of `product`:
+			product.mean()    # 6780
+
+			# np.cov returns the covariance matrix; the
+			# off-diagonal entry [0, 1] is Cov{temp, pres}
+			# (with N-1 normalisation, matching R).
+			# Calculated covariance is 7533.33
+			print("Covariance of temperature and "
+			      "pressure is = "
+			      f"{round(np.cov(temp, pres)[0, 1], 2)}")
+
+			# The covariance of a variable with
+			# itself is just the variance:
+			print("Covariance with itself is = "
+			      f"{round(np.cov(temp, temp)[0, 1], 2)}")
+			print("while the variance = "
+			      f"{round(temp.var(ddof=1), 2)}")
+
 		.. code-block:: r
 
 			temp <- c(273, 285, 297, 309, 321, 333,
 			          345, 357, 369, 381)
 			pres <- c(1600, 1670, 1730, 1830, 1880,
 			          1920, 2000, 2100, 2170, 2200)
-			humidity <- c(42, 48, 45, 49, 41, 46, 
+			humidity <- c(42, 48, 45, 49, 41, 46,
 			              48, 48, 45, 49)
 
 			temp.centered <- temp - mean(temp)
@@ -88,7 +126,7 @@ Use this to calculate the covariance between temperature and pressure by breakin
 
 			# R does element-by-element  multiplication in the above line
 			print(product)
-			# [1] 16740 10080  5400  1440   180    
+			# [1] 16740 10080  5400  1440   180
 			#        60  1620  5700 10920 15660
 
 			# Average of 'product':
@@ -152,23 +190,49 @@ It takes the covariance value and divides through by the units of :math:`x` and 
 
 So returning back to our example of the gas cylinder, the correlation between temperature and pressure, and temperature and humidity can be calculated now as:
 
+.. code-block:: python
+
+	import numpy as np
+
+	temp = np.array([273, 285, 297, 309, 321, 333, 345,
+	                 357, 369, 381])
+	pres = np.array([1600, 1670, 1730, 1830, 1880, 1920,
+	                 2000, 2100, 2170, 2200])
+	humidity = np.array([42, 48, 45, 49, 41, 46, 48,
+	                     48, 45, 49])
+
+	# np.corrcoef returns the correlation matrix; the
+	# off-diagonal entry [0, 1] is r(x, y).
+
+	# Correlation between temperature
+	# and pressure is high: 0.9968355
+	np.corrcoef(temp, pres)[0, 1]
+
+	# Correlation between temperature
+	# and humidity is low: 0.3803919
+	np.corrcoef(temp, humidity)[0, 1]
+
+	# What is correlation of humidity
+	# and pressure?
+	np.corrcoef(___, ___)[0, 1]
+
 .. code-block:: r
 
 	temp <- c(273, 285, 297, 309, 321, 333, 345,
 	          357, 369, 381)
 	pres <- c(1600, 1670, 1730, 1830, 1880, 1920,
 	          2000, 2100, 2170, 2200)
-	humidity <- c(42, 48, 45, 49, 41, 46, 48, 
+	humidity <- c(42, 48, 45, 49, 41, 46, 48,
 	              48, 45, 49)
 
 	# Correlation between temperature
 	# and pressure is high: 0.9968355
 	cor(temp, pres)
-	
+
 	# Correlation between temperature
 	# and humidity is low: 0.3803919
 	cor(temp, humidity)
-	
+
 	# What is correlation of humidity
 	# and pressure?
 	cor(___, ___)

--- a/least-squares-modelling/investigating-an-existing-linear-model.rst
+++ b/least-squares-modelling/investigating-an-existing-linear-model.rst
@@ -132,33 +132,88 @@ Here are some examples of the autocorrelation plot: in the first case you would 
 
 Another test for autocorrelation is the :index:`Durbin-Watson test <pair: Durbin-Watson test; autocorrelation>`. For more on this test see the book by Draper and Smith (Chapter 7, 3rd edition); in R you can use the ``durbinWatsonTest(model)`` function in ``library(car)``. Try generating autocorrelation of varying strength (positive, e.g. ``phi_long = 0.80`` and negative, e.g. ``phi_long = -0.75``) in the code below. Inspect the plots which are generated as a result, especially the time order plot: get a feeling for what a strong and weak positive/negative correlation looks like in the time order.
 
+.. code-block:: python
+
+	import numpy as np
+	import pandas as pd
+	import statsmodels.api as sm
+
+	pd.options.plotting.backend = "plotly"
+
+	# Adjust this autocorrelation parameter:
+	phi_long = 0.80
+
+	N = 1005
+	data = np.zeros(N)
+	for k in range(1, N):
+	    data[k] = (np.random.normal(scale=4)
+	               + phi_long * data[k - 1])
+	x = data + 50
+	pd.Series(x).describe()
+
+	# Plot autocorrelation in the first 100 points
+	pd.Series(data[:100]).plot.line(
+	    title="Raw data").update_layout(
+	    xaxis_title_text="Time order").show()
+
+	# Lag-1 scatter plot with a regression line.
+	xk = x[:1000]
+	xk1 = x[1:1001]
+	X = sm.add_constant(xk)
+	model = sm.OLS(xk1, X).fit()
+	r = np.corrcoef(xk1, xk)[0, 1]
+
+	fig = pd.DataFrame({"x[k]": xk,
+	                    "x[k+1]": xk1}
+	                   ).plot.scatter(x="x[k]",
+	                                  y="x[k+1]")
+	fig.update_xaxes(range=[30, 70])
+	fig.update_yaxes(range=[30, 70],
+	                 scaleanchor="x",
+	                 scaleratio=1)
+	x_line = np.array([30, 70])
+	fig.add_scatter(
+	    x=x_line,
+	    y=model.params[0] + model.params[1] * x_line,
+	    mode="lines",
+	    line=dict(color="darkgreen", width=2),
+	    showlegend=False,
+	)
+	fig.add_annotation(
+	    x=30, y=30, xanchor="left",
+	    text=f"Correlation = r = {round(r, 2)}",
+	    showarrow=False,
+	    font=dict(color="darkgreen", size=18),
+	)
+	fig.show()
+
 .. code-block:: r
 
 	# Adjust this autocorrelation parameter:
 	phi_long = 0.80
 
 	N = 1005
-	data <- numeric(N)	
+	data <- numeric(N)
 	for (k in 2:N){
-	  data[k] = rnorm(1, sd=4) + 
+	  data[k] = rnorm(1, sd=4) +
 	                       phi_long * data[k-1]
 	}
 	x <- data + 50
 	summary(x)
 
 	# Plot autocorrelation in the first 100 points
-	plot(data[1:100], type='b', 
+	plot(data[1:100], type='b',
 	     main='Raw data', xlab = 'Time order')
 
 	plot.new()
 	lims = c(30,70)
-	plot(x[1:1000], x[2:1001], asp=1, 
+	plot(x[1:1000], x[2:1001], asp=1,
 	     xlim=lims, ylim=lims)
 	model <- lm(x[2:1001] ~ x[1:1000])
 	abline(model, col="darkgreen", lwd=2)
-	text(30, 30, paste("Correlation = r = ", 
-	                   round(cor(x[2:1001], 
-	                         x[1:1000]), 2)), 
+	text(30, 30, paste("Correlation = r = ",
+	                   round(cor(x[2:1001],
+	                         x[1:1000]), 2)),
 	     col="darkgreen", cex=1.5, adj = c(0, NA))
 	
 

--- a/least-squares-modelling/least-squares-model-analysis.rst
+++ b/least-squares-modelling/least-squares-model-analysis.rst
@@ -361,6 +361,43 @@ Now it is straight forward to construct **confidence intervals for the least squ
 
 Returning :ref:`back to our ongoing example <LS-class-example>`, we can calculate the confidence interval for :math:`\beta_0` and :math:`\beta_1`. We calculated earlier already that |b0| = 3.0 and |b1| = 0.5. Using these values we can calculate the standard error:
 
+.. code-block:: python
+
+	import numpy as np
+	import statsmodels.api as sm
+
+	x = np.array([10, 8, 13, 9, 11, 14, 6, 4, 12, 7, 5])
+	y = np.array([8.04, 6.95, 7.58, 8.81, 8.33, 9.96,
+	              7.24, 4.26, 10.84, 4.82, 5.68])
+
+	# Calculate the linear model, where y
+	# is described by x.
+	X = sm.add_constant(x)
+	mod_ls = sm.OLS(y, X).fit()
+
+	# We can find what `b0` and `b1` are in
+	# several different ways:
+	print(mod_ls.summary())
+
+	# or using
+	print("The model coefficients are: ")
+	mod_ls.params
+
+	# Model predictions:
+	print("The predicted values are: ")
+	mod_ls.predict()
+	# [ 8.001  7.000  9.501  7.501  8.501
+	#  10.001  6.000  5.000  9.001  6.500  5.501]
+
+	# Prediction error = observed - predicted
+	error = y - mod_ls.predict()
+	N = len(x)
+
+	# The SE = standard error = 1.236603
+	std_error = np.sqrt((error ** 2).sum() / (N - 2))
+	print(f"Standard error SE = "
+	      f"{round(std_error, 3)}")
+
 .. code-block:: r
 
 	x <- c(10, 8, 13, 9, 11, 14, 6, 4, 12, 7, 5)
@@ -371,10 +408,10 @@ Returning :ref:`back to our ongoing example <LS-class-example>`, we can calculat
 	# where y is described by x"
 	mod.ls <- lm(y ~ x)
 
-	# We can find what the "b0" and "b1" 
+	# We can find what the "b0" and "b1"
 	# values are in several different ways:
 	summary(mod.ls)
-	
+
 	# or using
 	print('The model coefficients are: ')
 	coefficients(mod.ls)
@@ -382,7 +419,7 @@ Returning :ref:`back to our ongoing example <LS-class-example>`, we can calculat
 	# Model predictions:
 	print('The predicted values are: ')
 	predict(mod.ls)
-	# 8.001  7.000  9.501  7.501  8.501  
+	# 8.001  7.000  9.501  7.501  8.501
 	# 10.001  6.00  5.000  9.001  6.500  5.501
 
 	# Prediction error = observed - predicted
@@ -391,7 +428,7 @@ Returning :ref:`back to our ongoing example <LS-class-example>`, we can calculat
 
 	# The SE = standard error = 1.236603
 	std.error <- sqrt(sum(error^2) / (N-2))
-	paste0('Standard error SE = ', 
+	paste0('Standard error SE = ',
 	       round(std.error, 3))
 
 Use that :math:`S_E` value to calculate the confidence intervals for :math:`\beta_0` and :math:`\beta_1`, and use that :math:`c_t = 2.26` at the 95% confidence level. You can calculate  this value in R using ``qt(0.975, df=(N-2))``. There are :math:`n-2` degrees of freedom, the number of degrees of freedom used to calculate :math:`S_E`.
@@ -435,6 +472,41 @@ The plot shows the effect of varying the slope parameter, :math:`b_1`, from its 
 In many cases the confidence interval for the intercept is not of any value because the data for |x| is so far away from zero, or the true value of the intercept is not of concern for us.
 
 
+.. code-block:: python
+
+	import numpy as np
+	import statsmodels.api as sm
+
+	x = np.array([10, 8, 13, 9, 11, 14, 6, 4, 12, 7, 5])
+	y = np.array([8.04, 6.95, 7.58, 8.81, 8.33, 9.96,
+	              7.24, 4.26, 10.84, 4.82, 5.68])
+
+	# Calculate the linear model, where y
+	# is described by x.
+	X = sm.add_constant(x)
+	mod_ls = sm.OLS(y, X).fit()
+
+	# You can (and should at the beginning)
+	# calculate the confidence intervals as shown
+	# above. But there is a short-cut, to save
+	# time, and is less error prone:
+	mod_ls.conf_int()
+
+	#                  0         1
+	# const     0.455737  5.544445
+	# x1        0.233370  0.766812
+
+	# If you want the confidence interval at any
+	# other level, for example, at the 90% level:
+	mod_ls.conf_int(alpha=0.10)
+
+	#                  0         1
+	# const     0.938303  5.061879
+	# x1        0.283957  0.716225
+
+	# Compare this to the calculated value by hand
+	# above. It is exactly the same!
+
 .. code-block:: r
 
 	x <- c(10, 8, 13, 9, 11, 14, 6, 4, 12, 7, 5)
@@ -445,12 +517,12 @@ In many cases the confidence interval for the intercept is not of any value beca
 	# where y is described by x"
 	mod.ls <- lm(y ~ x)
 
-	# You can (and should at the beginning) 
+	# You can (and should at the beginning)
 	# calculate the confidence intervals as shown
 	# above. But there is a short-cut, to save
 	# time, and is less error prone:
 	confint(mod.ls)
-	
+
 	#                 2.5 %    97.5 %
 	# (Intercept) 0.4557369 5.5444449
 	# x           0.2333701 0.7668117
@@ -458,12 +530,12 @@ In many cases the confidence interval for the intercept is not of any value beca
 	# If you want the confidence interval at any
 	# other level, for example, at the 90% level:
 	confint(mod.ls, level=0.90)
-	
+
 	#                   5 %     95 %
 	# (Intercept) 0.9383030 5.061879
 	# x           0.2839568 0.716225
-	
-	# Compare this to the calculated value by hand 
+
+	# Compare this to the calculated value by hand
 	# above. It is exactly the same!
 
 

--- a/least-squares-modelling/least-squares-models-with-a-single-x-variable.rst
+++ b/least-squares-modelling/least-squares-models-with-a-single-x-variable.rst
@@ -223,17 +223,50 @@ We will refer back to the following example several times. Calculate the least s
 	* :math:`\sum_i{\left( x_i - \overline{\mathrm{x}}_1\right)^2} = 110`
 	|}
 
-To calculate the least squares model in R:
+To calculate the least squares model:
+
+.. code-block:: python
+
+	import numpy as np
+	import statsmodels.api as sm
+
+	x = np.array([10, 8, 13, 9, 11, 14, 6, 4, 12, 7, 5])
+	y = np.array([8.04, 6.95, 7.58, 8.81, 8.33, 9.96,
+	              7.24, 4.26, 10.84, 4.82, 5.68])
+
+	# Calculate the linear model, where y
+	# is described by x. add_constant adds
+	# the intercept term.
+	X = sm.add_constant(x)
+	mod_ls = sm.OLS(y, X).fit()
+
+	# Coefficients:
+	# const     3.0001
+	# x1        0.5001
+	mod_ls.params
+
+	# You can get more information with
+	print(mod_ls.summary())
+
+	print("The model coefficients are: ")
+	mod_ls.params
+
+	b0, b1 = mod_ls.params
+	x_new = 5.5
+	y_predicted = b0 + b1 * x_new
+	print(f"Given a new x value of {x_new} "
+	      f"the predicted y = "
+	      f"{round(y_predicted, 3)}")
 
 .. code-block:: r
 
 	x <- c(10, 8, 13, 9, 11, 14, 6, 4, 12, 7, 5)
-	y <- c(8.04, 6.95, 7.58, 8.81, 8.33, 9.96, 
+	y <- c(8.04, 6.95, 7.58, 8.81, 8.33, 9.96,
 	      7.24, 4.26, 10.84, 4.82, 5.68)
 
-	# "Calculate for me the linear model, 
+	# "Calculate for me the linear model,
 	# where y is described by x"
-	mod.ls <- lm(y ~ x) 
+	mod.ls <- lm(y ~ x)
 
 	# Call:
 	# lm(formula = y ~ x)
@@ -241,7 +274,7 @@ To calculate the least squares model in R:
 	# Coefficients:
 	# (Intercept)            x
 	#	       3.0001       0.5001
-	   
+
 	# You can get more information with
 	summary(mod.ls)
 
@@ -253,7 +286,7 @@ To calculate the least squares model in R:
 	x.new <- 5.5
 	y_predicted <- b0 + b1 * x.new
 	paste0('Given a new x value of ', x.new,
-	       ' the predicted y = ', 
+	       ' the predicted y = ',
 	       round(y_predicted, 3))
 
 *	:math:`b_0 = 3.0`


### PR DESCRIPTION
## Summary

Mirrors the Chapter 1–3 work (PRs #46, #48, #51, #52) for Chapter 4
(`least-squares-modelling/`). Adds a Python block immediately above
every inline `.. code-block:: r` in the chapter pages.

**Coverage (6 blocks across 4 files):**

- `covariance-and-correlation.rst`
  - Deviation-variable covariance walk-through. Uses `np.cov(...)[0, 1]`
    so the N−1 normalisation matches R's `cov()`.
  - Correlation example via `np.corrcoef(...)[0, 1]`.
- `investigating-an-existing-linear-model.rst`
  - AR(1) autocorrelation simulation. Reproduces the lag-1 scatter
    and regression line in Plotly via `statsmodels.OLS`, with the
    correlation `r` annotated in the corner exactly as the R code did.
- `least-squares-models-with-a-single-x-variable.rst`
  - The introductory `lm()` example, ported to `statsmodels.OLS` with
    `sm.add_constant`.
- `least-squares-model-analysis.rst`
  - Standard-error walk-through.
  - The `confint(...)` short-cut, ported to `mod_ls.conf_int(alpha=…)`.

The R blocks themselves are unchanged.

### Conscious omissions

- `least-squares-model-analysis.rst:552` (R) is **already paired** with
  a Python block at line 602, with the prose between them explicitly
  saying "The Python version follows below." Reordering would require
  rewriting that prose, so this section is left as-is.
- The 11 `.. literalinclude::` references into `figures/least-squares/*.R`
  remain R-only — those R sources live in the figures repo and are
  out of scope here.

## Test plan

- [x] `make text` — no new warnings (the 314 pre-existing warnings
      are all `figures/` symlink misses).
- [x] `make html` — confirmed `highlight-python` and `highlight-r`
      Pygments classes appear three times each on
      `_build/html/least-squares-modelling/least-squares-model-analysis`.
- [x] `make latex` — clean.
- [ ] `make latexpdf` — couldn't run locally (no `latexmk` in the
      sandbox); reviewer should verify per `CLAUDE.md`.
- [ ] After deploy, eyeball the longest block (autocorrelation
      simulation in `investigating-an-existing-linear-model`) to
      confirm it renders correctly.



---
_Generated by [Claude Code](https://claude.ai/code/session_01Dnw34bLqr9BVpt7pAFdFev)_