### PR TITLE
Add a near-zero correlation case study to chapter 4

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,6 +21,6 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-date-released: 2026-05-02
+date-released: 2026-05-03
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"

--- a/least-squares-modelling/covariance-and-correlation.rst
+++ b/least-squares-modelling/covariance-and-correlation.rst
@@ -334,6 +334,48 @@ it correlates with the outcome.
 	distill.corr().iloc[-1, :]
 
 
+.. _LS_correlation_near_zero_example:
+
+What does a near-zero correlation look like?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The cylinder-pressure, distillation-tower and flotation-cell examples above all show *strong*
+correlations. It is just as important to develop intuition for what :math:`r \approx 0` looks like
+in real data. The `unlimited-time-test <https://openmv.net/info/unlimited-time-test>`_ data set is
+a useful counter-example: students were given as much time as they wanted to write an open-book
+exam, and we have two columns: ``Time`` taken to finish, and the ``Grade`` achieved.
+
+.. code-block:: python
+
+	import pandas as pd
+
+	grades = pd.read_csv(
+	    "https://openmv.net/file/unlimited-time-test.csv"
+	)
+	grades.plot.scatter(x="Time", y="Grade", figsize=(8, 6))
+
+	# Correlation of -0.044 -- essentially zero.
+	grades.corr()
+
+The scatter plot shows no visible pattern, and the correlation matrix confirms it: :math:`r =
+-0.044`. Two things are worth noting from this example:
+
+	-	The correlation is *symmetric*: :math:`r(\text{Time}, \text{Grade}) = r(\text{Grade},
+		\text{Time}) = -0.044`. There is no notion of an :math:`x`- or :math:`y`-variable yet.
+
+	-	The :math:`R^2` value commonly reported with a least-squares model is just :math:`r^2`. So
+		without fitting any model we already know that a straight line through these data would
+		have :math:`R^2 = (-0.044)^2 \approx 0.002`. Said differently: ``Time`` would explain
+		about 0.2% of the variation in ``Grade``. This is one reason :math:`R^2` on its own is a
+		poor way to judge a regression model.
+
+Compare this against the cheddar-cheese exercise (:math:`r` around 0.5 to 0.8 between flavour and
+the chemical predictors), and against the cylinder-pressure example above where :math:`r = 0.997`.
+Looking at the *scatter plots* alongside the *correlation values* for these three regimes ---
+near-zero, moderate, near-one --- is the fastest way to develop a calibrated visual sense of what
+a correlation coefficient really means.
+
+
 .. TODO See article by Brillinger: John Tukey and the correlation coefficient (included as a PDF in the repo)
 
 Some definitions


### PR DESCRIPTION
## Summary

Final pass over `kgdunn/python-basic-notebooks` to pull anything still pedagogically valuable into chapters 2 (univariate-review) and 4 (least-squares) before the notebooks are retired.

After scanning Modules 9, 10, 11–13, 14, 15 and 16, only **one** fragment was worth lifting: the *unlimited-time-test* scatter plot from Module 10. Chapter 4 already has plenty of strong-correlation case studies (cylinder pressure, distillation tower, flotation cell, cheddar cheese) but no concrete *near-zero* example. The new subsection in `least-squares-modelling/covariance-and-correlation.rst`:

- shows the `Time` vs `Grade` scatter from `https://openmv.net/file/unlimited-time-test.csv`
- reports `r = -0.044` and notes the correlation is symmetric in `x` and `y`
- uses `R² = r²` to give readers a no-fit way to see how little of `Grade` is explained by `Time` (≈ 0.2%), motivating why `R²` alone is a poor regression metric
- explicitly contrasts the three correlation regimes the reader has now seen: near-zero (this example), moderate (~0.5–0.8 in cheddar cheese), and near-one (0.997 in cylinder pressure)

## What was considered and not added

- **Random walks** (Module 9 normal-distribution simulation): the dice-CLT example already covers the same point in `normal-distribution-and-checking-for-normality.rst`.
- **"Judging the Judges" peas box-plot** and **plastic-film thickness box-plot** (Module 9): both fit Chapter 3 (data-visualization), not 2 or 4.
- **Bacteria logistic-growth ODE** (Module 10): too specific; doesn't reinforce univariate or LS concepts.
- **Cheddar-cheese correlation challenge** (Module 10): already an exercise in `least-squares-exercises.rst`.
- **Peas pairplot** (Module 10): the existing `scatter_matrix` block on the larger distillation dataset already covers the technique.
- **Module 14 flotation/blender groupby walkthrough** and **Module 15 distillation regression**: already merged via PR #64.
- **Module 16 data-cleaning recipes** (`skiprows`, `.query`, `dropna` thresholds): general Pandas tutorial, not central to LS or univariate stats.

Citation date bumped per `CLAUDE.md`. README year range already 2010–2026.

## Test plan

- [x] `make text` succeeds with no new warnings (the few image-not-readable warnings are pre-existing, due to the symlinked `figures/` repo)
- [ ] HTML rendering of the new subsection looks reasonable on `learnche.org/pid` after deploy

https://claude.ai/code/session_01KWEqUZMZmaNdxbMt8oiAfu

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWEqUZMZmaNdxbMt8oiAfu)_