### PR TITLE
Fix Chapter 1 Geladi reference: expand initials to full first names so RST '#.' list renders without extra indentation

### DIFF
--- a/data-visualization/data-visualization-in-context.rst
+++ b/data-visualization/data-visualization-in-context.rst
@@ -55,4 +55,4 @@ References and readings
 #. William Cleveland, *Visualizing Data*, 1st edition, Hobart Press, 1993.
 #. William Cleveland, *The Elements of Graphing Data*, 2nd edition, Hobart Press, 1994.
 #. Su, `It's Easy to Produce Chartjunk Using Microsoft Excel 2007 but Hard to Make Good Graphs <https://dx.doi.org/10.1016/j.csda.2008.03.007>`_, *Computational Statistics and Data Analysis*, **52** (10), 4594-4601, 2008.
-#. P. Geladi, M. Manley and T. Lestander, `Scatter plotting in multivariate data analysis <https://literature.learnche.org/item/86/scatter-plotting-in-multivariate-data-analysis>`_, *Journal of Chemometrics*, **17**, 503-511, 2003.
+#. Paul Geladi, Marena Manley and Torbjörn Lestander, `Scatter plotting in multivariate data analysis <https://literature.learnche.org/item/86/scatter-plotting-in-multivariate-data-analysis>`_, *Journal of Chemometrics*, **17**, 503-511, 2003.


### PR DESCRIPTION
## Summary

- Fixes the visibly mis-indented Chapter 1 reference #8 (Geladi, Manley and Lestander 2003 scatter-plotting paper) that was reported in screenshot review.
- Cause: the Chapter 1 references list uses RST `#.` auto-numbered list markers. When an item's content begins with `<Letter>. <Word>` (e.g. `P. Geladi`), docutils interprets the second period as a *nested-list* marker and indents the item more than its siblings. The other items in the same list use full first names (Edward Tufte, Stephen Few, William Cleveland), so they don't trip the parser.
- Fix: expand `P. Geladi, M. Manley and T. Lestander` to `Paul Geladi, Marena Manley and Torbjörn Lestander` — matches the chapter's existing convention and resolves the parsing ambiguity.
- The same abbreviated-initial pattern in other newly-added entries (Ch5 `T. Lundstedt`, `R. Carlson`, `N. Bratchell`; Ch6 `J. Edward Jackson`; the Ch7 placeholder pages) is unaffected because those lists use `-` or `*` bullet markers, not `#.`.

## Test plan

- [x] `make text` builds clean (no new warnings).
- [ ] Spot-check the rendered Chapter 1 references page — reference 8 should now align with references 1–7.

https://claude.ai/code/session_016yBh3JNfRPquVwBkLnTDqH

---
_Generated by [Claude Code](https://claude.ai/code/session_016yBh3JNfRPquVwBkLnTDqH)_