### PR TITLE
Make the sphinx-copybutton clipboard icon actually visible

### DIFF
--- a/_static/css/theme-extended-kgd.css
+++ b/_static/css/theme-extended-kgd.css
@@ -69,3 +69,16 @@ h1 .headerlink {
     border-radius: 2px;
     padding: 0 2px;
 }
+
+/* sphinx-copybutton: always show the clipboard icon.
+   Upstream's default is `opacity: 0` with a hover trigger, which is invisible
+   on touch devices (iPad, phone) and easy to miss on desktop. Keep it
+   permanently visible but dimmed; brighten on hover / focus. */
+button.copybtn {
+    opacity: 0.6;
+}
+button.copybtn:hover,
+button.copybtn:focus,
+.highlight:hover button.copybtn {
+    opacity: 1;
+}


### PR DESCRIPTION
## Summary

After PR #86 wired up `sphinx-copybutton`, you couldn't see the
clipboard icon. Reason: upstream's default CSS sets

```css
button.copybtn { opacity: 0; }
.highlight:hover button.copybtn { opacity: 1; }
```

so the button is invisible until you **hover over the code block**.
That fails on touch devices (iPad, phone — no hover) and is easy to
miss on desktop because there's no signal that the button is even
there.

This PR adds a small override in the existing
`_static/css/theme-extended-kgd.css`:

- baseline `opacity: 0.6` so the icon is always discoverable
- `opacity: 1` on hover, focus, or when the parent `.highlight` is
  hovered

No new files, no extension config change, no Sphinx build change.

## Test plan

- [x] `make html` -- clean; the override is present in
      `_build/html/_static/css/theme-extended-kgd.css`
- [x] `grep -r goatcounter _build/html/contents` -- zero hits
- Note: if the icon was already in the deployed HTML but invisible
      because of the upstream CSS rule, a hard refresh (Cmd+Shift+R /
      Ctrl+F5) is also needed on the user's end to pick up the new
      CSS once this merges.

https://claude.ai/code/session_01Y83gT2kRtM6f97TcGZgSEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y83gT2kRtM6f97TcGZgSEs)_