### PR TITLE
Expand leading initials to full first names in all newly-added reference entries

### DIFF
--- a/design-analysis-experiments/examples-of-how-designed-experiments-are-used.rst
+++ b/design-analysis-experiments/examples-of-how-designed-experiments-are-used.rst
@@ -42,9 +42,9 @@ References and readings
 -	Raymond H. Myers, Douglas C. Montgomery and Christine M. Anderson-Cook, `Response Surface Methodology: Process and Product Optimization Using Designed Experiments <https://www.amazon.com/Response-Surface-Methodology-Optimization-Experiments/dp/0470174463>`_, Wiley, 2009.
 -	William Hill and William Hunter, "`A Review of Response Surface Methodology: A Literature Survey <https://www.jstor.org/stable/1266632>`_", *Technometrics*, **8**, 571-590, 1966.
 -	Owen L. Davies, `The Design and Analysis of Industrial Experiments <https://www.amazon.com/The-design-analysis-industrial-experiments/dp/B0007J7BME>`_, Chapter 11, revised 2nd edition, Hafner, 1967.
--	T. Lundstedt, E. Seifert, L. Abramo, B. Thelin, Å. Nyström, J. Pettersen and R. Bergman, `Experimental design and optimization <https://literature.learnche.org/item/169/experimental-design-and-optimization>`_, *Chemometrics and Intelligent Laboratory Systems*, **42**, 3-40, 1998.
--	R. Carlson, T. Lundstedt and C. Albano, `Screening of suitable solvents in organic synthesis. Strategies for solvent selection <https://literature.learnche.org/item/168/screening-of-suitable-solvents-in-organic-synthesis-strategies-for-solvent-selection>`_, *Acta Chemica Scandinavica*, **B39**, 79-91, 1985.
--	N. Bratchell, `Multivariate response surface modelling by principal components analysis <https://literature.learnche.org/item/6/multivariate-response-surface-modelling-by-principal-components-analysis>`_, *Journal of Chemometrics*, **3**, 579-588, 1989.
+-	Torbjörn Lundstedt, Elisabeth Seifert, Lisbeth Abramo, Bernt Thelin, Åsa Nyström, Jarle Pettersen and Rolf Bergman, `Experimental design and optimization <https://literature.learnche.org/item/169/experimental-design-and-optimization>`_, *Chemometrics and Intelligent Laboratory Systems*, **42**, 3-40, 1998.
+-	Rolf Carlson, Torbjörn Lundstedt and Christer Albano, `Screening of suitable solvents in organic synthesis. Strategies for solvent selection <https://literature.learnche.org/item/168/screening-of-suitable-solvents-in-organic-synthesis-strategies-for-solvent-selection>`_, *Acta Chemica Scandinavica*, **B39**, 79-91, 1985.
+-	Nigel Bratchell, `Multivariate response surface modelling by principal components analysis <https://literature.learnche.org/item/6/multivariate-response-surface-modelling-by-principal-components-analysis>`_, *Journal of Chemometrics*, **3**, 579-588, 1989.
 
 
 .. OTHER REFERENCES

--- a/product-development-product-improvement/batch-process-monitoring.rst
+++ b/product-development-product-improvement/batch-process-monitoring.rst
@@ -20,53 +20,53 @@ References to incorporate
 Foundational multiway PCA / PLS for batches
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* P. Nomikos and J. F. MacGregor, "`Monitoring batch processes using multiway principal component analysis <https://literature.learnche.org/item/30/monitoring-batch-processes-using-multiway-principal-component-analysis>`_", *AIChE Journal*, **40**, 1361-1375, 1994.
+* Paul Nomikos and John F. MacGregor, "`Monitoring batch processes using multiway principal component analysis <https://literature.learnche.org/item/30/monitoring-batch-processes-using-multiway-principal-component-analysis>`_", *AIChE Journal*, **40**, 1361-1375, 1994.
 
-* P. Nomikos and J. F. MacGregor, "`Multi-way partial least squares in monitoring batch processes <https://literature.learnche.org/item/32/multi-way-partial-least-squares-in-monitoring-batch-processes>`_", *Chemometrics and Intelligent Laboratory Systems*, **30**, 97-108, 1995.
+* Paul Nomikos and John F. MacGregor, "`Multi-way partial least squares in monitoring batch processes <https://literature.learnche.org/item/32/multi-way-partial-least-squares-in-monitoring-batch-processes>`_", *Chemometrics and Intelligent Laboratory Systems*, **30**, 97-108, 1995.
 
-* T. Kourti, P. Nomikos and J. F. MacGregor, "`Analysis, monitoring and fault diagnosis of batch processes using multiblock and multiway PLS <https://literature.learnche.org/item/33/analysis-monitoring-and-fault-diagnosis-of-batch-processes-using-multiblock-and-multiway-pls>`_", *Journal of Process Control*, **5**, 277-284, 1995.
+* Theodora Kourti, Paul Nomikos and John F. MacGregor, "`Analysis, monitoring and fault diagnosis of batch processes using multiblock and multiway PLS <https://literature.learnche.org/item/33/analysis-monitoring-and-fault-diagnosis-of-batch-processes-using-multiblock-and-multiway-pls>`_", *Journal of Process Control*, **5**, 277-284, 1995.
 
-* P. Nomikos and J. F. MacGregor, "`Multivariate SPC charts for monitoring batch processes <https://literature.learnche.org/item/34/multivariate-spc-charts-for-monitoring-batch-processes>`_", *Technometrics*, **37**, 41-59, 1995.
+* Paul Nomikos and John F. MacGregor, "`Multivariate SPC charts for monitoring batch processes <https://literature.learnche.org/item/34/multivariate-spc-charts-for-monitoring-batch-processes>`_", *Technometrics*, **37**, 41-59, 1995.
 
-* P. Nomikos, "`Detection and diagnosis of abnormal batch operations based on multi-way principal component analysis <https://literature.learnche.org/item/64/detection-and-diagnosis-of-abnormal-batch-operations-based-on-multi-way-principal-component-analysis>`_", *ISA Transactions*, **35**, 259-266, 1996.
+* Paul Nomikos, "`Detection and diagnosis of abnormal batch operations based on multi-way principal component analysis <https://literature.learnche.org/item/64/detection-and-diagnosis-of-abnormal-batch-operations-based-on-multi-way-principal-component-analysis>`_", *ISA Transactions*, **35**, 259-266, 1996.
 
-* K. A. Kosanovich, K. S. Dahl and M. J. Piovoso, "`Improved process understanding using multiway principal component analysis <https://literature.learnche.org/item/156/improved-process-understanding-using-multiway-principal-component-analysis>`_", *Industrial and Engineering Chemistry Research*, **35**, 138-146, 1996.
+* Karlene A. Kosanovich, Kenneth S. Dahl and Michael J. Piovoso, "`Improved process understanding using multiway principal component analysis <https://literature.learnche.org/item/156/improved-process-understanding-using-multiway-principal-component-analysis>`_", *Industrial and Engineering Chemistry Research*, **35**, 138-146, 1996.
 
