### PR TITLE
Add Python (Pandas + scikit-learn) examples to least-squares chapter

### DIFF
--- a/least-squares-modelling/covariance-and-correlation.rst
+++ b/least-squares-modelling/covariance-and-correlation.rst
@@ -245,8 +245,95 @@ Note that correlation is the same whether we measure temperature in Celsius or K
 	:align: center
 	:scale: 65
 	:alt: fake width
-	
-	
+
+
+.. _LS_correlation_matrix_in_python:
+
+Visualizing the correlation matrix
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When working with a real data set that has many variables, looking at correlations one pair at a
+time is tedious. Pandas can compute every pairwise correlation in one call with ``.corr()``, and we
+can visualize the resulting matrix as a *heat map* to spot patterns at a glance.
+
+The example below uses a `flotation cell <https://openmv.net/info/flotation-cell>`_ data set:
+
+.. code-block:: python
+
+	import pandas as pd
+
+	flot = pd.read_csv("https://openmv.net/file/flotation-cell.csv")
+
+	# A square matrix of correlation values, one
+	# per pair of numeric columns:
+	flot.corr()
+
+For a wider data set, the numeric matrix becomes hard to read; a heat map encodes the same
+information visually. Here we use a `distillation column
+<https://openmv.net/info/distillation-tower>`_ data set, where the goal is to predict
+``VapourPressure`` from process measurements:
+
+.. code-block:: python
+
+	import pandas as pd
+	import seaborn as sns
+
+	distill = pd.read_csv(
+	    "https://openmv.net/file/distillation-tower.csv"
+	)
+
+	# Print the correlation matrix as numbers:
+	display(distill.corr())
+
+	# A diverging palette is helpful: red for
+	# positive, blue for negative correlations,
+	# white for near-zero.
+	cmap = sns.diverging_palette(220, 10, as_cmap=True)
+	sns.set(rc={"figure.figsize": (15, 15)})
+	sns.heatmap(
+	    distill.corr(),
+	    cmap=cmap,
+	    square=True,
+	    linewidths=0.2,
+	    cbar_kws={"shrink": 0.5},
+	)
+
+A complementary view is the *scatter plot matrix*, which shows the actual data behind each
+correlation. The diagonal panels are replaced by a kernel density estimate (kde) of each variable's
+distribution:
+
+.. code-block:: python
+
+	from pandas.plotting import scatter_matrix
+
+	scatter_matrix(
+	    distill,
+	    alpha=0.2,
+	    figsize=(15, 15),
+	    diagonal="kde",
+	)
+
+	# For large data sets, sub-sample to speed
+	# up the plot, e.g. every second row:
+	scatter_matrix(
+	    distill.iloc[0::2, :],
+	    alpha=0.2,
+	    figsize=(15, 15),
+	    diagonal="kde",
+	)
+
+When the goal is to model a particular outcome variable (here ``VapourPressure``), the most useful
+slice of the correlation matrix is its last row: it ranks every potential predictor by how strongly
+it correlates with the outcome.
+
+.. code-block:: python
+
+	# The last row of the correlation matrix shows
+	# how each x-variable correlates with the
+	# outcome variable VapourPressure.
+	distill.corr().iloc[-1, :]
+
+
 .. TODO See article by Brillinger: John Tukey and the correlation coefficient (included as a PDF in the repo)
 
 Some definitions

--- a/least-squares-modelling/investigating-an-existing-linear-model.rst
+++ b/least-squares-modelling/investigating-an-existing-linear-model.rst
@@ -17,6 +17,50 @@ Along the way, while investigating these assumptions, we will introduce some new
 
 It is a common theme in any modelling work that the most informative plots are those of the residuals - the unmodelled component of our data.  We expect to see no structure in the residuals, and since the human eye is excellent at spotting patterns in plots, it is no surprise that various types of :index:`residual plots` are used to diagnose problems with our model.
 
