### PR TITLE
Fix covariance value: temperature-humidity is 35.4 [K.%], not 202

### DIFF
--- a/least-squares-modelling/covariance-and-correlation.rst
+++ b/least-squares-modelling/covariance-and-correlation.rst
@@ -146,7 +146,7 @@ Use this to calculate the covariance between temperature and pressure by breakin
 
 	-	The expected value of this product can be estimated by using the average, or any other suitable measure of location. In this case ``mean(product)`` in R gives 6780. This is the covariance value.
 
-	-	More specifically, we should provide the units as well:  the covariance between temperature and pressure is 6780 [K.kPa] in this example. Similarly the covariance between temperature and humidity is 202 [K.%].
+	-	More specifically, we should provide the units as well:  the covariance between temperature and pressure is 6780 [K.kPa] in this example. Similarly the covariance between temperature and humidity is 35.4 [K.%].
 
 In your own time calculate a rough numeric value and give the units of covariance for these cases:
 


### PR DESCRIPTION
## Summary

A reader pointed out a numerical error in the Covariance section
(`least-squares-modelling/covariance-and-correlation.rst`), in the
gray box that begins "Use this to calculate the covariance...". The
last bullet currently reads:

> "...the covariance between temperature and pressure is 6780 [K.kPa]
> in this example. Similarly the covariance between temperature and
> humidity is **202 [K.%]**."

`202` is real, but it is actually the **pressure / humidity**
mean-of-products — it had been misattributed to temperature / humidity.

Verified using only Python's standard library on the data table
already shown in the section:

| pair | mean(product), N | cov, N-1 |
| --- | --- | --- |
| temperature, pressure | **6780** | 7533.33 |
| temperature, humidity | **35.4** | 39.33 |
| pressure, humidity    | **202**  | 224.44 |

The neighbouring `6780` value in the same sentence uses
N-normalization (it is the mean of products — see the bullet just
above, which calls that "the covariance value"; the N vs. N-1
discussion comes in the following paragraph). To stay consistent
with `6780`, this PR changes the temperature-humidity figure to
**35.4 [K.%]** at the same normalization.

Single-line change, no other content affected.

## Test plan

- [x] Recompute by hand and with Python — values above match the reader's report.
- [ ] Build the book locally (`make html`) and visually skim the rendered Covariance section to confirm no formatting regressions.

Credit: thanks to the reader who flagged this and double-checked it
both by spreadsheet and with NumPy.

https://claude.ai/code/session_01MxVuizfJP1whrhQEBTC8mn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxVuizfJP1whrhQEBTC8mn)_