### PR TITLE
Fix dark-mode invisibility of search box text (#66)

### DIFF
--- a/_static/css/theme-extended-kgd.css
+++ b/_static/css/theme-extended-kgd.css
@@ -48,10 +48,17 @@ h1 .headerlink {
 	padding-left: 25px;
 }
 
-/* Pagefind UI: scale to fit the sidebar; inherit sphinx-book-theme's primary colour */
+/* Pagefind UI: scale to fit the sidebar; inherit sphinx-book-theme's
+   primary colour, and bind text/background/border to the theme's
+   --pst-* variables so the search input stays legible in dark mode
+   (issue #66). */
 #pagefind-search {
     --pagefind-ui-scale: 0.85;
     --pagefind-ui-primary: var(--pst-color-primary, #0071bc);
+    --pagefind-ui-text: var(--pst-color-text-base, #393939);
+    --pagefind-ui-background: var(--pst-color-background, #ffffff);
+    --pagefind-ui-border: var(--pst-color-border, #eeeeee);
+    --pagefind-ui-tag: var(--pst-color-on-surface, #f5f5f5);
     --pagefind-ui-border-radius: 4px;
 }
 


### PR DESCRIPTION
Fixes #66.

## Summary

In dark mode the sidebar search box accepted input but the typed text was invisible.

## Root cause

The search box is rendered by Pagefind UI (instantiated in `_templates/pagefind-search.html`). Pagefind's input text colour comes from the CSS variable `--pagefind-ui-text`, which defaults to `#393939` — near-black. When sphinx-book-theme switches to dark mode it sets `html[data-theme="dark"]` and swaps the page background to dark, but `--pagefind-ui-text` was never overridden, so the input kept rendering near-black text on a near-black background.

The previous overrides in `_static/css/theme-extended-kgd.css` only set `--pagefind-ui-scale`, `--pagefind-ui-primary`, and `--pagefind-ui-border-radius`; nothing tied the text/background/border colours to the active theme.

## Fix

Bind the Pagefind UI colour variables to the `--pst-*` colour variables that pydata-sphinx-theme (which sphinx-book-theme builds on) already redefines per theme:

```css
#pagefind-search {
    --pagefind-ui-scale: 0.85;
    --pagefind-ui-primary: var(--pst-color-primary, #0071bc);
    --pagefind-ui-text: var(--pst-color-text-base, #393939);
    --pagefind-ui-background: var(--pst-color-background, #ffffff);
    --pagefind-ui-border: var(--pst-color-border, #eeeeee);
    --pagefind-ui-tag: var(--pst-color-on-surface, #f5f5f5);
    --pagefind-ui-border-radius: 4px;
}
```

Because CSS variables resolve at use time, the search input now adapts live to light / dark / auto theme switches with no JS.

Each `var(...)` call retains the existing Pagefind default as a fallback so behaviour is identical if a `--pst-*` variable is ever unavailable.

## Scope

- Only `_static/css/theme-extended-kgd.css` is changed.
- No change to search behaviour, the Pagefind index, or `_templates/pagefind-search.html`.
- LaTeX output is unaffected — `_static/css/*` is consumed only by the HTML builder.

## Verification

- `make html` — succeeds, no new warnings; `_build/html/contents` exists (extensionless URL convention preserved).
- `make text` — succeeds; the only warnings are pre-existing image-not-readable / include-not-found warnings caused by the `figures/` repo (a separate symlinked repo per `CLAUDE.md`) being unavailable in the build environment. The CSS change introduces zero new warnings.
- `make latexpdf` — not run locally (no `latexmk` available in this build environment); LaTeX does not consume CSS so this fix cannot affect the PDF build. Worth a sanity-check run on a workstation with TeX Live before release.

## Test plan

- [ ] Open the rendered site, click the theme switcher → **dark**, focus the sidebar search box, type — text is visible (light text on dark background).
- [ ] Switch back to **light** — text is visible (dark text on light background).
- [ ] Switch to **auto** with the OS in dark mode — text is visible.
- [ ] Match-highlight (`mark` styling) is unchanged.

https://claude.ai/code/session_01UtmoWzskcnzj1hkShm5x1j

---
_Generated by [Claude Code](https://claude.ai/code/session_01UtmoWzskcnzj1hkShm5x1j)_