-* J. A. Westerhuis, T. Kourti and J. F. MacGregor, "`Comparing alternative approaches for multivariate statistical analysis of batch process data <https://literature.learnche.org/item/162/comparing-alternative-approaches-for-multivariate-statistical-analysis-of-batch-process-data>`_", *Journal of Chemometrics*, **13**, 397-413, 1999.
+* Johan A. Westerhuis, Theodora Kourti and John F. MacGregor, "`Comparing alternative approaches for multivariate statistical analysis of batch process data <https://literature.learnche.org/item/162/comparing-alternative-approaches-for-multivariate-statistical-analysis-of-batch-process-data>`_", *Journal of Chemometrics*, **13**, 397-413, 1999.
 
-* S. Wold, N. Kettaneh-Wold, J. F. MacGregor and K. G. Dunn, "`Batch process modeling and MSPC <https://literature.learnche.org/item/155/batch-process-modeling-and-mspc>`_", *Comprehensive Chemometrics*, **2.10**, 163-197, 2009.
+* Svante Wold, Nouna Kettaneh-Wold, John F. MacGregor and Kevin G. Dunn, "`Batch process modeling and MSPC <https://literature.learnche.org/item/155/batch-process-modeling-and-mspc>`_", *Comprehensive Chemometrics*, **2.10**, 163-197, 2009.
 
 Control, optimization and product quality
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* C. Duchesne and J. F. MacGregor, "`Multivariate analysis and optimization of process variable trajectories for batch processes <https://literature.learnche.org/item/92/multivariate-analysis-and-optimization-of-process-variable-trajectories-for-batch-processes>`_", *Chemometrics and Intelligent Laboratory Systems*, **51**, 125-137, 2000.
+* Carl Duchesne and John F. MacGregor, "`Multivariate analysis and optimization of process variable trajectories for batch processes <https://literature.learnche.org/item/92/multivariate-analysis-and-optimization-of-process-variable-trajectories-for-batch-processes>`_", *Chemometrics and Intelligent Laboratory Systems*, **51**, 125-137, 2000.
 
-* C. Duchesne, T. Kourti and J. F. MacGregor, "`Multivariate SPC for startups and grade transitions <https://literature.learnche.org/item/91/multivariate-spc-for-startups-and-grade-transitions>`_", *AIChE Journal*, **48**, 2890-2901, 2002.
+* Carl Duchesne, Theodora Kourti and John F. MacGregor, "`Multivariate SPC for startups and grade transitions <https://literature.learnche.org/item/91/multivariate-spc-for-startups-and-grade-transitions>`_", *AIChE Journal*, **48**, 2890-2901, 2002.
 
-* J. Flores-Cerrillo and J. F. MacGregor, "`Control of batch product quality by trajectory manipulation using latent variable models <https://literature.learnche.org/item/39/control-of-batch-product-quality-by-trajectory-manipulation-using-latent-variable-models>`_", *Journal of Process Control*, **14**, 539-553, 2004.
+* Jesus Flores-Cerrillo and John F. MacGregor, "`Control of batch product quality by trajectory manipulation using latent variable models <https://literature.learnche.org/item/39/control-of-batch-product-quality-by-trajectory-manipulation-using-latent-variable-models>`_", *Journal of Process Control*, **14**, 539-553, 2004.
 
-* J. Flores-Cerrillo and J. F. MacGregor, "`Multivariate monitoring of batch processes using batch-to-batch information <https://literature.learnche.org/item/163/multivariate-monitoring-of-batch-processes-using-batch-to-batch-information>`_", *AIChE Journal*, **50**, 1219-1228, 2004.
+* Jesus Flores-Cerrillo and John F. MacGregor, "`Multivariate monitoring of batch processes using batch-to-batch information <https://literature.learnche.org/item/163/multivariate-monitoring-of-batch-processes-using-batch-to-batch-information>`_", *AIChE Journal*, **50**, 1219-1228, 2004.
 
-* S. García-Muñoz, T. Kourti and J. F. MacGregor, "`Model predictive monitoring for batch processes <https://literature.learnche.org/item/157/model-predictive-monitoring-for-batch-processes>`_", *Industrial and Engineering Chemistry Research*, **43**, 5929-5941, 2004.
+* Salvador García-Muñoz, Theodora Kourti and John F. MacGregor, "`Model predictive monitoring for batch processes <https://literature.learnche.org/item/157/model-predictive-monitoring-for-batch-processes>`_", *Industrial and Engineering Chemistry Research*, **43**, 5929-5941, 2004.
 
 Performance, alignment, and spectroscopy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* S. P. Gurden, J. A. Westerhuis and A. K. Smilde, "`Monitoring of batch processes using spectroscopy <https://literature.learnche.org/item/140/monitoring-of-batch-processes-using-spectroscopy>`_", *AIChE Journal*, **48**, 2283-2297, 2002.
+* Stephen P. Gurden, Johan A. Westerhuis and Age K. Smilde, "`Monitoring of batch processes using spectroscopy <https://literature.learnche.org/item/140/monitoring-of-batch-processes-using-spectroscopy>`_", *AIChE Journal*, **48**, 2283-2297, 2002.
 
-* H.-J. Ramaker, E. N. M. Van Sprang, J. A. Westerhuis, S. P. Gurden, A. K. Smilde and F. H. Van Der Meulen, "`Performance assessment and improvement of control charts for statistical batch process monitoring <https://literature.learnche.org/item/164/performance-assessment-and-improvement-of-control-charts-for-statistical-batch-process-monitoring>`_", *Statistica Neerlandica*, **60**, 339-360, 2006.
+* Henk-Jan Ramaker, Eric N. M. Van Sprang, Johan A. Westerhuis, Stephen P. Gurden, Age K. Smilde and Frank H. Van Der Meulen, "`Performance assessment and improvement of control charts for statistical batch process monitoring <https://literature.learnche.org/item/164/performance-assessment-and-improvement-of-control-charts-for-statistical-batch-process-monitoring>`_", *Statistica Neerlandica*, **60**, 339-360, 2006.
 
-* J. M. González-Martínez, A. J. Ferrer and J. A. Westerhuis, "`Real-time synchronization of batch trajectories for on-line multivariate statistical process control using Dynamic Time Warping <https://literature.learnche.org/item/158/real-time-synchronization-of-batch-trajectories-for-on-line-multivariate-statistical-process-control-using-dynamic-time-warping>`_", *Chemometrics and Intelligent Laboratory Systems*, **105**, 195-206, 2011.
+* José M. González-Martínez, Alberto J. Ferrer and Johan A. Westerhuis, "`Real-time synchronization of batch trajectories for on-line multivariate statistical process control using Dynamic Time Warping <https://literature.learnche.org/item/158/real-time-synchronization-of-batch-trajectories-for-on-line-multivariate-statistical-process-control-using-dynamic-time-warping>`_", *Chemometrics and Intelligent Laboratory Systems*, **105**, 195-206, 2011.
 
 Theses (McMaster University)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* P. Nomikos, `Statistical process control of batch processes <https://literature.learnche.org/item/154/statistical-process-control-of-batch-processes>`_, Ph.D thesis, 1995.
