### PR TITLE
Use process-improve PCA in latent-variable Python snippets

### DIFF
--- a/latent-variable-modelling/principal-component-analysis/pca-example-analysis-of-spectral-data.rst
+++ b/latent-variable-modelling/principal-component-analysis/pca-example-analysis-of-spectral-data.rst
@@ -21,29 +21,23 @@ This code will calculate principal components for this data:
 .. code-block:: python
 
 	import pandas as pd
-	from sklearn.decomposition import PCA
-	from sklearn.preprocessing import StandardScaler
+	from process_improve.multivariate import PCA, MCUVScaler
 
 	# Read large data file
 	file = "http://openmv.net/file/tablet-spectra.csv"
 	spectra = pd.read_csv(file, header=None, index_col=0)
 
-	# Only extract 4 components, but
-	# center and scale the data before
-	# calculating the components.
-	scaler = StandardScaler()
-	X = scaler.fit_transform(spectra)
-	model_pca = PCA(n_components=4).fit(X)
+	# Only extract 4 components, but center and
+	# scale the data before fitting. MCUVScaler is
+	# mean-centring and unit-variance scaling.
+	spectra_mcuv = MCUVScaler().fit_transform(spectra)
+	model_pca = PCA(n_components=4).fit(spectra_mcuv)
 
-	# Standard deviation of each PC:
-	import numpy as np
-	print(np.sqrt(model_pca.explained_variance_))
-
-	# Proportion of variance:
-	print(model_pca.explained_variance_ratio_)
+	# Proportion of variance per component:
+	print(model_pca.r2_per_component_)
 
 	# Cumulative proportion:
-	print(model_pca.explained_variance_ratio_.cumsum())
+	print(model_pca.r2_cumulative_)
 
 .. code-block:: r
 
@@ -93,45 +87,31 @@ The code for the above plots is:
 .. code-block:: python
 
 	import numpy as np
-	import pandas as pd
 	import plotly.graph_objects as go
+	import pandas as pd
 	from plotly.subplots import make_subplots
-	from sklearn.decomposition import PCA
-	from sklearn.preprocessing import StandardScaler
+	from process_improve.multivariate import PCA, MCUVScaler
 
 	file = "http://openmv.net/file/tablet-spectra.csv"
 	spectra = pd.read_csv(file, header=None, index_col=0)
 
-	# Only extract 4 components, but center and scale
-	# the data before calculating the components.
-	scaler = StandardScaler()
-	spectra_mcuv = scaler.fit_transform(spectra)
+	# Center and scale the data before fitting.
+	spectra_mcuv = MCUVScaler().fit_transform(spectra)
 	model_pca = PCA(n_components=4).fit(spectra_mcuv)
-	# sklearn stores components row-wise; transpose to
-	# match the K-by-A loadings matrix used in the text.
-	spectra_P = model_pca.components_.T
-	spectra_T = model_pca.transform(spectra_mcuv)
 
-	# Baseline variance (per element).
-	spectra_X2 = spectra_mcuv * spectra_mcuv
-
+	# The fitted PCA model exposes the per-variable R^2
+	# (cumulative up to each component) and the per-row
+	# SPE values directly, both indexed by component.
+	# r2_per_variable_ is K-by-A; spe_ is N-by-A.
 	wavelengths = np.arange(600, 1900, 2)
 	colors = {1: "darkgreen", 2: "black", 3: "blue"}
 	widths = {1: 2, 2: 4, 3: 6}
-	SPE = {}
+
 	r2_fig = go.Figure()
 	for a in (1, 2, 3):