+.. _LS_test_set_predictions_with_sklearn:
+
+Testing the model on unseen data
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The residual statistics on the building data give one view of the model. A more honest assessment
+is the residuals on data that the model has **never seen**. Continuing the distillation example
+from the :ref:`prior chapter <LS_residuals_and_R2_with_sklearn>`, where we held out the rows from
+index 150 onward as the testing partition, we can call ``.predict(...)`` again, but on the test
+set:
+
+.. code-block:: python
+
+	# The held-out partition of the data set:
+	X_test = test[["InvTemp3"]].values
+	y_test = test["VapourPressure"].values
+
+	prediction_test = mymodel.predict(X_test)
+	errors_test = y_test - prediction_test
+
+	avg_absolute_error_test = (
+	    pd.Series(errors_test).abs().mean()
+	)
+	std_error_test = errors_test.std()
+
+	print(
+	    f"Testing-data: average absolute error = "
+	    f"{avg_absolute_error_test:.3f}, "
+	    f"std. dev. = {std_error_test:.3f}"
+	)
+
+	# Inspect the residuals in time order; any
+	# drift or pattern is a sign that the model
+	# does not generalize.
+	pd.Series(errors_test).plot(
+	    grid=True,
+	    title="Testing-data residuals (Actual - Predicted)",
+	)
+
+If the testing-data error is much larger than the building-data error, or if the residual time
+series shows an obvious drift, then the model has not generalized: there is structure in the data
+that is not captured by ``InvTemp3`` alone. The remedy is to add more explanatory variables, which
+is the topic of the :ref:`section on multiple linear regression <LS_multiple_X_MLR>`.
+
 The assumption of normally distributed errors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/least-squares-modelling/least-squares-exercises.rst
+++ b/least-squares-modelling/least-squares-exercises.rst
@@ -31,6 +31,30 @@ Exercises
 		y.mc <- y - mean(y)
 		summary(lm(y.mc ~ x.mc))
 
+	The same comparison in Python, using ``statsmodels``, would be:
+
+	.. code-block:: python
+
+		import pandas as pd
+		import statsmodels.api as sm
+
+		distill = pd.read_csv(
+		    "https://openmv.net/file/distillation-tower.csv"
+		)
+		x = distill["TempC2"].values
+		y = distill["VapourPressure"].values
+
+		# Model 1: y ~ x
+		print(sm.OLS(y, sm.add_constant(x)).fit().summary())
+
+		# Model 2: y ~ (x - mean(x))
+		x_mc = x - x.mean()
+		print(sm.OLS(y, sm.add_constant(x_mc)).fit().summary())
+
+		# Model 3: (y - mean(y)) ~ (x - mean(x))
+		y_mc = y - y.mean()
+		print(sm.OLS(y_mc, sm.add_constant(x_mc)).fit().summary())
+
 .. admonition:: Question
 
 	For a :math:`x_{\text{new}}` value and the linear model :math:`y = b_0 + b_1 x` the prediction interval for :math:`\hat{y}_\text{new}` is:
@@ -843,6 +867,117 @@ Exercises
 
 	.. literalinclude:: ../figures/least-squares/cheddar-cheese.R
 		:language: s