+* Paul Nomikos, `Statistical process control of batch processes <https://literature.learnche.org/item/154/statistical-process-control-of-batch-processes>`_, Ph.D thesis, 1995.
 
-* C. M. Jaeckle, `Product and process improvement using latent variable methods <https://literature.learnche.org/item/167/product-and-process-improvement-using-latent-variable-methods>`_, Ph.D thesis, 1998.
+* Christiane M. Jaeckle, `Product and process improvement using latent variable methods <https://literature.learnche.org/item/167/product-and-process-improvement-using-latent-variable-methods>`_, Ph.D thesis, 1998.
 
-* J. Flores-Cerrillo, `Quality control for batch processes using multivariate latent variable methods <https://literature.learnche.org/item/51/quality-control-for-batch-processes-using-multivariate-latent-variable-methods>`_, Ph.D thesis, 2003.
+* Jesus Flores-Cerrillo, `Quality control for batch processes using multivariate latent variable methods <https://literature.learnche.org/item/51/quality-control-for-batch-processes-using-multivariate-latent-variable-methods>`_, Ph.D thesis, 2003.
 
-* S. García-Muñoz, `Batch process improvement using latent variable methods <https://literature.learnche.org/item/3/batch-process-improvement-using-latent-variable-methods>`_, Ph.D thesis, 2004.
+* Salvador García-Muñoz, `Batch process improvement using latent variable methods <https://literature.learnche.org/item/3/batch-process-improvement-using-latent-variable-methods>`_, Ph.D thesis, 2004.
 
-* C. Pereira Rodrigues, `Industrial batch data analysis using latent variable methods <https://literature.learnche.org/item/161/industrial-batch-data-analysis-using-latent-variable-methods>`_, Masters thesis, 2006.
+* Cecilia Pereira Rodrigues, `Industrial batch data analysis using latent variable methods <https://literature.learnche.org/item/161/industrial-batch-data-analysis-using-latent-variable-methods>`_, Masters thesis, 2006.

--- a/product-development-product-improvement/image-analysis.rst
+++ b/product-development-product-improvement/image-analysis.rst
@@ -20,56 +20,56 @@ References to incorporate
 Foundational MIA papers and books
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* P. Geladi, S. Wold and K. H. Esbensen, "`Image analysis and chemical information in images <https://literature.learnche.org/item/136/image-analysis-and-chemical-information-in-images>`_", *Analytica Chimica Acta*, **191**, 473-480, 1986.
+* Paul Geladi, Svante Wold and Kim H. Esbensen, "`Image analysis and chemical information in images <https://literature.learnche.org/item/136/image-analysis-and-chemical-information-in-images>`_", *Analytica Chimica Acta*, **191**, 473-480, 1986.
 
-* P. Geladi, H. Isaksson, L. Lindqvist, S. Wold and K. H. Esbensen, "`Principal component analysis of multivariate images <https://literature.learnche.org/item/126/principal-component-analysis-of-multivariate-images>`_", *Chemometrics and Intelligent Laboratory Systems*, **5**, 209-220, 1989.
+* Paul Geladi, Hans Isaksson, Lennart Lindqvist, Svante Wold and Kim H. Esbensen, "`Principal component analysis of multivariate images <https://literature.learnche.org/item/126/principal-component-analysis-of-multivariate-images>`_", *Chemometrics and Intelligent Laboratory Systems*, **5**, 209-220, 1989.
 
-* K. H. Esbensen and P. Geladi, "`Strategy of multivariate image analysis (MIA) <https://literature.learnche.org/item/137/strategy-of-multivariate-image-analysis-mia>`_", *Chemometrics and Intelligent Laboratory Systems*, **7**, 67-86, 1989.
+* Kim H. Esbensen and Paul Geladi, "`Strategy of multivariate image analysis (MIA) <https://literature.learnche.org/item/137/strategy-of-multivariate-image-analysis-mia>`_", *Chemometrics and Intelligent Laboratory Systems*, **7**, 67-86, 1989.
 
-* P. Geladi, E. Bengtsson, K. H. Esbensen and H. Grahn, "`Image analysis in chemistry I: Properties of images, greylevel operations, the multivariate image <https://literature.learnche.org/item/133/image-analysis-in-chemistry-i-properties-of-images-greylevel-operations-the-multivariate-image>`_", *TrAC Trends in Analytical Chemistry*, **11**, 41-53, 1992.
+* Paul Geladi, Ewert Bengtsson, Kim H. Esbensen and Hans Grahn, "`Image analysis in chemistry I: Properties of images, greylevel operations, the multivariate image <https://literature.learnche.org/item/133/image-analysis-in-chemistry-i-properties-of-images-greylevel-operations-the-multivariate-image>`_", *TrAC Trends in Analytical Chemistry*, **11**, 41-53, 1992.
 
-* P. Geladi, H. Grahn, K. H. Esbensen and E. Bengtsson, "`Image analysis in chemistry II: Multivariate image analysis <https://literature.learnche.org/item/134/image-analysis-in-chemistry-ii-multivariate-image-analysis>`_", *TrAC Trends in Analytical Chemistry*, **11**, 121-130, 1992.
+* Paul Geladi, Hans Grahn, Kim H. Esbensen and Ewert Bengtsson, "`Image analysis in chemistry II: Multivariate image analysis <https://literature.learnche.org/item/134/image-analysis-in-chemistry-ii-multivariate-image-analysis>`_", *TrAC Trends in Analytical Chemistry*, **11**, 121-130, 1992.
 
-* P. Geladi and H. Grahn, `Multivariate Image Analysis <https://literature.learnche.org/item/138/multivariate-image-analysis>`_, Wiley, 1997.
+* Paul Geladi and Hans Grahn, `Multivariate Image Analysis <https://literature.learnche.org/item/138/multivariate-image-analysis>`_, Wiley, 1997.
 
-* H. Grahn and P. Geladi, `Techniques and Applications of Hyperspectral Image Analysis <https://literature.learnche.org/item/139/techniques-and-applications-of-hyperspectral-image-analysis>`_, Wiley, 2007.
+* Hans Grahn and Paul Geladi, `Techniques and Applications of Hyperspectral Image Analysis <https://literature.learnche.org/item/139/techniques-and-applications-of-hyperspectral-image-analysis>`_, Wiley, 2007.
 
-* J. M. Prats-Montalbán, A. De Juan and A. J. Ferrer, "`Multivariate image analysis: A review with applications <https://literature.learnche.org/item/127/multivariate-image-analysis-a-review-with-applications>`_", *Chemometrics and Intelligent Laboratory Systems*, **107**, 1-23, 2011.
+* José M. Prats-Montalbán, Anna De Juan and Alberto J. Ferrer, "`Multivariate image analysis: A review with applications <https://literature.learnche.org/item/127/multivariate-image-analysis-a-review-with-applications>`_", *Chemometrics and Intelligent Laboratory Systems*, **107**, 1-23, 2011.
 
