### PR TITLE
Add Python equivalents alongside R blocks in Chapter 6

### DIFF
--- a/latent-variable-modelling/principal-component-analysis/pca-example-analysis-of-spectral-data.rst
+++ b/latent-variable-modelling/principal-component-analysis/pca-example-analysis-of-spectral-data.rst
@@ -16,18 +16,45 @@ A data set, `available on the dataset website <http://openmv.net/info/tablet-spe
 	:width: 750px
 	:align: center
 	
-This R code will calculate principal components for this data:
+This code will calculate principal components for this data:
+
+.. code-block:: python
+
+	import pandas as pd
+	from sklearn.decomposition import PCA
+	from sklearn.preprocessing import StandardScaler
+
+	# Read large data file
+	file = "http://openmv.net/file/tablet-spectra.csv"
+	spectra = pd.read_csv(file, header=None, index_col=0)
+
+	# Only extract 4 components, but
+	# center and scale the data before
+	# calculating the components.
+	scaler = StandardScaler()
+	X = scaler.fit_transform(spectra)
+	model_pca = PCA(n_components=4).fit(X)
+
+	# Standard deviation of each PC:
+	import numpy as np
+	print(np.sqrt(model_pca.explained_variance_))
+
+	# Proportion of variance:
+	print(model_pca.explained_variance_ratio_)
+
+	# Cumulative proportion:
+	print(model_pca.explained_variance_ratio_.cumsum())
 
 .. code-block:: r
 
 	# Read large data file
 	file <- 'http://openmv.net/file/tablet-spectra.csv'
 	spectra <- read.csv(file, header = FALSE, row.names = 1)
-	
+
 	# Only extract 4 components, but
 	# center and scale the data before
 	# calculation the components
-	model.pca <- prcomp(spectra, 
+	model.pca <- prcomp(spectra,
 	                    center = TRUE,
 	                    scale =TRUE,
 	                    rank. = 4)
@@ -63,6 +90,77 @@ Finally, we can show the SPE plot for each observation. SPE values for each tabl
 	
 The code for the above plots is:
 
+.. code-block:: python
+
+	import numpy as np
+	import pandas as pd
+	import plotly.graph_objects as go
+	from plotly.subplots import make_subplots
+	from sklearn.decomposition import PCA
+	from sklearn.preprocessing import StandardScaler
+
+	file = "http://openmv.net/file/tablet-spectra.csv"
+	spectra = pd.read_csv(file, header=None, index_col=0)
+
+	# Only extract 4 components, but center and scale
+	# the data before calculating the components.
+	scaler = StandardScaler()
+	spectra_mcuv = scaler.fit_transform(spectra)
+	model_pca = PCA(n_components=4).fit(spectra_mcuv)
+	# sklearn stores components row-wise; transpose to
+	# match the K-by-A loadings matrix used in the text.
+	spectra_P = model_pca.components_.T
+	spectra_T = model_pca.transform(spectra_mcuv)
+
+	# Baseline variance (per element).
+	spectra_X2 = spectra_mcuv * spectra_mcuv
+
+	wavelengths = np.arange(600, 1900, 2)
+	colors = {1: "darkgreen", 2: "black", 3: "blue"}
+	widths = {1: 2, 2: 4, 3: 6}
+	SPE = {}
+	r2_fig = go.Figure()
+	for a in (1, 2, 3):
+	    spectra_Xhat_a = spectra_T[:, :a] @ spectra_P[:, :a].T
+	    spectra_E = spectra_mcuv - spectra_Xhat_a
+	    spectra_E2 = spectra_E * spectra_E
+	    spectra_Xhat_a_2 = spectra_Xhat_a * spectra_Xhat_a
+
+	    SPE[a] = np.sqrt(spectra_E2.sum(axis=1))
+	    R2_k_a = (spectra_Xhat_a_2.sum(axis=0)
+	              / spectra_X2.sum(axis=0))
+
+	    r2_fig.add_trace(go.Scatter(
+	        x=wavelengths, y=R2_k_a,
+	        mode="lines",
+	        name=f"R^2: component {a}",
+	        line=dict(color=colors[a], width=widths[a]),
+	    ))
+	r2_fig.update_layout(
+	    xaxis_title_text="Wavelengths",
+	    yaxis_title_text="R^2 per component (wavelength)",
+	    yaxis=dict(range=[0, 1]),
+	)
+	r2_fig.show()
+
+	# SPE plot: 3 stacked panels (A=1, A=2, A=3).
+	N = spectra.shape[0]
+	spe_fig = make_subplots(
+	    rows=3, cols=1, shared_xaxes=True,
+	    subplot_titles=("SPE: A=1", "SPE: A=2", "SPE: A=3"),
+	)
+	for k, a in enumerate((1, 2, 3), start=1):
+	    spe_fig.add_trace(
+	        go.Scatter(x=np.arange(1, N + 1), y=SPE[a],
+	                   mode="lines",
+	                   line=dict(color=colors[a], width=2),
+	                   showlegend=False),
+	        row=k, col=1,
+	    )
+	spe_fig.update_xaxes(title_text="Tablet number",
+	                     row=3, col=1)
+	spe_fig.show()
+
 .. code-block:: r
 
 	file <- 'http://openmv.net/file/tablet-spectra.csv'
@@ -72,7 +170,7 @@ The code for the above plots is:
 	# Only extract 4 components, but
 	# center and scale the data before
 	# calculation the components
-	model.pca <- prcomp(spectra, 
+	model.pca <- prcomp(spectra,
 	                    center = TRUE,
 	                    scale =TRUE,
 	                    rank. = 4)

--- a/latent-variable-modelling/projection-to-latent-structures/pls-exercises.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-exercises.rst
@@ -36,6 +36,18 @@ The taste of cheddar cheese
 		:width: 900px
 		:align: center
 
+	.. code-block:: python
+
+		import pandas as pd
+		import plotly.express as px
+
+		filename = "http://openmv.net/file/cheddar-cheese.csv"
+		cheese = pd.read_csv(filename)
+		cheese.describe()
+
+		fig = px.scatter_matrix(cheese.iloc[:, 1:5])
+		fig.show()
+
 	.. code-block:: r
 
 		filename <- 'http://openmv.net/file/cheddar-cheese.csv'
@@ -52,6 +64,23 @@ The taste of cheddar cheese
 #.	What would the loadings look like?
 
 #.	Build a PCA model now to verify your answers.
+
+	.. code-block:: python
+
+		import pandas as pd
+		from sklearn.decomposition import PCA
+		from sklearn.preprocessing import StandardScaler
+
+		filename = "http://openmv.net/file/cheddar-cheese.csv"
+		cheese = pd.read_csv(filename)
+		cheese.describe()
+
+		X = StandardScaler().fit_transform(
+		    cheese.iloc[:, 1:5])
+		model_pca = PCA().fit(X)
+		print(model_pca.explained_variance_ratio_.cumsum())
+		loadings_P = model_pca.components_.T
+		scores_T = model_pca.transform(X)
 
 	.. code-block:: r
 
@@ -87,6 +116,32 @@ The taste of cheddar cheese
 
 	*	Compare this to the PLS model's :math:`R^2_y` value.
 
+	.. code-block:: python
+
+		import numpy as np
+		import pandas as pd
+		import statsmodels.api as sm
+
+		cheese = pd.read_csv(
+		    "http://openmv.net/file/cheddar-cheese.csv")
+		cheese.describe()
+
+		# Least squares model:
+		X = sm.add_constant(
+		    cheese[["Acetic", "H2S", "Lactic"]])
+		model_lm = sm.OLS(cheese["Taste"], X).fit()
+		resid = model_lm.resid
+		resid_ssq = (resid ** 2).sum()
+		standard_error = np.sqrt(
+		    resid_ssq / model_lm.df_resid)
+		ssq_total = ((cheese["Taste"]
+		              - cheese["Taste"].mean()) ** 2).sum()
+		R2_value = 1 - resid_ssq / ssq_total
+		print(f"Least squares SE = "
+		      f"{round(standard_error, 2)}")
+		print(f"Least squares R^2 = "
+		      f"{round(R2_value * 100, 2)}%")
+
 	.. code-block:: r
 
 		cheese <- read.csv('http://openmv.net/file/cheddar-cheese.csv')
@@ -108,6 +163,43 @@ The taste of cheddar cheese
 		       round(R2.value*100, 2), '%')
 
 #.	Now build a PCR model in R using only 1 component, then using 2 components. Again calculate the standard error and :math:`R^2_y` values.
+
+	.. code-block:: python
+
+		import numpy as np
+		import pandas as pd
+		import statsmodels.api as sm
+		from sklearn.decomposition import PCA
+		from sklearn.preprocessing import StandardScaler
+
+		cheese = pd.read_csv(
+		    "http://openmv.net/file/cheddar-cheese.csv")
+		cheese.describe()
+
+		# PCA model with only 2 components
+		X_scaled = StandardScaler().fit_transform(
+		    cheese.iloc[:, 1:4])
+		model_pca = PCA(n_components=2).fit(X_scaled)
+		scores_T = model_pca.transform(X_scaled)
+
+		# PCR model using only PC 1
+		y = cheese["Taste"]
+		pcr_1 = sm.OLS(
+		    y, sm.add_constant(scores_T[:, [0]])).fit()
+
+		# PCR model using PC 1 and PC 2
+		pcr_2 = sm.OLS(
+		    y, sm.add_constant(scores_T)).fit()
+
+		SE_1 = np.sqrt(
+		    (pcr_1.resid ** 2).sum() / pcr_1.df_resid)
+		SE_2 = np.sqrt(
+		    (pcr_2.resid ** 2).sum() / pcr_2.df_resid)
+
+		print(f"SE for PCR with 1 component: "
+		      f"{round(SE_1, 2)}")
+		print(f"SE for PCR with 2 components: "
+		      f"{round(SE_2, 2)}")
 
 	.. code-block:: r
 


### PR DESCRIPTION
## Summary

Mirrors the Chapter 1–5 work (PRs #46, #48, #51, #52, #53, #54) for
Chapter 6 (`latent-variable-modelling/`). Adds a Python block
immediately above every inline `.. code-block:: r` in the chapter
pages.

**Coverage (6 blocks across 2 files):**

- `principal-component-analysis/pca-example-analysis-of-spectral-data.rst`
  - Tablet-spectra PCA via `sklearn.decomposition.PCA` on
    `StandardScaler`-centred data. Surfaces the same standard
    deviation, proportion-of-variance, and cumulative-proportion
    arrays that R's `prcomp` summary prints.
  - Per-wavelength *R²* and per-tablet SPE plots, ported as a single
    *R²* line chart and a 3-row Plotly subplots SPE figure. Loop over
    `a ∈ {1, 2, 3}` mirrors the R structure but reuses the same `E`
    and `Xhat` tensors instead of recomputing them.
- `projection-to-latent-structures/pls-exercises.rst`
  - Cheddar-cheese `scatterplotMatrix` → `plotly.express.scatter_matrix`.
  - 4-column PCA via `sklearn` (using `cheese.iloc[:, 1:5]` so the
    column slice matches the R `cheese[, 2:5]` indexing).
  - MLR `Taste ~ Acetic + H2S + Lactic` ported to `statsmodels.OLS`,
    with the same residual-SSQ / *S_E* / *R²* reporting.
  - PCR with 1 and 2 components: `sklearn` PCA + `statsmodels.OLS`,
    same `SE_1` / `SE_2` reporting.

The R blocks themselves are unchanged. The chapter has no
figures-repo literalincludes, so this PR fully covers the chapter.

`CITATION.cff` was already at today's date from a prior PR; no bump
needed.

## Test plan

- [x] `make text` — no new warnings (the 314 pre-existing warnings
      are all `figures/` symlink misses).
- [x] `make html` — confirmed `highlight-python` and `highlight-r`
      Pygments classes both appear four times each on
      `_build/html/latent-variable-modelling/projection-to-latent-structures/pls-exercises`.
- [x] `make latex` — clean.
- [ ] `make latexpdf` — couldn't run locally (no `latexmk` in the
      sandbox); reviewer should verify per `CLAUDE.md`.
- [ ] After deploy, eyeball the spectral-data SPE/R² block (longest
      one in the chapter) to confirm the multi-trace Plotly figures
      render correctly.



---
_Generated by [Claude Code](https://claude.ai/code/session_01Dnw34bLqr9BVpt7pAFdFev)_