+
+	A Pandas / scikit-learn version of the same workflow is given below for reference:
+
+	.. code-block:: python
+
+		import pandas as pd
+		from pandas.plotting import scatter_matrix
+		from sklearn.linear_model import LinearRegression
+
+		cheese = pd.read_csv(
+		    "https://openmv.net/file/cheddar-cheese.csv"
+		)
+
+		# Drop the case identifier; it is not a
+		# variable to model with.
+		cheese = cheese.drop(columns="Case")
+
+		# Correlation matrix and scatter plot matrix:
+		cheese.corr()
+		scatter_matrix(
+		    cheese,
+		    alpha=0.8,
+		    marker="s",
+		    figsize=(8, 8),
+		    diagonal="kde",
+		)
+
+		# Single-variable model: predict Taste from
+		# acetic acid concentration.
+		X = cheese[["Acetic"]].values
+		y = cheese["Taste"].values
+		single = LinearRegression().fit(X, y)
+		print(
+		    f"Intercept = {single.intercept_:.3f}, "
+		    f"slope = {single.coef_[0]:.3f}"
+		)
+
+		# Multiple linear regression with all three
+		# x-variables:
+		X_mlr = cheese[["Acetic", "H2S", "Lactic"]].values
+		mlr = LinearRegression().fit(X_mlr, y)
+		print(
+		    f"Intercept = {mlr.intercept_:.3f}, "
+		    f"coefficients = {mlr.coef_}"
+		)
+		print(f"R^2 = {mlr.score(X_mlr, y):.3f}")
+
+.. admonition:: Question
+
+	The `Kamyr digester data set <https://openmv.net/info/kamyr-digester>`_ comes from a pulp and
+	paper plant. Use it to practise the early steps of the data-analysis workflow before fitting
+	a least squares model.
+
+	#.	Read the data, drop any non-numeric identifier columns, and produce a histogram of every
+		variable. Find two variables with a clearly bimodal distribution, and two that are
+		roughly normally distributed.
+
+	#.	For each bimodal variable, plot it in time order. Does the bimodal histogram now make
+		sense?
+
+	#.	Find the three columns most strongly positively correlated, and the three most strongly
+		negatively correlated, with the outcome variable ``Y-Kappa``. Build a 7-column data frame
+		that combines those six predictors with ``Y-Kappa``, and produce a scatter plot matrix
+		for that subset only.
+
+	#.	If you needed to *increase* the Kappa number for this process, which variables would you
+		change, and in which direction?
+
+.. admonition:: Solution
+
+	Starter code for the exploration:
+
+	.. code-block:: python
+
+		import pandas as pd
+
+		digester = pd.read_csv(
+		    "https://openmv.net/file/kamyr-digester.csv"
+		)
+
+		# A histogram per numeric column.
+		# Adjust figsize and bins to taste:
+		digester.hist(figsize=(15, 12), bins=30,
+		              color="lightblue")
+
+		# Numeric correlation matrix.
+		# Sort by the column we care about,
+		# from most negative to most positive:
+		correlations = digester.corr()["Y-Kappa"]
+		correlations.sort_values()
+
+		# Pick the 3 strongest positive and 3
+		# strongest negative correlations, then
+		# build a 7-column subset:
+		positives = (
+		    correlations.drop("Y-Kappa")
+		    .sort_values(ascending=False)
+		    .head(3)
+		    .index.tolist()
+		)
+		negatives = (
+		    correlations.drop("Y-Kappa")
+		    .sort_values()
+		    .head(3)
+		    .index.tolist()
+		)
+		subset = digester[positives + negatives + ["Y-Kappa"]]
+
+		from pandas.plotting import scatter_matrix
+		scatter_matrix(subset, alpha=0.4,
+		               figsize=(12, 12), diagonal="kde")
 
 .. admonition:: Question
 

--- a/least-squares-modelling/least-squares-model-analysis.rst
+++ b/least-squares-modelling/least-squares-model-analysis.rst
@@ -732,4 +732,111 @@ As for the R code, we can see at a glance:
 	- The two probability values, ``P>|t|``, for |b0| and |b1| should be familiar to you; they are the probability with which we expect to find a value of :math:`z` greater than the calculated :math:`z`-value (called ``t value`` in the output above). The smaller the number, the more confident we can be the confidence interval contains the parameter estimate.
 	- You can construct the confidence interval for |b0| or |b1| by using their reported standard errors and multiplying by the corresponding :math:`t`-value. For example, if you want 99% confidence limits, then look up the 99% values for the :math:`t`-distribution using :math:`n-k` degrees of freedom, in this case it would be ``from scipy.stats import t; t.ppf(1-(1-0.99)/2, df=9)``, which is :math:`\pm 3.25`. So the 99% confidence limits for the slope coefficient would be :math:`[0.5 - 3.25 \times 0.1179; 0.5 + 3.25 \times 0.1179] = [0.117; 0.883]`. However, the table output gives you the 95% confidence interval. Under the column ``0.025`` and ``0.975`` (leaving 2.5% in the lower and upper tail respectively). For the slope coefficient, for example, this interval is [0.233; 0.767]. If you desire, for example, the 99% confidence interval, you can adjust the code: ``print(results.summary(alpha=1-0.99))``
 	- The :math:`R^2 = 0.6665` value.