-* J. Burger and A. A. Gowen, "`Data handling in hyperspectral image analysis <https://literature.learnche.org/item/132/data-handling-in-hyperspectral-image-analysis>`_", *Chemometrics and Intelligent Laboratory Systems*, **108**, 13-22, 2011.
+* James Burger and Aoife A. Gowen, "`Data handling in hyperspectral image analysis <https://literature.learnche.org/item/132/data-handling-in-hyperspectral-image-analysis>`_", *Chemometrics and Intelligent Laboratory Systems*, **108**, 13-22, 2011.
 
-* A. A. Gowen, F. Marini, C. Esquerre, C. P. F. O'Donnell, G. Downey and J. Burger, "`Time series hyperspectral chemical imaging data: Challenges, solutions and applications <https://literature.learnche.org/item/135/time-series-hyperspectral-chemical-imaging-data-challenges-solutions-and-applications>`_", *Analytica Chimica Acta*, **705**, 272-282, 2011.
+* Aoife A. Gowen, Federico Marini, Carlos Esquerre, C. P. F. O'Donnell, G. Downey and James Burger, "`Time series hyperspectral chemical imaging data: Challenges, solutions and applications <https://literature.learnche.org/item/135/time-series-hyperspectral-chemical-imaging-data-challenges-solutions-and-applications>`_", *Analytica Chimica Acta*, **705**, 272-282, 2011.
 
 Industrial applications and case studies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* M. H. Bharati and J. F. MacGregor, "`Multivariate image analysis for real-time process monitoring and control <https://literature.learnche.org/item/19/multivariate-image-analysis-for-real-time-process-monitoring-and-control>`_", *Industrial and Engineering Chemistry Research*, **37**, 4715-4724, 1998.
+* Manish H. Bharati and John F. MacGregor, "`Multivariate image analysis for real-time process monitoring and control <https://literature.learnche.org/item/19/multivariate-image-analysis-for-real-time-process-monitoring-and-control>`_", *Industrial and Engineering Chemistry Research*, **37**, 4715-4724, 1998.
 
-* M. H. Bharati, J. F. MacGregor and W. Tropper, "`Softwood lumber grading through on-line multivariate image analysis techniques <https://literature.learnche.org/item/117/softwood-lumber-grading-through-on-line-multivariate-image-analysis-techniques>`_", *Industrial and Engineering Chemistry Research*, **42**, 5345-5353, 2003.
+* Manish H. Bharati, John F. MacGregor and William Tropper, "`Softwood lumber grading through on-line multivariate image analysis techniques <https://literature.learnche.org/item/117/softwood-lumber-grading-through-on-line-multivariate-image-analysis-techniques>`_", *Industrial and Engineering Chemistry Research*, **42**, 5345-5353, 2003.
 
-* H. Yu and J. F. MacGregor, "`Multivariate image analysis and regression for prediction of coating content and distribution in the production of snack foods <https://literature.learnche.org/item/119/multivariate-image-analysis-and-regression-for-prediction-of-coating-content-and-distribution-in-the-production-of-snack-foods>`_", *Chemometrics and Intelligent Laboratory Systems*, **67**, 125-144, 2003.
+* Honglu Yu and John F. MacGregor, "`Multivariate image analysis and regression for prediction of coating content and distribution in the production of snack foods <https://literature.learnche.org/item/119/multivariate-image-analysis-and-regression-for-prediction-of-coating-content-and-distribution-in-the-production-of-snack-foods>`_", *Chemometrics and Intelligent Laboratory Systems*, **67**, 125-144, 2003.
 
-* H. Yu, J. F. MacGregor, G. Haarsma and W. Bourg, "`Digital imaging for online monitoring and control of industrial snack food processes <https://literature.learnche.org/item/57/digital-imaging-for-online-monitoring-and-control-of-industrial-snack-food-processes>`_", *Industrial and Engineering Chemistry Research*, **42**, 3036-3044, 2003.
+* Honglu Yu, John F. MacGregor, Gabe Haarsma and Wilfred Bourg, "`Digital imaging for online monitoring and control of industrial snack food processes <https://literature.learnche.org/item/57/digital-imaging-for-online-monitoring-and-control-of-industrial-snack-food-processes>`_", *Industrial and Engineering Chemistry Research*, **42**, 3036-3044, 2003.
 
-* H. Yu and J. F. MacGregor, "`Monitoring flames in an industrial boiler using multivariate image analysis <https://literature.learnche.org/item/118/monitoring-flames-in-an-industrial-boiler-using-multivariate-image-analysis>`_", *AIChE Journal*, **50**, 1474-1483, 2004.
+* Honglu Yu and John F. MacGregor, "`Monitoring flames in an industrial boiler using multivariate image analysis <https://literature.learnche.org/item/118/monitoring-flames-in-an-industrial-boiler-using-multivariate-image-analysis>`_", *AIChE Journal*, **50**, 1474-1483, 2004.
 
-* M. H. Bharati, J. J. Liu and J. F. MacGregor, "`Image texture analysis: Methods and comparisons <https://literature.learnche.org/item/116/image-texture-analysis-methods-and-comparisons>`_", *Chemometrics and Intelligent Laboratory Systems*, **72**, 57-71, 2004.
+* Manish H. Bharati, Jay Liu and John F. MacGregor, "`Image texture analysis: Methods and comparisons <https://literature.learnche.org/item/116/image-texture-analysis-methods-and-comparisons>`_", *Chemometrics and Intelligent Laboratory Systems*, **72**, 57-71, 2004.
 
-* J. J. Liu, M. H. Bharati, K. G. Dunn and J. F. MacGregor, "`Automatic masking in multivariate image analysis using support vector machines <https://literature.learnche.org/item/42/automatic-masking-in-multivariate-image-analysis-using-support-vector-machines>`_", *Chemometrics and Intelligent Laboratory Systems*, **79**, 42-54, 2005.
+* Jay Liu, Manish H. Bharati, Kevin G. Dunn and John F. MacGregor, "`Automatic masking in multivariate image analysis using support vector machines <https://literature.learnche.org/item/42/automatic-masking-in-multivariate-image-analysis-using-support-vector-machines>`_", *Chemometrics and Intelligent Laboratory Systems*, **79**, 42-54, 2005.
 
-* G. Szatvanyi, C. Duchesne and G. Bartolacci, "`Multivariate image analysis of flames for product quality and combustion control in rotary kilns <https://literature.learnche.org/item/141/multivariate-image-analysis-of-flames-for-product-quality-and-combustion-control-in-rotary-kilns>`_", *Industrial and Engineering Chemistry Research*, **45**, 4706-4715, 2005.
+* Gabor Szatvanyi, Carl Duchesne and G. Bartolacci, "`Multivariate image analysis of flames for product quality and combustion control in rotary kilns <https://literature.learnche.org/item/141/multivariate-image-analysis-of-flames-for-product-quality-and-combustion-control-in-rotary-kilns>`_", *Industrial and Engineering Chemistry Research*, **45**, 4706-4715, 2005.
 
