### PR TITLE
Add last-commit badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Kevin Dunn. Actively written and updated since August 2010.
 [![License: CC BY-SA 4.0](https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-sa/4.0/)
 [![Read online](https://img.shields.io/badge/read-learnche.org%2Fpid-blue.svg)](https://learnche.org/pid)
 [![Download PDF](https://img.shields.io/badge/download-PDF-red.svg)](https://learnche.org/pid/PID.pdf?2026-05-02)
+[![Last commit](https://img.shields.io/github/last-commit/kgdunn/pid-book.svg)](https://github.com/kgdunn/pid-book/commits)
 [![Issues](https://img.shields.io/github/issues/kgdunn/pid-book.svg)](https://github.com/kgdunn/pid-book/issues)
 
 > **Just want to read it?** Go to **<https://learnche.org/pid>** (HTML) or

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Kevin Dunn. Actively written and updated since August 2010.
 [![License: CC BY-SA 4.0](https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-sa/4.0/)
 [![Read online](https://img.shields.io/badge/read-learnche.org%2Fpid-blue.svg)](https://learnche.org/pid)
 [![Download PDF](https://img.shields.io/badge/download-PDF-red.svg)](https://learnche.org/pid/PID.pdf?2026-05-02)
+[![Build status](https://img.shields.io/github/actions/workflow/status/kgdunn/pid-book/build-deploy.yml?branch=master&label=build)](https://github.com/kgdunn/pid-book/actions/workflows/build-deploy.yml)
+[![Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fkgdunn%2Fpid-book%2Fmaster%2Fpyproject.toml&query=%24.project.version&label=version&prefix=v&color=blue)](https://github.com/kgdunn/pid-book/blob/master/pyproject.toml)
 [![Last commit](https://img.shields.io/github/last-commit/kgdunn/pid-book.svg)](https://github.com/kgdunn/pid-book/commits)
 [![Issues](https://img.shields.io/github/issues/kgdunn/pid-book.svg)](https://github.com/kgdunn/pid-book/issues)
 


### PR DESCRIPTION
## Summary
- Adds a shields.io `github/last-commit` badge to the README's badge row so readers can see at a glance how recently the book has been touched.
- Auto-updates from GitHub; nothing to maintain by hand.

## Test plan
- [ ] Confirm the badge renders on the GitHub README preview and links to the commits page.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bj1qSPpPFs8vAuZsQSvrTw)_