### PR TITLE
Add 'For instructors' section to README

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,6 +21,6 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-date-released: 2026-05-01
+date-released: 2026-05-02
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,44 @@ introductory-graduate courses, and for self-study by practitioners.
 
 The full table of contents lives in [`contents.rst`](contents.rst).
 
+## For instructors
+
+You're welcome to use this book — and the course materials below — for your
+own teaching. Everything is licensed under
+[CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/), so you can
+share, adapt, and even commercialize derivative work as long as you attribute
+the original and license the result under the same terms. No permission
+needed.
+
+The book has been adopted at other universities (undergraduate and graduate)
+and used inside companies as an internal training manual.
+
+Course materials live on the original
+[Learning Chemical Engineering: Courses](https://learnche.org/4C3/Main_Page)
+site:
+
+- [Suggested course structure](https://learnche.org/4C3/Course_outlines)
+- [PDF slides](https://learnche.org/4C3/Main_Page) covering every section of
+  the book
+- [Assignments (with solutions)](https://learnche.org/4C3/Assignments_from_prior_years)
+- [Midterms / tests](https://learnche.org/4C3/Midterms_from_prior_years)
+- [Final exams](https://learnche.org/4C3/Final_exams_from_prior_years)
+- Projects for
+  [response surface optimization](https://learnche.org/4C3/Response_surface_project_from_prior_years)
+  and
+  [design of experiments](https://learnche.org/4C3/Designed_experiments_projects_from_prior_years)
+- A [tutorial to learn R](https://learnche.org/4C3/Software_tutorial)
+- [Video recordings](https://learnche.org/4C3/Course_videos_and_audio_from_previous_years)
+  of the course on YouTube
+- [Sample datasets](https://openmv.net/) for assignments, tests, and practice
+
+**Teaching at a company?** Get in touch via the
+[contact page](https://learnche.org/4C3/Statistics_for_Engineering:About) for
+additional slides, worksheets, and tips.
+
+Questions, comments, or "how did you make that figure?" enquiries are all
+welcome through the same contact link.
+
 ## Compiling the book yourself
 
 ### Prerequisites


### PR DESCRIPTION
## Summary

- Adds a new `## For instructors` section to `README.md`, between "What the book covers" and "Compiling the book yourself", surfacing the same guidance the author publishes at <https://yint.org/instructors>.
- Lists the course materials hosted on the Learning Chemical Engineering: Courses site — suggested course structure, PDF slides, assignments, midterms, finals, RSM and DOE projects, R tutorial, course videos, and OpenMV sample datasets — with direct links.
- Bumps `CITATION.cff` `date-released` to today (`2026-05-02`) per `CLAUDE.md`'s rule for substantive PRs. The README attribution year range (`2010–2026`) is already current.

## Test plan

- [ ] Render `README.md` on GitHub and confirm the new section appears in the right place with all bullet links resolving.
- [ ] Spot-check a couple of links (e.g. `Course_outlines`, `openmv.net`, the CC BY-SA license).
- [ ] Confirm `CITATION.cff` parses (YAML); GitHub's "Cite this repository" picker should now show the bumped date.
- [ ] No build files touched, so `make html` / `make latexpdf` are not in scope.

https://claude.ai/code/session_01Fq8teUJCmezJcBQiwpTXBP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fq8teUJCmezJcBQiwpTXBP)_