-* J. J. Liu and J. F. MacGregor, "`On the extraction of spectral and spatial information from images <https://literature.learnche.org/item/125/on-the-extraction-of-spectral-and-spatial-information-from-images>`_", *Chemometrics and Intelligent Laboratory Systems*, **85**, 119-130, 2007.
+* Jay Liu and John F. MacGregor, "`On the extraction of spectral and spatial information from images <https://literature.learnche.org/item/125/on-the-extraction-of-spectral-and-spatial-information-from-images>`_", *Chemometrics and Intelligent Laboratory Systems*, **85**, 119-130, 2007.
 
 Theses (McMaster University)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* M. H. Bharati, `Multivariate image analysis for real-time process monitoring <https://literature.learnche.org/item/144/multivariate-image-analysis-for-real-time-process-monitoring>`_, Masters thesis, 1997.
+* Manish H. Bharati, `Multivariate image analysis for real-time process monitoring <https://literature.learnche.org/item/144/multivariate-image-analysis-for-real-time-process-monitoring>`_, Masters thesis, 1997.
 
-* M. H. Bharati, `Multivariate image analysis and regression for industrial process monitoring and product quality control <https://literature.learnche.org/item/128/multivariate-image-analysis-and-regression-for-industrial-process-monitoring-and-product-quality-control>`_, Ph.D thesis, 2002.
+* Manish H. Bharati, `Multivariate image analysis and regression for industrial process monitoring and product quality control <https://literature.learnche.org/item/128/multivariate-image-analysis-and-regression-for-industrial-process-monitoring-and-product-quality-control>`_, Ph.D thesis, 2002.
 
-* J. J. Liu, `Machine vision for process industries: Monitoring, control, and optimization of visual quality of processes and products <https://literature.learnche.org/item/129/machine-vision-for-process-industries-monitoring-control-and-optimization-of-visual-quality-of-processes-and-products>`_, Ph.D thesis, 2004.
+* Jay Liu, `Machine vision for process industries: Monitoring, control, and optimization of visual quality of processes and products <https://literature.learnche.org/item/129/machine-vision-for-process-industries-monitoring-control-and-optimization-of-visual-quality-of-processes-and-products>`_, Ph.D thesis, 2004.
 
-* Z. Liu, `NIR imaging and its application to wheat grading <https://literature.learnche.org/item/130/nir-imaging-and-its-application-to-wheat-grading>`_, Masters thesis, 2006.
+* Zheng Liu, `NIR imaging and its application to wheat grading <https://literature.learnche.org/item/130/nir-imaging-and-its-application-to-wheat-grading>`_, Masters thesis, 2006.
 
-* M.-J. Bruwer, `Process systems approaches to diagnostic imaging and property prediction <https://literature.learnche.org/item/131/process-systems-approaches-to-diagnostic-imaging-and-property-prediction>`_, Ph.D thesis, 2006.
+* Mark-John Bruwer, `Process systems approaches to diagnostic imaging and property prediction <https://literature.learnche.org/item/131/process-systems-approaches-to-diagnostic-imaging-and-property-prediction>`_, Ph.D thesis, 2006.

--- a/product-development-product-improvement/multivariate-process-monitoring.rst
+++ b/product-development-product-improvement/multivariate-process-monitoring.rst
@@ -21,55 +21,55 @@ References to incorporate
 Foundational MSPC papers
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-* J. V. Kresta, J. F. MacGregor and T. E. Marlin, "`Multivariate statistical monitoring of process operating performance <https://literature.learnche.org/item/9/multivariate-statistical-monitoring-of-process-operating-performance>`_", *Canadian Journal of Chemical Engineering*, **69**, 35-47, 1991.
+* James V. Kresta, John F. MacGregor and Thomas E. Marlin, "`Multivariate statistical monitoring of process operating performance <https://literature.learnche.org/item/9/multivariate-statistical-monitoring-of-process-operating-performance>`_", *Canadian Journal of Chemical Engineering*, **69**, 35-47, 1991.
 
-* J. F. MacGregor and T. Kourti, "`Statistical process control of multivariate processes <https://literature.learnche.org/item/16/statistical-process-control-of-multivariate-processes>`_", *Control Engineering Practice*, **3**, 403-414, 1995.
+* John F. MacGregor and Theodora Kourti, "`Statistical process control of multivariate processes <https://literature.learnche.org/item/16/statistical-process-control-of-multivariate-processes>`_", *Control Engineering Practice*, **3**, 403-414, 1995.
 
-* T. Kourti and J. F. MacGregor, "`Process analysis, monitoring and diagnosis using multivariate projection methods <https://literature.learnche.org/item/31/process-analysis-monitoring-and-diagnosis-using-multivariate-projection-methods>`_", *Chemometrics and Intelligent Laboratory Systems*, **28**, 3-21, 1995.
+* Theodora Kourti and John F. MacGregor, "`Process analysis, monitoring and diagnosis using multivariate projection methods <https://literature.learnche.org/item/31/process-analysis-monitoring-and-diagnosis-using-multivariate-projection-methods>`_", *Chemometrics and Intelligent Laboratory Systems*, **28**, 3-21, 1995.
 
-* T. Kourti and J. F. MacGregor, "`Multivariate SPC methods for process and product monitoring <https://literature.learnche.org/item/81/multivariate-spc-methods-for-process-and-product-monitoring>`_", *Journal of Quality Technology*, **28**, 409-428, 1996.
+* Theodora Kourti and John F. MacGregor, "`Multivariate SPC methods for process and product monitoring <https://literature.learnche.org/item/81/multivariate-spc-methods-for-process-and-product-monitoring>`_", *Journal of Quality Technology*, **28**, 409-428, 1996.
 
-* J. A. Westerhuis, T. Kourti and J. F. MacGregor, "`Analysis of multiblock and hierarchical PCA and PLS models <https://literature.learnche.org/item/95/analysis-of-multiblock-and-hierarchical-pca-and-pls-models>`_", *Journal of Chemometrics*, **12**, 301-321, 1998.
+* Johan A. Westerhuis, Theodora Kourti and John F. MacGregor, "`Analysis of multiblock and hierarchical PCA and PLS models <https://literature.learnche.org/item/95/analysis-of-multiblock-and-hierarchical-pca-and-pls-models>`_", *Journal of Chemometrics*, **12**, 301-321, 1998.
 
-* T. Kourti, "`Process analysis and abnormal situation detection: From theory to practice <https://literature.learnche.org/item/87/process-analysis-and-abnormal-situation-detection-from-theory-to-practice>`_", *IEEE Control Systems*, **22**, 10-25, 2002.
+* Theodora Kourti, "`Process analysis and abnormal situation detection: From theory to practice <https://literature.learnche.org/item/87/process-analysis-and-abnormal-situation-detection-from-theory-to-practice>`_", *IEEE Control Systems*, **22**, 10-25, 2002.
 
-* T. Kourti, "`Abnormal situation detection, three-way data and projection methods; robust data archiving and modeling for industrial applications <https://literature.learnche.org/item/120/abnormal-situation-detection-three-way-data-and-projection-methods-robust-data-archiving-and-modeling-for-industrial-applications>`_", *Annual Reviews in Control*, **27**, 131-139, 2003.
+* Theodora Kourti, "`Abnormal situation detection, three-way data and projection methods; robust data archiving and modeling for industrial applications <https://literature.learnche.org/item/120/abnormal-situation-detection-three-way-data-and-projection-methods-robust-data-archiving-and-modeling-for-industrial-applications>`_", *Annual Reviews in Control*, **27**, 131-139, 2003.
 