-	- Be able to calculate the residuals: :math:`e_i = y_i - \hat{y}_i = y_i - b_0 - b_1 x_i`. 
+	- Be able to calculate the residuals: :math:`e_i = y_i - \hat{y}_i = y_i - b_0 - b_1 x_i`.
+
+
+.. _LS_visualizing_a_fit_with_seaborn:
+
+Visualizing the fit
+^^^^^^^^^^^^^^^^^^^
+
+Returning to the larger distillation example from the
+:ref:`prior section <LS_single_x_sklearn_distillation>`, the seaborn library has a useful function,
+``regplot``, that draws the scatter plot of the raw data, overlays the least squares line, and
+shades the confidence interval for the regression line in a single call.
+
+.. code-block:: python
+
+	import pandas as pd
+	import seaborn as sns
+
+	distill = pd.read_csv(
+	    "https://openmv.net/file/distillation-tower.csv"
+	)
+
+	ax = sns.regplot(
+	    x="InvTemp3",
+	    y="VapourPressure",
+	    data=distill,
+	)
+	ax.grid(True)
+
+A common upgrade is the ``jointplot``, which adds a histogram (or kernel density estimate) of each
+variable to the margins of the plot:
+
+.. code-block:: python
+
+	# Marginal histograms with the regression line:
+	sns.jointplot(
+	    x="InvTemp3",
+	    y="VapourPressure",
+	    data=distill,
+	    kind="reg",
+	)
+
+	# Or the kernel density estimate:
+	sns.jointplot(
+	    x="InvTemp3",
+	    y="VapourPressure",
+	    data=distill,
+	    kind="kde",
+	)
+
+
+.. _LS_residuals_and_R2_with_sklearn:
+
+Residuals, standard error and :math:`R^2` for the model
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once a scikit-learn ``LinearRegression`` object has been fitted, the residuals on the building
+data are obtained by subtracting the predictions from the observed values. Two simple summaries
+of the residuals are useful: their average absolute size, and their standard deviation. Both are
+"smaller is better", and the standard deviation is the model's standard error :math:`S_E`.
+
+We continue with the model fitted in the
+:ref:`prior section <LS_single_x_sklearn_distillation>`:
+
+.. code-block:: python
+
+	# Predictions and residuals on the building data:
+	X_build = build[["InvTemp3"]]
+	y_build = build["VapourPressure"].values
+
+	prediction_build = mymodel.predict(X_build)
+	errors_build = y_build - prediction_build
+
+	# Average absolute residual:
+	avg_absolute_error = (
+	    pd.Series(errors_build).abs().mean()
+	)
+
+	# Standard deviation of the residuals
+	# (equivalent to S_E, up to the n-k correction):
+	std_error = errors_build.std()
+
+	print(
+	    f"Average absolute error = "
+	    f"{avg_absolute_error:.3f}, "
+	    f"std. dev. of residuals = "
+	    f"{std_error:.3f}"
+	)
+
+	# Plot residuals in time order to look for
+	# trends or autocorrelation:
+	pd.Series(errors_build).plot(
+	    grid=True,
+	    title="Building-data residuals (Actual - Predicted)",
+	)
+
+The :math:`R^2` value can be read off directly from the model object, using its ``.score(...)``
+method:
+
+.. code-block:: python
+
+	# R-squared on the building data:
+	mymodel.score(X_build, y_build)
+
+As emphasized earlier in this section, a high :math:`R^2` value is **not** a measure of
+prediction accuracy: it only tells you how strongly :math:`x` and :math:`y` are correlated. The
+prediction quality on **new** data is a more honest test, and that is what we turn to in the
+:ref:`next section <LS_test_set_predictions_with_sklearn>`.

--- a/least-squares-modelling/least-squares-models-with-a-single-x-variable.rst
+++ b/least-squares-modelling/least-squares-models-with-a-single-x-variable.rst
@@ -294,6 +294,65 @@ To calculate the least squares model:
 *	When :math:`x_i = 5`, then :math:`\hat{y}_i = 3.0 + 0.5 \times 5.5 = 5.75`
 
 