-	    spectra_Xhat_a = spectra_T[:, :a] @ spectra_P[:, :a].T
-	    spectra_E = spectra_mcuv - spectra_Xhat_a
-	    spectra_E2 = spectra_E * spectra_E
-	    spectra_Xhat_a_2 = spectra_Xhat_a * spectra_Xhat_a
-
-	    SPE[a] = np.sqrt(spectra_E2.sum(axis=1))
-	    R2_k_a = (spectra_Xhat_a_2.sum(axis=0)
-	              / spectra_X2.sum(axis=0))
-
 	    r2_fig.add_trace(go.Scatter(
-	        x=wavelengths, y=R2_k_a,
+	        x=wavelengths,
+	        y=model_pca.r2_per_variable_[a],
 	        mode="lines",
 	        name=f"R^2: component {a}",
 	        line=dict(color=colors[a], width=widths[a]),
@@ -151,7 +131,8 @@ The code for the above plots is:
 	)
 	for k, a in enumerate((1, 2, 3), start=1):
 	    spe_fig.add_trace(
-	        go.Scatter(x=np.arange(1, N + 1), y=SPE[a],
+	        go.Scatter(x=np.arange(1, N + 1),
+	                   y=model_pca.spe_[a],
 	                   mode="lines",
 	                   line=dict(color=colors[a], width=2),
 	                   showlegend=False),

--- a/latent-variable-modelling/projection-to-latent-structures/pls-exercises.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-exercises.rst
@@ -68,19 +68,17 @@ The taste of cheddar cheese
 	.. code-block:: python
 
 		import pandas as pd
-		from sklearn.decomposition import PCA
-		from sklearn.preprocessing import StandardScaler
+		from process_improve.multivariate import PCA, MCUVScaler
 
 		filename = "http://openmv.net/file/cheddar-cheese.csv"
 		cheese = pd.read_csv(filename)
 		cheese.describe()
 
-		X = StandardScaler().fit_transform(
-		    cheese.iloc[:, 1:5])
-		model_pca = PCA().fit(X)
-		print(model_pca.explained_variance_ratio_.cumsum())
-		loadings_P = model_pca.components_.T
-		scores_T = model_pca.transform(X)
+		X = MCUVScaler().fit_transform(cheese.iloc[:, 1:5])
+		model_pca = PCA(n_components=4).fit(X)
+		print(model_pca.r2_cumulative_)
+		loadings_P = model_pca.loadings_
+		scores_T = model_pca.scores_
 
 	.. code-block:: r
 
@@ -169,18 +167,17 @@ The taste of cheddar cheese
 		import numpy as np
 		import pandas as pd
 		import statsmodels.api as sm
-		from sklearn.decomposition import PCA
-		from sklearn.preprocessing import StandardScaler
+		from process_improve.multivariate import PCA, MCUVScaler
 
 		cheese = pd.read_csv(
 		    "http://openmv.net/file/cheddar-cheese.csv")
 		cheese.describe()
 
 		# PCA model with only 2 components
-		X_scaled = StandardScaler().fit_transform(
+		X_scaled = MCUVScaler().fit_transform(
 		    cheese.iloc[:, 1:4])
 		model_pca = PCA(n_components=2).fit(X_scaled)
-		scores_T = model_pca.transform(X_scaled)
+		scores_T = model_pca.scores_.to_numpy()
 
 		# PCR model using only PC 1
 		y = cheese["Taste"]


### PR DESCRIPTION
## Summary

The book is the companion to the `process-improve` Python library, but its
Python snippets in the latent-variable chapter were calling `sklearn.decomposition.PCA`
+ `sklearn.preprocessing.StandardScaler` instead. This PR switches those
snippets to `process_improve.multivariate.PCA` + `MCUVScaler`.

Two files touched:

- `latent-variable-modelling/principal-component-analysis/pca-example-analysis-of-spectral-data.rst`
  - First block: replace sklearn PCA / StandardScaler with `process_improve` PCA / MCUVScaler.
    Print `r2_per_component_` and `r2_cumulative_` directly instead of
    sklearn's `explained_variance_` / `explained_variance_ratio_`.
  - Second block (R^2 per wavelength + SPE per tablet): use the model's
    `r2_per_variable_` and `spe_` attributes directly instead of
    reconstructing `Xhat`, computing residuals, and recomputing R^2 / SPE
    by hand. Net 30+ lines removed.

- `latent-variable-modelling/projection-to-latent-structures/pls-exercises.rst`
  - Cheddar cheese PCA block: same swap; use `loadings_` / `scores_` /
    `r2_cumulative_`.
  - PCR block (PCA scores fed into `statsmodels.OLS`): use `process_improve`
    PCA for the projection step; statsmodels remains for the OLS fit.

## What was deliberately NOT changed

Per the brief: don't sacrifice pedagogy. R blocks, `scipy.stats` calls
(`norm.pdf` / `norm.cdf` / `norm.ppf`, `t.pdf` / `t.cdf` / `t.ppf`), the
hand-derived Shewhart / EWMA / Cpk code, the OLS / `statsmodels` snippets,
the manual factorial design construction in `saturated-designs-for-screening.rst`,
and similar didactic blocks all stay as-is. They each *teach the math*; replacing
them with a library call would short-circuit the lesson.

## Test plan

- [x] `make text` builds (existing image / R-include warnings only; no new warnings)
- [x] Smoke-tested the rewritten Python snippets locally against synthetic data:
      `r2_per_component_`, `r2_cumulative_`, `r2_per_variable_`, and `spe_`
      all give the values the original hand-computed code produced.
- [ ] Reviewer to spot-check the rendered HTML for the two pages.

https://claude.ai/code/session_01SoaUWMCRPJt69YhWsCpcUE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoaUWMCRPJt69YhWsCpcUE)_