-* T. Kourti, "`Application of latent variable methods to process control and multivariate statistical process control in industry <https://literature.learnche.org/item/88/application-of-latent-variable-methods-to-process-control-and-multivariate-statistical-process-control-in-industry>`_", *International Journal of Adaptive Control and Signal Processing*, **19**, 213-246, 2005.
+* Theodora Kourti, "`Application of latent variable methods to process control and multivariate statistical process control in industry <https://literature.learnche.org/item/88/application-of-latent-variable-methods-to-process-control-and-multivariate-statistical-process-control-in-industry>`_", *International Journal of Adaptive Control and Signal Processing*, **19**, 213-246, 2005.
 
 Fault detection and diagnosis
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* S. Yoon and J. F. MacGregor, "`Statistical and causal model-based approaches to fault detection and isolation <https://literature.learnche.org/item/89/statistical-and-causal-model-based-approaches-to-fault-detection-and-isolation>`_", *AIChE Journal*, **46**, 1813-1824, 2000.
+* Seongkyu Yoon and John F. MacGregor, "`Statistical and causal model-based approaches to fault detection and isolation <https://literature.learnche.org/item/89/statistical-and-causal-model-based-approaches-to-fault-detection-and-isolation>`_", *AIChE Journal*, **46**, 1813-1824, 2000.
 
-* S. Yoon and J. F. MacGregor, "`Fault diagnosis with multivariate statistical models part I: Using steady state fault signatures <https://literature.learnche.org/item/90/fault-diagnosis-with-multivariate-statistical-models-part-i-using-steady-state-fault-signatures>`_", *Journal of Process Control*, **11**, 387-400, 2001.
+* Seongkyu Yoon and John F. MacGregor, "`Fault diagnosis with multivariate statistical models part I: Using steady state fault signatures <https://literature.learnche.org/item/90/fault-diagnosis-with-multivariate-statistical-models-part-i-using-steady-state-fault-signatures>`_", *Journal of Process Control*, **11**, 387-400, 2001.
 
-* P. Miller, R. E. Swanson and C. E. Heckler, "`Contribution plots: A missing link in multivariate quality control <https://literature.learnche.org/item/78/contribution-plots-a-missing-link-in-multivariate-quality-control>`_", *Applied Mathematics and Computer Science*, **8**, 775-792, 1998.
+* Paige Miller, Ronald E. Swanson and Charles E. Heckler, "`Contribution plots: A missing link in multivariate quality control <https://literature.learnche.org/item/78/contribution-plots-a-missing-link-in-multivariate-quality-control>`_", *Applied Mathematics and Computer Science*, **8**, 775-792, 1998.
 
-* C. R. Alvarez, A. Brandolin and M. C. Sánchez, "`On the variable contributions to the D-statistic <https://literature.learnche.org/item/21/on-the-variable-contributions-to-the-d-statistic>`_", *Chemometrics and Intelligent Laboratory Systems*, **88**, 189-196, 2007.
+* Carlos R. Alvarez, Adriana Brandolin and Mabel C. Sánchez, "`On the variable contributions to the D-statistic <https://literature.learnche.org/item/21/on-the-variable-contributions-to-the-d-statistic>`_", *Chemometrics and Intelligent Laboratory Systems*, **88**, 189-196, 2007.
 
-* R. De Maesschalck, D. Jouan-Rimbaud and D. L. Massart, "`The Mahalanobis distance <https://literature.learnche.org/item/67/the-mahalanobis-distance>`_", *Chemometrics and Intelligent Laboratory Systems*, **50**, 1-18, 2000.
+* Roy De Maesschalck, Delphine Jouan-Rimbaud and D. Luc Massart, "`The Mahalanobis distance <https://literature.learnche.org/item/67/the-mahalanobis-distance>`_", *Chemometrics and Intelligent Laboratory Systems*, **50**, 1-18, 2000.
 
-* S. J. Qin, S. Valle and M. J. Piovoso, "`On unifying multiblock analysis with application to decentralized process monitoring <https://literature.learnche.org/item/165/on-unifying-multiblock-analysis-with-application-to-decentralized-process-monitoring>`_", *Journal of Chemometrics*, **15**, 715-742, 2001.
+* Joe Qin, Sergio Valle and Michael J. Piovoso, "`On unifying multiblock analysis with application to decentralized process monitoring <https://literature.learnche.org/item/165/on-unifying-multiblock-analysis-with-application-to-decentralized-process-monitoring>`_", *Journal of Chemometrics*, **15**, 715-742, 2001.
 
 Industrial troubleshooting case studies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* B. Skagerberg, J. F. MacGregor and C. Kiparissides, "`Multivariate data analysis applied to low-density polyethylene reactors <https://literature.learnche.org/item/27/multivariate-data-analysis-applied-to-low-density-polyethylene-reactors>`_", *Chemometrics and Intelligent Laboratory Systems*, **14**, 341-356, 1992.
+* Bert Skagerberg, John F. MacGregor and Costas Kiparissides, "`Multivariate data analysis applied to low-density polyethylene reactors <https://literature.learnche.org/item/27/multivariate-data-analysis-applied-to-low-density-polyethylene-reactors>`_", *Chemometrics and Intelligent Laboratory Systems*, **14**, 341-356, 1992.
 
-* J. F. MacGregor, C. M. Jaeckle, C. Kiparissides and M. Koutoudi, "`Process monitoring and diagnosis by multiblock PLS method <https://literature.learnche.org/item/29/process-monitoring-and-diagnosis-by-multiblock-pls-method>`_", *AIChE Journal*, **40**, 826-838, 1994.
+* John F. MacGregor, Christiane M. Jaeckle, Costas Kiparissides and M. Koutoudi, "`Process monitoring and diagnosis by multiblock PLS method <https://literature.learnche.org/item/29/process-monitoring-and-diagnosis-by-multiblock-pls-method>`_", *AIChE Journal*, **40**, 826-838, 1994.
 
-* S. García-Muñoz, T. Kourti, J. F. MacGregor, A. G. Mateos and G. Murphy, "`Troubleshooting of an industrial batch process using multivariate methods <https://literature.learnche.org/item/24/troubleshooting-of-an-industrial-batch-process-using-multivariate-methods>`_", *Industrial and Engineering Chemistry Research*, **42**, 3592-3601, 2003.
+* Salvador García-Muñoz, Theodora Kourti, John F. MacGregor, Arthur G. Mateos and Gerald Murphy, "`Troubleshooting of an industrial batch process using multivariate methods <https://literature.learnche.org/item/24/troubleshooting-of-an-industrial-batch-process-using-multivariate-methods>`_", *Industrial and Engineering Chemistry Research*, **42**, 3592-3601, 2003.
 
