### PR TITLE
Add click-to-copy buttons on every HTML code block

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -20,12 +20,26 @@ needs_sphinx = "5.0"
 extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.mathjax",
+    "sphinx_copybutton",
     "sphinxcontrib.jquery",
     "my-extensions.youtube",
 ]
 
 # Avoid Subresource Integrity errors for the bundled jQuery.
 jquery_use_sri = False
+
+# Configure the copy button on every code block.
+# Strip interactive prompts so paste-into-REPL still works:
+#   >>>   doctest
+#   ...   doctest continuation
+#   $     shell
+#   In [N]:  IPython
+# copybutton_only_copy_prompt_lines = True keeps the output lines out of
+# the clipboard when a prompt is present.
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: "
+copybutton_prompt_is_regexp = True
+copybutton_only_copy_prompt_lines = True
+copybutton_remove_prompts = True
 
 # NOTE: MathJax path is also forced in `layout.html` (see the `{# MathJax #}` comment).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
 dependencies = [
     "sphinx>=8.1.3",
     "sphinx-book-theme>=1.1.4",
+    "sphinx-copybutton>=0.5.2",
     "sphinxcontrib-jquery>=4.1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -191,6 +191,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "sphinx" },
     { name = "sphinx-book-theme" },
+    { name = "sphinx-copybutton" },
     { name = "sphinxcontrib-jquery" },
 ]
 
@@ -198,6 +199,7 @@ dependencies = [
 requires-dist = [
     { name = "sphinx", specifier = ">=8.1.3" },
     { name = "sphinx-book-theme", specifier = ">=1.1.4" },
+    { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinxcontrib-jquery", specifier = ">=4.1" },
 ]
 
@@ -310,6 +312,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/45/19/d002ed96bdc7738c15847c730e1e88282d738263deac705d5713b4d8fa94/sphinx_book_theme-1.1.4.tar.gz", hash = "sha256:73efe28af871d0a89bd05856d300e61edce0d5b2fbb7984e84454be0fedfe9ed", size = 439188, upload-time = "2025-02-20T16:32:32.581Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/9e/c41d68be04eef5b6202b468e0f90faf0c469f3a03353f2a218fd78279710/sphinx_book_theme-1.1.4-py3-none-any.whl", hash = "sha256:843b3f5c8684640f4a2d01abd298beb66452d1b2394cd9ef5be5ebd5640ea0e1", size = 433952, upload-time = "2025-02-20T16:32:31.009Z" },
+]
+
+[[package]]
+name = "sphinx-copybutton"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/48/1ea60e74949eecb12cdd6ac43987f9fd331156388dcc2319b45e2ebb81bf/sphinx_copybutton-0.5.2-py3-none-any.whl", hash = "sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e", size = 13343, upload-time = "2023-04-14T08:10:20.844Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Wires up the standard [`sphinx-copybutton`](https://sphinx-copybutton.readthedocs.io/) extension so that every `.. code-block::` in the HTML book gets a small clipboard icon in the top-right corner. The icon works on touch as well as click, so readers on iPads / phones can copy code without selecting it manually.

Three small changes:

- **`pyproject.toml`** -- add `sphinx-copybutton>=0.5.2` to `dependencies`.
- **`conf.py`** -- add `"sphinx_copybutton"` to `extensions` and four config lines for prompt handling (see below).
- **`uv.lock`** -- regenerated by `uv sync` to include the one new package.

### Prompt-stripping configuration

```python
copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: "
copybutton_prompt_is_regexp = True
copybutton_only_copy_prompt_lines = True
copybutton_remove_prompts = True
```

- Matches the four prompts that actually appear in this book: `>>> ` and `... ` (doctest), `$ ` (shell), `In [N]: ` (IPython).
- `copybutton_remove_prompts = True` strips the prompt from what lands on the clipboard, so the pasted text is directly runnable.
- `copybutton_only_copy_prompt_lines = True` skips doctest output lines when a prompt is present, so e.g. the `array([0.350, 0.503])` line from `model.r2_cumulative_.values` does not end up in the clipboard alongside the `>>>` line.

## Test plan

- [x] `make text` -- clean, no warnings
- [x] `make html` -- clean; `copybutton.css` / `copybutton.js` / `copy-button.svg` ship under `_build/html/_static/`; every built page loads the two copybutton assets; `grep -r goatcounter _build/html/contents` returns 0 hits
- [ ] `make latexpdf` -- **not run locally** (no TeX toolchain in this sandbox). The extension is HTML-only and does not emit any LaTeX-specific markup, so a PDF regression is not expected, but CI's `build-and-deploy` step exercises the LaTeX writer and will catch any regression.

https://claude.ai/code/session_01Y83gT2kRtM6f97TcGZgSEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y83gT2kRtM6f97TcGZgSEs)_