+.. _LS_single_x_sklearn_distillation:
+
+A larger example with scikit-learn: predicting vapour pressure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For larger data sets, the ``LinearRegression`` class from scikit-learn provides a convenient API
+that fits naturally with Pandas data frames. We will use it again on the `distillation tower
+<https://openmv.net/info/distillation-tower>`_ data set introduced in the
+:ref:`prior section <LS_correlation_matrix_in_python>`.
+
+Good statistical practice is to split the data: build the model on one part, then test it on
+unseen data. Otherwise we get an inflated sense of how well the model performs. The ``.iloc``
+accessor in Pandas selects rows by position, so we use it to split the 253 observations into a
+"build" partition (the first 150 rows) and a "test" partition (the remaining rows):
+
+.. code-block:: python
+
+	import pandas as pd
+
+	distill = pd.read_csv(
+	    "https://openmv.net/file/distillation-tower.csv"
+	)
+
+	# Use the first 150 rows to build the model,
+	# and the remaining rows to test it later.
+	build = distill.iloc[:150]
+	test = distill.iloc[150:]
+	build.shape, test.shape
+
+Now fit a single-variable least squares model that uses ``InvTemp3`` (the inverse of a temperature
+measurement on tray 3) to predict ``VapourPressure``. The double-bracket idiom
+``build[["InvTemp3"]]`` returns a column matrix (a 2-D :math:`n \times 1` array), which is the
+shape scikit-learn expects for the predictor matrix :math:`\mathbf{X}`:
+
+.. code-block:: python
+
+	from sklearn.linear_model import LinearRegression
+
+	# X must be a 2-D array (n_rows by n_cols).
+	# build[["InvTemp3"]] returns a column matrix;
+	# build["InvTemp3"] would return a 1-D array.
+	X = build[["InvTemp3"]].values
+	y = build["VapourPressure"].values
+
+	mymodel = LinearRegression()
+	mymodel.fit(X, y)
+
+	# .intercept_ is a scalar; .coef_ is an array,
+	# so we index it with [0] to print the slope.
+	print(
+	    f"Intercept = {mymodel.intercept_:.5g}, "
+	    f"slope = {mymodel.coef_[0]:.5g}"
+	)
+
+We will return to this model in the :ref:`next section <standard-error-section>` to inspect its
+residuals, its standard error, and its :math:`R^2` value, and again in the section on
+:ref:`multiple linear regression <LS_multiple_X_MLR>` to extend it with a second predictor.
+
+
 
 ..	Estimating the parameters when the data are centered
 	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/least-squares-modelling/multiple-linear-regression.rst
+++ b/least-squares-modelling/multiple-linear-regression.rst
@@ -184,6 +184,82 @@ This is a good point to introduce some terminology you might come across.  Imagi
 
 In the prior example, we could say: the effect of substrate concentration on yield, :index:`controlling <single: controlling for another variable>` for temperature, is to increase the yield by 3.2 :math:`\mu\text{g}` for every increase in 1 g/L of substrate concentration.
 