-* I. Miletic, S. Quinn, M. Dudzic, V. Vaculik and M. Champagne, "`An industrial perspective on implementing on-line applications of multivariate statistics <https://literature.learnche.org/item/18/an-industrial-perspective-on-implementing-on-line-applications-of-multivariate-statistics>`_", *Journal of Process Control*, **14**, 821-836, 2004.
+* Ivan Miletic, Shannon Quinn, Michael Dudzic, Vit Vaculik and Marc Champagne, "`An industrial perspective on implementing on-line applications of multivariate statistics <https://literature.learnche.org/item/18/an-industrial-perspective-on-implementing-on-line-applications-of-multivariate-statistics>`_", *Journal of Process Control*, **14**, 821-836, 2004.
 
 Theses (McMaster University)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* C. F. Slama, `Multivariate statistical analysis of data from an industrial fluidized catalytic cracking process using PCA and PLS <https://literature.learnche.org/item/59/multivariate-statistical-analysis-of-data-from-an-industrial-fluidized-catalytic-cracking-process-using-pca-and-pls>`_, Masters thesis, 1991.
+* Carol F. Slama, `Multivariate statistical analysis of data from an industrial fluidized catalytic cracking process using PCA and PLS <https://literature.learnche.org/item/59/multivariate-statistical-analysis-of-data-from-an-industrial-fluidized-catalytic-cracking-process-using-pca-and-pls>`_, Masters thesis, 1991.
 
-* C. Duchesne, `Improvement of processes and product quality through multivariate data analysis <https://literature.learnche.org/item/46/improvement-of-processes-and-product-quality-through-multivariate-data-analysis>`_, Ph.D thesis, 2000.
+* Carl Duchesne, `Improvement of processes and product quality through multivariate data analysis <https://literature.learnche.org/item/46/improvement-of-processes-and-product-quality-through-multivariate-data-analysis>`_, Ph.D thesis, 2000.
 
-* F. Yacoub, `Learning from data using latent variable methods <https://literature.learnche.org/item/112/learning-from-data-using-latent-variable-methods>`_, Ph.D thesis, 2006.
+* François Yacoub, `Learning from data using latent variable methods <https://literature.learnche.org/item/112/learning-from-data-using-latent-variable-methods>`_, Ph.D thesis, 2006.
 
-* E. Nichols, `Latent variable methods: Case studies in the food industry <https://literature.learnche.org/item/113/latent-variable-methods-case-studies-in-the-food-industry>`_, Masters thesis, 2011.
+* Emily Nichols, `Latent variable methods: Case studies in the food industry <https://literature.learnche.org/item/113/latent-variable-methods-case-studies-in-the-food-industry>`_, Masters thesis, 2011.

--- a/product-development-product-improvement/product-development.rst
+++ b/product-development-product-improvement/product-development.rst
@@ -284,12 +284,12 @@ References
 
 The four-table organization is drawn from a sequence of papers, several of whose authors I have had the pleasure of working with over the past 25 years:
 
-	*	S. Garcia-Munoz, "Two Novel Methods to Analyze the Combined Effect of Multiple Raw-Materials and Processing Conditions on the Product's Final Attributes: JRPLS and TPLS." *Chemometrics and Intelligent Laboratory Systems*, **133**, 2014, https://doi.org/10.1016/j.chemolab.2014.02.006
+	*	Salvador García-Muñoz, "Two Novel Methods to Analyze the Combined Effect of Multiple Raw-Materials and Processing Conditions on the Product's Final Attributes: JRPLS and TPLS." *Chemometrics and Intelligent Laboratory Systems*, **133**, 2014, https://doi.org/10.1016/j.chemolab.2014.02.006
 
-	*	K. Muteki, J. F. MacGregor, and T. Ueda. "`Mixture Designs and Models for the Simultaneous Selection of Ingredients and Their Ratios <https://literature.learnche.org/item/146/mixture-designs-and-models-for-the-simultaneous-selection-of-ingredients-and-their-ratios>`_." *Chemometrics and Intelligent Laboratory Systems*, **86**, 2007.
+	*	Koji Muteki, John F. MacGregor and Toshihiro Ueda, "`Mixture Designs and Models for the Simultaneous Selection of Ingredients and Their Ratios <https://literature.learnche.org/item/146/mixture-designs-and-models-for-the-simultaneous-selection-of-ingredients-and-their-ratios>`_." *Chemometrics and Intelligent Laboratory Systems*, **86**, 2007.
 
-	*	C. M. Jaeckle and J. F. MacGregor. "`Product Design through Multivariate Statistical Analysis of Process Data <https://literature.learnche.org/item/61/product-design-through-multivariate-statistical-analysis-of-process-data>`_." *AIChE Journal*, **44**, 1998.
+	*	Christiane M. Jaeckle and John F. MacGregor, "`Product Design through Multivariate Statistical Analysis of Process Data <https://literature.learnche.org/item/61/product-design-through-multivariate-statistical-analysis-of-process-data>`_." *AIChE Journal*, **44**, 1998.
 
-	*	E. Tomba, M. Barolo, and S. García-Muñoz. "General Framework for Latent Variable Model Inversion for the Design and Manufacturing of New Products." *Industrial & Engineering Chemistry Research*, **51**, 2012, https://doi.org/10.1021/ie301214c
+	*	Emanuele Tomba, Massimiliano Barolo and Salvador García-Muñoz, "General Framework for Latent Variable Model Inversion for the Design and Manufacturing of New Products." *Industrial & Engineering Chemistry Research*, **51**, 2012, https://doi.org/10.1021/ie301214c
 
 

--- a/product-development-product-improvement/soft-sensors.rst
+++ b/product-development-product-improvement/soft-sensors.rst
@@ -21,26 +21,26 @@ References to incorporate
 Foundational and review papers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* J. V. Kresta, T. E. Marlin and J. F. MacGregor, "`Development of inferential process models using PLS <https://literature.learnche.org/item/17/development-of-inferential-process-models-using-pls>`_", *Computers and Chemical Engineering*, **18**, 597-611, 1994.
+* James V. Kresta, Thomas E. Marlin and John F. MacGregor, "`Development of inferential process models using PLS <https://literature.learnche.org/item/17/development-of-inferential-process-models-using-pls>`_", *Computers and Chemical Engineering*, **18**, 597-611, 1994.
 
-* L. Fortuna, S. Graziani, A. Rizzo and M. G. Xibilia, `Soft Sensors for Monitoring and Control of Industrial Processes <https://literature.learnche.org/item/111/soft-sensors-for-monitoring-and-control-of-industrial-processes>`_, Springer, 2007.
+* Luigi Fortuna, Salvatore Graziani, Alessandro Rizzo and M. Gabriella Xibilia, `Soft Sensors for Monitoring and Control of Industrial Processes <https://literature.learnche.org/item/111/soft-sensors-for-monitoring-and-control-of-industrial-processes>`_, Springer, 2007.
 
