### PR TITLE
Add privacy-first telemetry + per-page sparklines

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -60,7 +60,22 @@ jobs:
             texlive-xetex \
             latexmk
 
+      - name: Fetch ECharts (for sidebar sparklines)
+        # Pinned official Apache ECharts build, line/bar/pie subset.
+        # ~280 KB minified / ~80 KB gzip; served from same origin so no
+        # third-party requests at runtime. The file is .gitignored.
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p _static/js
+          curl -fsSL --retry 3 \
+            -o _static/js/echarts-min.js \
+            https://cdn.jsdelivr.net/npm/echarts@5.5.1/dist/echarts.simple.min.js
+          test -s _static/js/echarts-min.js
+
       - name: Build HTML
+        env:
+          PID_BOOK_TELEMETRY: ${{ github.event_name != 'pull_request' && '1' || '0' }}
+          PID_BOOK_GC_CODE: ${{ vars.GOATCOUNTER_CODE || 'learnche-pid' }}
         run: uv run make html
 
       - name: Build PDF

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ __pycache__/
 **/.ipynb_checkpoints/**
 .venv/
 
+# ECharts bundle for sidebar sparklines, fetched at build time by CI.
+_static/js/echarts-min.js
+
 
 
 design-analysis-experiments/Readings/

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,6 +21,6 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-date-released: 2026-05-09
+date-released: 2026-05-10
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"

--- a/_static/js/telemetry.js
+++ b/_static/js/telemetry.js
@@ -1,0 +1,219 @@
+/*
+ * pid-book telemetry: privacy-first, cookieless, opt-out-friendly.
+ *
+ * Loaded only when conf.py sees PID_BOOK_TELEMETRY=1 (production deploys
+ * from GitHub Actions). Honours Do-Not-Track. Skips localhost / file://
+ * so that CC BY-SA reusers self-hosting the source never phone home.
+ *
+ * Three responsibilities:
+ *   1. Pageview pixel via GoatCounter (loaded async).
+ *   2. Search-query event capture from BOTH Sphinx and Pagefind boxes.
+ *   3. 90-day pageview sparkline in the sidebar (ECharts, lazy-loaded).
+ *
+ * The ECharts asset (`_static/js/echarts-min.js`) is fetched at build time
+ * by .github/workflows/build-deploy.yml; it is NOT in git. If absent the
+ * sparkline is silently skipped — pageview/search tracking still works.
+ *
+ * What is collected and what is not is described at /pid/privacy.
+ */
+(function () {
+  // 0. Bail-outs (run before any network)
+  if (
+    navigator.doNotTrack === "1" ||
+    window.doNotTrack === "1" ||
+    navigator.msDoNotTrack === "1"
+  )
+    return;
+
+  var host = location.hostname;
+  if (
+    location.protocol === "file:" ||
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host === "" ||
+    /\.local$/.test(host)
+  )
+    return;
+
+  var cfg = window.__PID_TELEMETRY || {};
+  if (!cfg.gc) return;
+
+  // 1. Path normalisation: extensionless URLs, fold trailing slash and /index.
+  function normPath() {
+    var p = location.pathname.replace(/\/+$/, "") || "/";
+    p = p.replace(/\.html?$/i, "").replace(/\/index$/, "");
+    return p + location.search;
+  }
+
+  // 2. GoatCounter pixel.
+  window.goatcounter = { no_onload: true, path: normPath };
+  var gcScript = document.createElement("script");
+  gcScript.async = true;
+  gcScript.setAttribute(
+    "data-goatcounter",
+    "https://" + cfg.gc + ".goatcounter.com/count"
+  );
+  gcScript.src = "//gc.zgo.at/count.js";
+  gcScript.onload = function () {
+    try {
+      window.goatcounter.count();
+    } catch (e) {
+      /* ignore */
+    }
+  };
+  document.head.appendChild(gcScript);
+
+  // 3. Search instrumentation. Debounced; never sends PII or empties.
+  var DEBOUNCE_MS = 800;
+  var lastSent = "";
+  function sendQuery(q) {
+    q = (q || "").trim();
+    if (!q || q === lastSent || q.length > 80) return;
+    if (/[\w.+-]+@[\w-]+\.[\w.-]+/.test(q)) return; // crude email guard
+    lastSent = q;
+    try {
+      window.goatcounter.count({
+        path: "/search?q=" + encodeURIComponent(q),
+        event: true,
+      });
+    } catch (e) {
+      /* ignore */
+    }
+  }
+  function debounce(fn) {
+    var t;
+    return function (e) {
+      clearTimeout(t);
+      var v = e.target.value;
+      t = setTimeout(function () {
+        fn(v);
+      }, DEBOUNCE_MS);
+    };
+  }
+
+  function hookSphinxSearch() {
+    var el = document.querySelector('input[name="q"]');
+    if (el && !el.__pidHooked) {
+      el.__pidHooked = true;
+      el.addEventListener("input", debounce(sendQuery));
+    }
+  }
+  function hookPagefindSearch() {
+    var el = document.querySelector(".pagefind-ui__search-input");
+    if (el && !el.__pidHooked) {
+      el.__pidHooked = true;
+      el.addEventListener("input", debounce(sendQuery));
+      return true;
+    }
+    return false;
+  }
+
+  // 4. Sparkline. Lazy-loads ECharts only if the mount point exists.
+  function renderSparkline() {
+    var mount = document.getElementById("pid-sparkline");
+    if (!mount) return;
+    var pageKey = mount.getAttribute("data-page") || "";
+    if (!pageKey) {
+      // Fallback: derive from the URL when the template didn't supply one.
+      pageKey = location.pathname
+        .replace(/^\/pid\//, "")
+        .replace(/\/+$/, "")
+        .replace(/\.html?$/i, "");
+      if (!pageKey) pageKey = "contents";
+    }
+
+    fetch("/_stats/sparklines.json", { cache: "force-cache" })
+      .then(function (r) {
+        if (!r.ok) throw new Error("sparklines.json " + r.status);
+        return r.json();
+      })
+      .then(function (data) {
+        var series = data && data[pageKey];
+        if (!series || !series.length) {
+          // No history yet (e.g. a freshly added page). Hide silently.
+          var heading = mount.previousElementSibling;
+          if (heading && heading.tagName === "P") heading.style.display = "none";
+          mount.style.display = "none";
+          return;
+        }
+        loadECharts(function (echarts) {
+          if (!echarts) return;
+          var dates = series.map(function (p) {
+            return p[0];
+          });
+          var values = series.map(function (p) {
+            return p[1];
+          });
+          var chart;
+          try {
+            chart = echarts.init(mount, null, { renderer: "svg" });
+          } catch (e) {
+            return;
+          }
+          chart.setOption({
+            grid: { left: 0, right: 0, top: 2, bottom: 0 },
+            xAxis: { type: "category", show: false, data: dates },
+            yAxis: { type: "value", show: false },
+            tooltip: {
+              trigger: "axis",
+              formatter: function (params) {
+                var p = params[0];
+                return p.name + "<br/>" + p.value + " views";
+              },
+            },
+            series: [
+              {
+                type: "line",
+                data: values,
+                showSymbol: false,
+                smooth: true,
+                lineStyle: { width: 1.5 },
+                areaStyle: { opacity: 0.15 },
+              },
+            ],
+          });
+          window.addEventListener("resize", function () {
+            chart.resize();
+          });
+        });
+      })
+      .catch(function () {
+        /* network/JSON error: leave the empty mount; do not break the page */
+      });
+  }
+
+  function loadECharts(cb) {
+    if (window.echarts) return cb(window.echarts);
+    var s = document.createElement("script");
+    s.src = "/pid/_static/js/echarts-min.js";
+    s.async = true;
+    s.onload = function () {
+      cb(window.echarts);
+    };
+    s.onerror = function () {
+      cb(null);
+    };
+    document.head.appendChild(s);
+  }
+
+  // 5. Boot once the DOM is ready.
+  function boot() {
+    hookSphinxSearch();
+    if (!hookPagefindSearch()) {
+      var mo = new MutationObserver(function () {
+        if (hookPagefindSearch()) mo.disconnect();
+      });
+      mo.observe(document.body, { childList: true, subtree: true });
+      // Safety: stop observing after 15 s no matter what.
+      setTimeout(function () {
+        mo.disconnect();
+      }, 15000);
+    }
+    renderSparkline();
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", boot);
+  } else {
+    boot();
+  }
+})();

--- a/_templates/pid-sidebar-extra.html
+++ b/_templates/pid-sidebar-extra.html
@@ -22,4 +22,14 @@
     <a href="https://docs.google.com/forms/d/1IpO-bvJwQwhK64eid4YXwJBvGxN5cfyYDv81G-YgWrM/viewform"
        target="_blank">Suggest improvements; provide feedback; point out spelling, grammar, or other errors</a>
   </p>
+  {% if pid_telemetry %}
+  <hr/>
+  <p style="color:#777; font-size:0.85em; margin:0.3em 0 0.1em">Page views (90 days)</p>
+  <div id="pid-sparkline" style="width:100%; height:38px"
+       data-page="{{ pagename }}"></div>
+  {% endif %}
+  <hr/>
+  <p style="color:#777; font-size:0.85em">
+    <a href="{{ pathto('privacy') }}">Privacy</a>
+  </p>
 </div>

--- a/conf.py
+++ b/conf.py
@@ -237,6 +237,39 @@ html_link_suffix = ""
 html_secnumber_suffix = r". "
 
 
+# -- Optional production-only telemetry ----------------------------------------
+# Off by default; enabled in CI for the master/deploy build via env vars.
+# See `_static/js/telemetry.js` and `privacy.rst` for what is collected.
+TELEMETRY_ENABLED = os.environ.get("PID_BOOK_TELEMETRY", "0") == "1"
+TELEMETRY_GC_CODE = os.environ.get("PID_BOOK_GC_CODE", "")
+
+if TELEMETRY_ENABLED:
+    # html_js_files is consumed only by the HTML builder, so LaTeX/text/epub
+    # builders are unaffected.
+    html_js_files = [("js/telemetry.js", {"defer": "defer"})]
+
+    # Surfaced to Jinja templates; gates the sparkline mount in
+    # `_templates/pid-sidebar-extra.html`.
+    html_context = {
+        "pid_telemetry": True,
+        "pid_gc_code": TELEMETRY_GC_CODE,
+    }
+
+    def _inject_telemetry_globals(app, pagename, templatename, context, doctree):
+        # Single inline <script> appended to the per-page metatags context.
+        # This is the theme-agnostic Sphinx pattern for HEAD injection and
+        # avoids needing a layout.html override.
+        gc = TELEMETRY_GC_CODE.replace('"', "")
+        snippet = (
+            f'<script>window.__PID_TELEMETRY={{gc:"{gc}"}};</script>'
+        )
+        context["metatags"] = context.get("metatags", "") + snippet
+
+    def setup(app):
+        app.connect("html-page-context", _inject_telemetry_globals)
+        return {"parallel_read_safe": True, "parallel_write_safe": True}
+
+
 # -- Options for link checking -------------------------------------------------
 
 # A list of regular expressions that match URIs that should not be checked when doing linkcheck.

--- a/contents.rst
+++ b/contents.rst
@@ -7,6 +7,7 @@ Process Improvement Using Data
    :hidden:
 
    preface/index
+   privacy
 
 
 .. toctree::

--- a/privacy.rst
+++ b/privacy.rst
@@ -1,0 +1,38 @@
+.. _privacy:
+
+Privacy
+=======
+
+This site collects the bare minimum needed to know which sections are read
+and which searches are useful — no more.
+
+What is collected
+-----------------
+
+* **Aggregate pageviews** via `GoatCounter <https://www.goatcounter.com>`_,
+  loaded as a small cookieless script on every HTML page. No cookies are set,
+  no IP address is stored, no third-party trackers are loaded, and no
+  cross-site identifiers exist.
+* **In-book search queries** — what you type into the sidebar search box —
+  are sent the same way. Queries are debounced, queries longer than 80
+  characters are dropped, and anything that looks like an email address is
+  dropped client-side before sending.
+* **Server access logs**, processed locally with
+  `GoAccess <https://goaccess.io>`_. IPs are anonymised and only daily
+  aggregates are kept; raw logs rotate within 30 days.
+
+The resulting aggregates — top pages, the 90-day per-page sparklines you see
+in the sidebar, search queries, and an overview report — are **public** at
+`learnche.org/_stats/ <https://learnche.org/_stats/>`_, in keeping with the
+open spirit of this CC BY-SA 4.0 book.
+
+Opt out
+-------
+
+The pixel honours your browser's *Do Not Track* setting: enable DNT and no
+event of any kind is sent. Self-hosted copies of this book do not phone
+home — the script short-circuits on ``localhost``, ``127.0.0.1``, and
+``file://`` URLs.
+
+Questions or concerns: please open an issue at
+https://github.com/kgdunn/pid-book/issues.


### PR DESCRIPTION
## Summary

The HTML book ships with **zero** analytics today, so there is no way to
tell which sections readers actually use, what they search for, or which
pages need attention. This PR adds three layered, privacy-first signals:

- **Cookieless GoatCounter pixel** — pageviews + in-book search-query
  events from both the Sphinx and Pagefind boxes. Debounced (800 ms),
  PII-stripped (emails dropped), no cookies, no IP storage, honours DNT.
- **Sidebar ECharts sparkline** per page (90 days), fed by a public
  `/_stats/sparklines.json` derived from server access logs — so it
  counts ad-blocked readers, which the JS pixel cannot.
- **`/pid/privacy`** page describing what is collected and how to opt
  out, with a permanent sidebar link. Public dashboard at
  `/_stats/` is acknowledged in the spirit of the open book.

The fourth signal lives **server-side** — GoAccess + a small
`build-sparklines.py` cron — and is not part of this PR. Step-by-step
operator notes were delivered alongside this PR (not in repo).

## Design

- **Off by default.** Telemetry is gated on `PID_BOOK_TELEMETRY=1`,
  which the workflow sets only for non-PR events (`push` to `master`,
  `workflow_dispatch`). Local builds, PR previews, CC BY-SA self-
  hosters, DNT users, and `localhost`/`file://` short-circuit before
  any network call.
- **Theme-agnostic injection.** Uses Sphinx's standard `html_js_files`
  and an `html-page-context` handler that appends a one-line
  `<script>window.__PID_TELEMETRY = {gc: "..."}</script>` to the
  `metatags` context. No `layout.html` override needed.
- **ECharts** is fetched at build time (pinned `5.5.1`, official
  `echarts.simple.min.js`, ~80 KB gzip), gitignored, served same-
  origin — no third-party CDN at runtime.
- **Sparkline data shape.** `/_stats/sparklines.json` is
  `{ "<sphinx-pagename>": [["YYYY-MM-DD", hits], ...], ... }`. Empty or
  missing entries cause the mount + heading to hide silently — no
  "0 hits" placeholder for new pages.
- **Defence in depth.** Even if the env-var gate were misconfigured,
  the existing `if: github.event_name != 'pull_request'` on the
  rsync step still keeps PR HTML off production.

## Files

- `conf.py` — telemetry env-var block, `html_context.pid_telemetry`,
  `html-page-context` handler, `setup(app)`.
- `_static/js/telemetry.js` (new) — pixel, search hooks, sparkline
  renderer.
- `_static/js/echarts-min.js` — gitignored; fetched in CI.
- `privacy.rst` (new) + hidden toctree entry in `contents.rst`.
- `_templates/pid-sidebar-extra.html` — sparkline mount (gated) +
  permanent Privacy link.
- `.github/workflows/build-deploy.yml` — Fetch ECharts step + env
  vars on the Build HTML step.
- `CITATION.cff` — `date-released: 2026-05-10` per repo policy.
- `.gitignore` — exclude `_static/js/echarts-min.js`.

## Test plan

- [x] `make html` (default): no `goatcounter`, no `pid-sparkline` in
      output
- [x] `PID_BOOK_TELEMETRY=1 PID_BOOK_GC_CODE=learnche-pid make html`:
      `<script src="_static/js/telemetry.js" defer>` and
      `__PID_TELEMETRY={gc:"learnche-pid"}` present on `contents` and
      a deep page (`data-visualization/box-plots`); `pid-sparkline`
      mount present
- [x] `make text` succeeds (no new warnings vs. baseline)
- [ ] CI build green; PR build does not include telemetry strings
- [ ] Post-merge: open `https://learnche.org/pid/contents` in a fresh
      private window, no extensions, no DNT — hit appears in
      GoatCounter within 30 s
- [ ] Type a search query in the sidebar — event
      `/search?q=<query>` arrives in GoatCounter
- [ ] Enable DNT and reload — zero new hits
- [ ] After server-side cron has produced `/_stats/sparklines.json` —
      sparkline renders on a page with history; mount is hidden on a
      page without history (e.g. `/pid/privacy`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VGw7f4BEC1Za4tBeLJ3jcG)_