+
+.. _LS_MLR_with_sklearn:
+
+Fitting an MLR model with scikit-learn
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In the :ref:`single-x section <LS_single_x_sklearn_distillation>` we built a model on the
+distillation tower data using only ``InvTemp3`` as a predictor of ``VapourPressure``. We now
+extend that model by adding a second predictor, ``InvPressure1`` (the inverse of a pressure
+measurement). The scikit-learn API requires almost no change: we simply pass a list of column
+names instead of a single one.
+
+.. code-block:: python
+
+	import pandas as pd
+	from sklearn.linear_model import LinearRegression
+
+	distill = pd.read_csv(
+	    "https://openmv.net/file/distillation-tower.csv"
+	)
+	build = distill.iloc[:150]
+	test = distill.iloc[150:]
+
+	# Specifying the predictors as a list lets us
+	# add or remove variables without touching
+	# the rest of the code:
+	predictors = ["InvTemp3", "InvPressure1"]
+
+	X_build_MLR = build[predictors].values
+	y_build = build["VapourPressure"].values
+
+	full_model = LinearRegression()
+	full_model.fit(X=X_build_MLR, y=y_build)
+
+	# Residuals on the building data:
+	predict_MLR_build = full_model.predict(X_build_MLR)
+	errors_MLR_build = y_build - predict_MLR_build
+	avg_absolute_error_MLR_build = (
+	    pd.Series(errors_MLR_build).abs().mean()
+	)
+	print(
+	    f"MLR building-data average absolute error "
+	    f"= {avg_absolute_error_MLR_build:.3f}"
+	)
+
+	pd.Series(errors_MLR_build).plot(
+	    grid=True,
+	    title="MLR residuals (Actual - Predicted)",
+	)
+
+The same model is then assessed on the held-out test partition. Compare the average absolute
+error and standard deviation against the values reported in the
+:ref:`single-predictor case <LS_test_set_predictions_with_sklearn>`: a useful additional predictor
+should reduce both numbers, *and* leave the residual time series free of obvious drift or
+structure.
+
+.. code-block:: python
+
+	X_test_MLR = test[predictors].values
+	y_test = test["VapourPressure"].values
+
+	predict_MLR_test = full_model.predict(X_test_MLR)
+	errors_MLR_test = y_test - predict_MLR_test
+
+	avg_absolute_error_MLR_test = (
+	    pd.Series(errors_MLR_test).abs().mean()
+	)
+	std_error_MLR_test = errors_MLR_test.std()
+
+	print(
+	    f"MLR testing-data average absolute error "
+	    f"= {avg_absolute_error_MLR_test:.3f}, "
+	    f"std. dev. = {std_error_MLR_test:.3f}"
+	)
+
+
 Integer (dummy, indicator) variables in the model
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/least-squares-modelling/summary-of-steps-to-build-and-investigate-a-linear-model.rst
+++ b/least-squares-modelling/summary-of-steps-to-build-and-investigate-a-linear-model.rst
@@ -71,6 +71,98 @@ Summary of steps to build and investigate a linear model
 		lines(lowess(y, predict(model), f=0.5))     # a smoother
 		abline(a=0, b=1, col="red")                 # a 45 degree line
 
+
+.. _LS_workflow_blender_python:
+
+A worked example of the workflow in Python
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The steps above describe a general workflow that applies to any data analysis project, not just
+least squares. We illustrate the early steps of that workflow on the
+`blender efficiency <https://openmv.net/info/blender-efficiency>`_ data set, which records the
+result of designed experiments where four factors were varied to study blending efficiency:
+``ParticleSize``, ``MixerDiameter``, ``MixerRotation``, and ``BlendingTime``.
+
+The six-step workflow on these data:
+
+#.	**Define the objective**: understand which factors drive ``BlendingEfficiency``.
+
+#.	**Get the data**:
+
+	.. code-block:: python
+
+		import pandas as pd
+
+		blender = pd.read_csv(
+		    "https://openmv.net/file/blender-efficiency.csv"
+		)
+
+#.	**Explore**: look at a few rows, the column types, and a numeric summary.
+
+	.. code-block:: python
+
+		blender.head()
+		blender.tail()
+		blender.describe()
+		blender.info()
+
+#.	**Clean**: in this case the data are pre-cleaned, so we move on.
+
+#.	**Calculate**: a correlation matrix and scatter-plot matrix highlight which factors are most
+	related to the outcome variable.
+
+	.. code-block:: python
+
+		from pandas.plotting import scatter_matrix
+
+		# Numeric correlation matrix:
+		blender.corr()
+
+		# Visual version: scatter plot of every
+		# pair of variables, with a kde on the
+		# diagonal.
+		scatter_matrix(
+		    blender,
+		    alpha=0.2,
+		    figsize=(10, 8),
+		    diagonal="kde",
+		)
+
+	Filtering and grouping are part of the daily work of anyone working with data, and Pandas
+	makes both very compact:
+
+	.. code-block:: python
+
+		# Boolean indexing returns only the rows
+		# where the condition is true:
+		blender[blender["ParticleSize"] == 2]
+		blender[blender["ParticleSize"] <= 5]
+		blender[blender["ParticleSize"] > 5]
+
+		# groupby applies the same calculation
+		# to each value of the grouping variable:
+		blender.groupby("ParticleSize").mean()
+		blender.groupby("ParticleSize").std()
+		blender.groupby("ParticleSize").max()
+
+#.	**Communicate**: create a separate plot per particle size, so each subgroup can be inspected
+	on its own axes:
+
+	.. code-block:: python
+
+		for psize, subset in blender.groupby("ParticleSize"):
+		    ax = subset.plot.scatter(
+		        x="BlendingTime",
+		        y="BlendingEfficiency",
+		    )
+		    ax.set_title(f"When particle size = {psize}")
+
+	Once the patterns are clear, you can fit a least squares model using
+	:ref:`scikit-learn <LS_single_x_sklearn_distillation>` or
+	:ref:`statsmodels <LS-class-example>` and continue with the residual diagnostics outlined in
+	the steps above.
+
+
 ..	R2 = corr(x,y) = cov(X,Y)/SD(X)/SD(Y): notice the symmetry, R2 is the same whether y~x or x~y
 
 .. Notes for this section