-* P. Kadlec, B. Gabrys and S. Strandt, "`Data-driven soft sensors in the process industry <https://literature.learnche.org/item/105/data-driven-soft-sensors-in-the-process-industry>`_", *Computers and Chemical Engineering*, **33**, 795-814, 2009.
+* Petr Kadlec, Bogdan Gabrys and Sibylle Strandt, "`Data-driven soft sensors in the process industry <https://literature.learnche.org/item/105/data-driven-soft-sensors-in-the-process-industry>`_", *Computers and Chemical Engineering*, **33**, 795-814, 2009.
 
-* P. Kadlec, R. Grbić and B. Gabrys, "`Review of adaptation mechanisms for data-driven soft sensors <https://literature.learnche.org/item/106/review-of-adaptation-mechanisms-for-data-driven-soft-sensors>`_", *Computers and Chemical Engineering*, **35**, 1-24, 2011.
+* Petr Kadlec, Ratko Grbić and Bogdan Gabrys, "`Review of adaptation mechanisms for data-driven soft sensors <https://literature.learnche.org/item/106/review-of-adaptation-mechanisms-for-data-driven-soft-sensors>`_", *Computers and Chemical Engineering*, **35**, 1-24, 2011.
 
-* B. Lin, B. Recke, J. K. H. Knudsen and S. B. Jørgensen, "`A systematic approach for soft sensor development <https://literature.learnche.org/item/107/a-systematic-approach-for-soft-sensor-development>`_", *Computers and Chemical Engineering*, **31**, 419-425, 2007.
+* Bao Lin, Bodil Recke, Jørgen K. H. Knudsen and Sten Bay Jørgensen, "`A systematic approach for soft sensor development <https://literature.learnche.org/item/107/a-systematic-approach-for-soft-sensor-development>`_", *Computers and Chemical Engineering*, **31**, 419-425, 2007.
 
 Industrial applications and case studies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* H. M. Budman, C. Webb, T. R. Holcomb and M. Morari, "`Robust inferential control for a packed-bed reactor <https://literature.learnche.org/item/22/robust-inferential-control-for-a-packed-bed-reactor>`_", *Industrial and Engineering Chemistry Research*, **31**, 1665-1679, 1992.
+* Hector M. Budman, Chris Webb, Tyler R. Holcomb and Manfred Morari, "`Robust inferential control for a packed-bed reactor <https://literature.learnche.org/item/22/robust-inferential-control-for-a-packed-bed-reactor>`_", *Industrial and Engineering Chemistry Research*, **31**, 1665-1679, 1992.
 
-* B. S. Dayal, J. F. MacGregor, P. A. Taylor, R. Kildaw and S. Marcikic, "`Application of feedforward neural networks and partial least squares regression to modelling Kappa number in a continuous Kamyr digester <https://literature.learnche.org/item/124/application-of-feedforward-neural-networks-and-partial-least-squares-regression-to-modelling-kappa-number-in-a-continuous-kamyr-digester>`_", *Pulp and Paper Canada*, **95**, T7-T13, 1994.
+* Bhupinder S. Dayal, John F. MacGregor, Paul A. Taylor, R. Kildaw and S. Marcikic, "`Application of feedforward neural networks and partial least squares regression to modelling Kappa number in a continuous Kamyr digester <https://literature.learnche.org/item/124/application-of-feedforward-neural-networks-and-partial-least-squares-regression-to-modelling-kappa-number-in-a-continuous-kamyr-digester>`_", *Pulp and Paper Canada*, **95**, T7-T13, 1994.
 
-* V. Tzovla and A. Mehta, "`Creating intelligence: Automating the approach to development and online operation of soft sensors <https://literature.learnche.org/item/103/creating-intelligence-automating-the-approach-to-development-and-online-operation-of-soft-sensors>`_", *InTech*, September, 30-33, 2002.
+* Vasiliki Tzovla and Ashish Mehta, "`Creating intelligence: Automating the approach to development and online operation of soft sensors <https://literature.learnche.org/item/103/creating-intelligence-automating-the-approach-to-development-and-online-operation-of-soft-sensors>`_", *InTech*, September, 30-33, 2002.
 
 Theses (McMaster University)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* S. D. Roney, `Development of inferential sensors for chemical processes using partial least squares <https://literature.learnche.org/item/143/development-of-inferential-sensors-for-chemical-processes-using-partial-least-squares>`_, Masters thesis, 1998.
+* Steven D. Roney, `Development of inferential sensors for chemical processes using partial least squares <https://literature.learnche.org/item/143/development-of-inferential-sensors-for-chemical-processes-using-partial-least-squares>`_, Masters thesis, 1998.


### PR DESCRIPTION
## Summary

Follows up on PR #81's Chapter 1 fix. The same RST rendering quirk — docutils interpreting `<Letter>.<space>` at the start of a list item as a nested-list marker — affects every reference entry I added (or touched) that starts with an abbreviated initial. Reported visually in the Chapter 7 References section screenshot.

## What changed

| File | Effect |
|---|---|
| `design-analysis-experiments/examples-of-how-designed-experiments-are-used.rst` | 3 of my entries (Lundstedt, Carlson, Bratchell) |
| `product-development-product-improvement/product-development.rst` | Full References section (4 entries: Garcia-Munoz, Muteki, Jaeckle, Tomba — 2 were already mine, 2 pre-existing) |
| `product-development-product-improvement/image-analysis.rst` | All entries — rewritten with full first names |
| `product-development-product-improvement/soft-sensors.rst` | All entries — rewritten with full first names |
| `product-development-product-improvement/batch-process-monitoring.rst` | All entries — rewritten with full first names |
| `product-development-product-improvement/multivariate-process-monitoring.rst` | All entries — rewritten with full first names |

Total: 83 +/- lines across 6 files. No catalogue links changed.

## Chapter 6 references list — not affected

Every entry in `latent-variable-modelling.rst`'s references list starts with `**Category**:` (bold prefix like `**General**:` or `**About PCA**:`), so mid-line initials don't trigger the parser. The "J. Edward Jackson" entry I added in PR #71 renders fine and is unchanged.

## First names with low confidence

These were not in the catalogue's author list but are widely documented; if any are wrong, a one-line follow-up fix:

- **Nigel Bratchell** (Unilever; 1989 JoC paper, id=6)
- **Gabor Szatvanyi** (Carl Duchesne's PhD student at Laval; id=141)
- **José M. González-Martínez** (Univ. Politècnica de València; id=158)
- **Roy De Maesschalck** (VUB / Massart group; id=67)
- **Joe Qin** — he publishes as "S. Joe Qin" but the leading `S.` triggers the parser, so dropping the initial here. Catalogue id=165.

## Test plan

- [x] `make text` builds clean (no new warnings).
- [x] `grep -nE "^\*\s+[A-Z]\. |^[-*]\s+[A-Z]\. " product-development-product-improvement/*.rst` returns no matches — no remaining leading-initial entries.
- [ ] Visual review: open Chapter 7 References, image-analysis, soft-sensors, batch-process-monitoring, multivariate-process-monitoring pages; confirm every bullet aligns at the same column.

https://claude.ai/code/session_016yBh3JNfRPquVwBkLnTDqH

---
_Generated by [Claude Code](https://claude.ai/code/session_016yBh3JNfRPquVwBkLnTDqH)_