### PR TITLE
Add Python equivalents alongside R blocks in Chapter 5

### DIFF
--- a/design-analysis-experiments/fractional-factorial-designs/half-fractions.rst
+++ b/design-analysis-experiments/fractional-factorial-designs/half-fractions.rst
@@ -64,6 +64,28 @@ The :math:`\mathbf{X}` matrix is not :ref:`orthogonal <DOE_orthogonality>` anymo
 
 For these reasons the least squares model cannot be solved by inverting the :math:`\mathbf{X}^T\mathbf{X}` matrix. Prove it to yourself by using this code:
 
+.. code-block:: python
+
+	import numpy as np
+
+	intercept = np.ones(4)
+	A = np.array([-1, +1, -1, +1])
+	B = np.array([-1, -1, +1, +1])
+	C = A * B
+	X = np.column_stack([intercept, A, B, C,
+	                     A * B, A * C, B * C,
+	                     A * B * C])
+
+	XtX = X.T @ X
+	print("The X'X matrix is = ")
+	print(XtX)
+
+	print("Calculate the inverse (it will fail!)")
+	np.linalg.inv(XtX)
+
+	# We cannot, since the determinant is 0:
+	np.linalg.det(XtX)
+
 .. code-block:: r
 
 	int <- c(1, 1, 1, 1)

--- a/design-analysis-experiments/fractional-factorial-designs/saturated-designs-for-screening.rst
+++ b/design-analysis-experiments/fractional-factorial-designs/saturated-designs-for-screening.rst
@@ -47,6 +47,64 @@ where :math:`\mathbf{b} = [b_0, b_A, b_B, b_C, b_D, b_E, b_F, b_G]`. The matrix 
 
 How do you assess which main effects are important?  There are eight data points and eight parameters, so there are no degrees of freedom and the residuals are all zero. In this case you have to use a :ref:`Pareto plot <DOE-Pareto-plot>`, which requires that your variables have been suitably scaled in order to judge importance of the main effects relative to each other. The Pareto plot would be given as shown below, and as usual, it does not show the intercept term.
 
+.. code-block:: python
+
+	import itertools
+	import numpy as np
+	import pandas as pd
+	import statsmodels.api as sm
+
+	pd.options.plotting.backend = "plotly"
+
+	# Create vectors for each factor in the experiment.
+	# itertools.product gives the full 2^3 design.
+	design = pd.DataFrame(
+	    list(itertools.product([-1, +1],
+	                           [-1, +1],
+	                           [-1, +1])),
+	    columns=["A", "B", "C"],
+	)
+	A = design["A"].to_numpy()
+	B = design["B"].to_numpy()
+	C = design["C"].to_numpy()
+	D = A * B
+	E = A * C
+	F = B * C
+	G = A * B * C
+	y = np.array([77.1, 68.9, 75.5, 72.5,
+	              67.9, 68.5, 71.5, 63.7])
+
+	X = np.column_stack([A, B, C, D, E, F, G])
+	X = sm.add_constant(X)
+	demo = sm.OLS(y, X).fit()
+	print(demo.summary())
+
+	# OK, now we are ready to generate the Pareto plot.
+	# Sort the absolute coefficient values, dropping
+	# the intercept (matching the R paretoPlot conventions).
+	names = ["A", "B", "C", "D", "E", "F", "G"]
+	effects = pd.Series(
+	    np.abs(demo.params[1:]),
+	    index=names,
+	).sort_values()
+	fig = effects.plot.bar(orientation="h")
+	fig.update_layout(
+	    xaxis_title_text="|effect|",
+	    yaxis_title_text="Factor",
+	    showlegend=False,
+	)
+	fig.show()
+
+	# Try getting the results manually:
+	XtX = X.T @ X
+	print("The XtX matrix is:")
+	print(XtX)
+
+	Xty = X.T @ y
+	b = np.linalg.solve(XtX, Xty)
+	print("The solution vector is:")
+	print(b)
+
 .. code-block:: r
 
 	# Create vectors for each factor in the experiment


### PR DESCRIPTION
## Summary

Mirrors the Chapter 1–4 work (PRs #46, #48, #51, #52, #53) for
Chapter 5 (`design-analysis-experiments/`). Adds a Python block
immediately above every inline `.. code-block:: r` in the chapter
pages.

**Coverage (2 blocks across 2 files):**

- `fractional-factorial-designs/half-fractions.rst`
  - The singular *X'X* demonstration (full 2³ design with `C`
    aliased as `A * B`), ported to NumPy with
    `np.column_stack`, `np.linalg.inv`, and `np.linalg.det`. The
    inversion fails for the same reason as in R — exposes the
    collinearity between aliased columns.
- `fractional-factorial-designs/saturated-designs-for-screening.rst`
  - The 7-factor saturated screening example with Pareto plot.
    `itertools.product` builds the full 2³ base design,
    `statsmodels.OLS` fits the model, and a Plotly horizontal bar
    chart of the absolute (non-intercept) coefficients replaces
    the R `paretoPlot` helper (which depended on an external
    server-loaded function).

The R blocks themselves are unchanged.

### Conscious omissions

- The 3 `.. literalinclude::` references into `figures/doe/` —
  `bioreactor-case-improved.R`, `chemical_reaction_contours.m`,
  `fractional-factorial-question.R` — remain as-is. The R / Matlab
  sources live in the separate figures repo.

## Test plan

- [x] `make text` — no new warnings (the 314 pre-existing warnings
      are all `figures/` symlink misses).
- [x] `make html` — confirmed `highlight-python` and `highlight-r`
      Pygments classes both appear once on each of
      `_build/html/design-analysis-experiments/fractional-factorial-designs/half-fractions`
      and `.../saturated-designs-for-screening`.
- [x] `make latex` — clean.
- [ ] `make latexpdf` — couldn't run locally (no `latexmk` in the
      sandbox); reviewer should verify per `CLAUDE.md`.



---
_Generated by [Claude Code](https://claude.ai/code/session_01Dnw34bLqr9BVpt7pAFdFev)_