### PR DESCRIPTION
## Summary

- Lifts the worked code from `Module-14-interactive.ipynb` and `Module-15-interactive.ipynb` in `kgdunn/python-basic-notebooks` into chapter 4 as plain `.. code-block:: python` examples, matching the style of the `univariate-review/` chapter (no notebook directives, no `.ipynb` files committed).
- Adds Pandas + scikit-learn coverage where the chapter previously had only theory or only R: a complete distillation-tower walkthrough that threads through five files (single-x → diagnostics → test-set → MLR), and a Pandas version of the 6-step workflow on the blender-efficiency data.
- The `multiple-linear-regression.rst` file previously contained no Python at all; it now does.
- Adds Python starters next to existing R solutions for the distillation, cheddar-cheese, and Kamyr-digester exercises.

### Files changed

| File | What was added |
|------|----------------|
| `least-squares-modelling/covariance-and-correlation.rst` | `df.corr()`, seaborn heatmap, `scatter_matrix`, last row of the correlation matrix |
| `least-squares-modelling/least-squares-models-with-a-single-x-variable.rst` | `.iloc` train/test split, `LinearRegression().fit(...)` on the distillation data |
| `least-squares-modelling/least-squares-model-analysis.rst` | `sns.regplot`/`jointplot`, residual MAE/std + sequence plot, `.score()` for R² |
| `least-squares-modelling/investigating-an-existing-linear-model.rst` | `.predict(...)` on the held-out test set |
| `least-squares-modelling/multiple-linear-regression.rst` | MLR via predictor list, plus test-set validation |
| `least-squares-modelling/summary-of-steps-to-build-and-investigate-a-linear-model.rst` | 6-step workflow on `blender-efficiency.csv` |
| `least-squares-modelling/least-squares-exercises.rst` | Python starters for distillation, cheddar-cheese, and a new Kamyr-digester exploration |

### Cross-references

The new sections form a single thread that the reader can follow forward and back via `:ref:` labels:

- `LS_correlation_matrix_in_python` → `LS_single_x_sklearn_distillation` → `LS_visualizing_a_fit_with_seaborn` → `LS_residuals_and_R2_with_sklearn` → `LS_test_set_predictions_with_sklearn` → `LS_MLR_with_sklearn`
- `LS_workflow_blender_python` is referenced from the existing summary section.

## Test plan

- [x] `make text` builds successfully (314 warnings, all pre-existing — missing files from the externally-symlinked `figures/` repo, none touch the new content).
- [x] `grep "code-block:: python"` confirms 7 modified files now contain Python blocks under the intended headings.
- [x] Code snippets were copied verbatim from the source notebooks; spot-check by running one block per file in a Python REPL with `pandas`, `seaborn`, `scikit-learn` against the live `openmv.net` datasets.
- [ ] `make html` and `make latexpdf` (run by the maintainer; this PR makes content-only edits to existing `.rst` files and does not touch `Makefile`, `pyproject.toml`, `conf.py`, or any extension code).

https://claude.ai/code/session_01LMW6ujAoZMmB7yi9Sfqnwr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMW6ujAoZMmB7yi9Sfqnwr)_