### PR TITLE
Cache-bust the sidebar PDF link with the git SHA

### DIFF
--- a/_templates/pid-sidebar-extra.html
+++ b/_templates/pid-sidebar-extra.html
@@ -1,7 +1,7 @@
 <div class="pid-sidebar-extra">
   <hr/>
   <p>
-    <a href="{{ pathto('', 1) }}PID.pdf">
+    <a href="{{ pathto('', 1) }}PID.pdf?{{ release }}">
       <img style="width:28px; vertical-align:middle; margin-right:6px"
            src="{{ pathto('_static/media/512px-Document-pdf.svg.png', 1) }}"
            alt="PDF icon" />Download PDF of entire book


### PR DESCRIPTION
## Summary

Site visitors at learnche.org/pid kept getting the stale PDF because
`_templates/pid-sidebar-extra.html` linked to a bare `PID.pdf`. Browsers
and the CDN happily kept serving the cached copy across rebuilds.

The `?2026-05-01` query string in `README.md` only helps clicks that
originate from GitHub; it never reaches the rendered book pages.

This PR appends `?{{ release }}` to the sidebar's PDF link.
`release` is already exposed in `conf.py` as the short git SHA, so each
push produces a fresh URL and the next visit fetches the rebuilt PDF.

## Verification

Built `_build/html/contents` locally and confirmed the rendered link is
now `<a href="./PID.pdf?b7f5e1">` (or whatever the latest short SHA is).

- [x] `make html` succeeds, link contains the SHA cache-buster.
- [x] `make latex` succeeds (the change is HTML-only; this sandbox has
      no `pdflatex` so the full `make latexpdf` was not run; the
      template touched is not part of the LaTeX backend).

https://claude.ai/code/session_01SoaUWMCRPJt69YhWsCpcUE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoaUWMCRPJt69YhWsCpcUE)_