### PR TITLE
§7.3: redefine phases (drop unsettled 15-Dec), use score_contributions

### DIFF
--- a/product-development-product-improvement/multivariate-process-monitoring.rst
+++ b/product-development-product-improvement/multivariate-process-monitoring.rst
@@ -44,10 +44,13 @@ froth that overflows. Five process tags are recorded every 30 seconds:
 * ``Air flow rate`` -- aeration rate into the bottom of the cell.
 
 The dataset is a 30-second sampling of those five tags over two consecutive
-days. The first day (15 December 2004) is used as the phase 1 stretch, on
-which we will build both the univariate chart limits and the multivariate
-model. The second day onwards is the phase 2 stretch, against which both
-charts are evaluated.
+days. The first 479 observations (15 December 2004) were visibly unsettled
+and make a poor in-control reference, so we discard them entirely. Phase 1
+is the next 1000 observations (250 2-minute subgroups, plenty for fitting a
+2-component PCA model on five variables) and phase 2 is everything after
+that (1443 observations, 360 subgroups). Both the univariate chart limits
+and the multivariate model are built on phase 1, and both charts are then
+evaluated on phase 2.
 
 Loading the data and setting up the phase split:
 
@@ -62,13 +65,14 @@ Loading the data and setting up the phase split:
 	flot = pd.read_csv("https://openmv.net/file/flotation-cell.csv")
 	num = flot.drop(columns=["Date and time"])
 
-	N_phase1 = 479
-	phase1 = num.iloc[:N_phase1]
-	phase2 = num.iloc[N_phase1:]
+	N_DROP = 479           # discard the unsettled startup stretch
+	N_PHASE1_RAW = 1000    # next 1000 raw obs = 250 subgroups of 4
+	phase1 = num.iloc[N_DROP : N_DROP + N_PHASE1_RAW].reset_index(drop=True)
+	phase2 = num.iloc[N_DROP + N_PHASE1_RAW :].reset_index(drop=True)
 	print(f"phase1 shape: {phase1.shape}  phase2 shape: {phase2.shape}")
 
-This gives 479 phase-1 observations on 15 December and 2442 phase-2
-observations from 16 December onwards.
+This gives 1000 raw phase-1 observations and 1443 raw phase-2 observations
+(or 250 vs. 360 subgroups of size 4).
 
 .. _APPS_multivariate_monitoring_univariate:
 
@@ -109,11 +113,11 @@ those same limits to phase-2 subgroups:
 	first_alarm_p2 = int(np.where((xbar_p2 < lcl) | (xbar_p2 > ucl))[0][0])
 	print(f"first phase-2 alarm at subgroup index {first_alarm_p2}")
 
-The 99.7% Shewhart limits on the feed rate come out at :math:`325.5 \pm 24.4`
-(LCL = 301.0, UCL = 349.9), no phase-1 alarms, and the **first phase-2 alarm
-appears at subgroup 62** -- about two hours into 16 December. The trace below
-shows the phase-1 subgroups (in black) and the phase-2 subgroups (in blue),
-with the limits derived from phase 1 carried across:
+The 99.7% Shewhart limits on the feed rate come out at :math:`341.6 \pm 22.5`
+(LCL = 319.1, UCL = 364.1), no phase-1 alarms, and the **first phase-2 alarm
+appears at subgroup 105** -- about 3.5 hours into the monitoring period. The
+trace below shows the phase-1 subgroups (in black) and the phase-2 subgroups
+(in blue), with the limits derived from phase 1 carried across:
 
 .. code-block:: python
 
@@ -124,10 +128,10 @@ with the limits derived from phase 1 carried across:
 	fig = go.Figure()
 	fig.add_trace(go.Scatter(x=idx_p1, y=xbar_p1, mode="lines+markers",
 		line=dict(color="black"), marker=dict(size=4, color="black"),
-		name="Phase 1 (15 Dec)"))
+		name="Phase 1 (training, 250 subgroups)"))
 	fig.add_trace(go.Scatter(x=idx_p2, y=xbar_p2, mode="lines+markers",
 		line=dict(color="#1f77b4"), marker=dict(size=4, color="#1f77b4"),
-		name="Phase 2 (16 Dec onwards)"))
+		name="Phase 2 (monitoring, 360 subgroups)"))
 	fig.add_hline(y=target, line_color="grey", line_dash="dot",
 		annotation_text="target")
 	fig.add_hline(y=ucl, line_color="red", line_dash="dash",
@@ -149,11 +153,11 @@ with the limits derived from phase 1 carried across:
 
 	Shewhart chart on ``Feed rate`` (subgroup size 4, 2-minute aggregation):
 	phase-1 subgroups in black, phase-2 subgroups in blue, 3-sigma limits
-	(``LCL = 301.0`` and ``UCL = 349.9``) carried across from phase 1. The
-	first phase-2 alarm sits at subgroup 62, ~2 hours into 16 December.
+	(``LCL = 319.1`` and ``UCL = 364.1``) carried across from phase 1. The
+	first phase-2 alarm sits at subgroup 105, about 3.5 hours in.
 
 The chart does flag the disturbance eventually, but the first alarm sits at
-subgroup 62, with the disturbance well-established by that point. The
+subgroup 105, with the disturbance well-established by that point. The
 question is whether the other four tags carry information that, combined
 with feed rate, would have caught the shift earlier.
 
@@ -183,7 +187,7 @@ away.
 	p2_sub = subgroup_means(phase2, n_sub)
 	print(f"phase 1 subgroups: {p1_sub.shape}   phase 2 subgroups: {p2_sub.shape}")
 
-This gives 119 phase-1 subgroups and 610 phase-2 subgroups. We centre
+This gives 250 phase-1 subgroups and 360 phase-2 subgroups. We centre
 and scale the 5 tags using their phase-1 subgroup means and standard
 deviations, then fit a :math:`A`-component PCA on phase 1 only. The
 cumulative :math:`R^2_X` tells us how much joint variability each latent
@@ -198,8 +202,8 @@ variable picks up:
 	model3 = PCA(n_components=3).fit(scaler.transform(p1_sub))
 	print("R^2 cumulative (3 components):", model3.r2_cumulative_.values)
 
-A 2-component model captures :math:`R^2_X \approx [0.38, 0.61]` (38% and an
-extra 23%, for a cumulative 61%), and a third component adds another 21%.
+A 2-component model captures :math:`R^2_X \approx [0.33, 0.63]` (33% and an
+extra 29%, for a cumulative 63%), and a third component adds another 15%.
 Two components are enough to demonstrate the monitoring idea, so we proceed
 with the 2-component model.
 
@@ -216,9 +220,9 @@ where the in-control operating region lies in score space:
 	:scale: 80
 	:align: center
 
-	Phase-1 score plot (119 subgroup means from 15 December) with the 95%
-	:math:`T^2` ellipse drawn in. The in-control cloud sits inside the
-	ellipse and is roughly centred at the origin.
+	Phase-1 score plot (250 subgroup means from the chosen training stretch)
+	with the 95% :math:`T^2` ellipse drawn in. The in-control cloud sits
+	inside the ellipse and is roughly centred at the origin.
 
 The phase-1 cloud is roughly elliptical and centred at the origin -- exactly
 what we want from a stable operating period. The loadings tell us which raw
@@ -278,10 +282,11 @@ read out two diagnostics:
 	print(f"first T^2 alarm at phase-2 subgroup {first_t2}")
 	print(f"first SPE alarm at phase-2 subgroup {first_spe}")
 
-The 95% T² limit is 6.25 and the 95% SPE limit is 2.38. **Both diagnostics
-first alarm at phase-2 subgroup 5**, about ten minutes into 16 December.
-Compare that with ~120 minutes of feed-rate Shewhart silence before its
-first alarm at subgroup 62. Drawing the two multivariate traces side by
+The 95% T² limit is 6.11 and the 95% SPE limit is 2.36. **The first
+phase-2 SPE alarm comes at subgroup 1 and the first T² alarm at subgroup
+6** -- both within twelve minutes of the monitoring period starting.
+Compare that with ~3.5 hours of feed-rate Shewhart silence before its
+first alarm at subgroup 105. Drawing the two multivariate traces side by
 side with their 95% limits:
 
 .. code-block:: python
@@ -310,14 +315,14 @@ side with their 95% limits:
 	:scale: 80
 	:align: center
 
-	Hotelling's :math:`T^2` (top, 95% limit at 6.25) and SPE (bottom, 95%
-	limit at 2.38) on the 610 phase-2 subgroups. Both first cross their
-	limit at subgroup 5 (~10 minutes into 16 December) and stay elevated
-	through most of the day.
+	Hotelling's :math:`T^2` (top, 95% limit at 6.11) and SPE (bottom, 95%
+	limit at 2.36) on the 360 phase-2 subgroups. The SPE first crosses
+	its limit at subgroup 1, the :math:`T^2` at subgroup 6; both stay
+	elevated through the rest of the monitoring period.
 
-Both diagnostics rise within minutes of 16 December starting and stay
-elevated for most of the day -- a much earlier and stronger signal than the
-univariate chart on feed rate alone.
+Both diagnostics rise within minutes of the monitoring period starting
+and stay elevated for most of it -- a much earlier and stronger signal
+than the univariate chart on feed rate alone.
 
 .. _APPS_multivariate_monitoring_contribution:
 
@@ -325,42 +330,47 @@ Diagnosing the alarm: contribution plot
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :math:`T^2` and SPE statistics tell us *that* the operation has moved
-off-spec; the contribution plot tells us *which* tag drove the alarm. For an
-SPE alarm, the per-variable contribution is :math:`(x_k - \hat{x}_k)^2` in
-the centred-and-scaled space:
+off-spec; the contribution plot tells us *which* tag drove the alarm.
+``PCA.score_contributions(t_start, weighted=True)`` decomposes the score
+vector at the alarm back into variable space via the loadings, with each
+component re-weighted by :math:`1 / \sqrt{\lambda_a}` so the result is a
+contribution to :math:`T^2` rather than to a raw Euclidean distance in
+score space:
 
 .. code-block:: python
 
-	first_alarm = int(flagged_spe.index[0])
-	row_scaled = scaler.transform(p2_sub).loc[first_alarm].values
-	row_hat = row_scaled @ model.loadings_.values @ model.loadings_.values.T
-	contribs = pd.Series((row_scaled - row_hat) ** 2,
-		index=p1_sub.columns, name="SPE contribution")
+	first_alarm = int(flagged_t2.index[0])
+	t_at_alarm = result.scores.loc[first_alarm].values
+	contribs = model.score_contributions(t_at_alarm, weighted=True)
 
 	fig = go.Figure(go.Bar(x=contribs.index, y=contribs.values,
-		marker_color="#d62728"))
+		marker_color="#4c72b0"))
+	fig.add_hline(y=0, line_color="black", line_width=0.6)
 	fig.update_layout(
-		title=f"SPE contributions at phase-2 subgroup {first_alarm} (16 Dec, first SPE alarm)",
-		yaxis_title="(x_k - x_hat_k)^2 in scaled units", height=380,
+		title=f"T^2 contributions at phase-2 subgroup {first_alarm} (first T^2 alarm)",
+		yaxis_title="Contribution to T^2 (scaled units)", height=380,
 		margin=dict(l=70, r=20, t=60, b=80))
 	fig.show()
 
 .. figure:: ../figures/monitoring/Flotation-MSPC-contributions.png
-	:alt: Per-variable SPE contributions at the first phase-2 SPE alarm.
+	:alt: Per-variable T^2 contributions at the first phase-2 T^2 alarm.
 	:width: 700px
 	:scale: 80
 	:align: center
 
-	Per-variable contributions to SPE at phase-2 subgroup 5 (16 Dec, first
-	SPE alarm). ``Pulp level`` (5.8) and ``Feed rate`` (3.8) dominate;
-	``Upstream pH`` is a distant third (1.3). ``CuSO4 added`` and ``Air
-	flow rate`` are essentially in pattern.
+	Per-variable contributions to :math:`T^2` at phase-2 subgroup 6
+	(first :math:`T^2` alarm). All five variables contribute in the same
+	direction with comparable magnitude: ``Air flow rate`` (-1.37),
+	``Feed rate`` (-1.22), ``CuSO4 added`` (-1.22), ``Upstream pH``
+	(-1.17), and ``Pulp level`` (-1.05). The subgroup has shifted away
+	from the model centre along PC1 (and a little along PC2) in a
+	balanced way: no single tag dominates.
 
-At the first SPE alarm, **``Pulp level`` and ``Feed rate``** carry the
-largest contributions (5.8 and 3.8 respectively in scaled-squared units),
-with ``Upstream pH`` a distant third (1.3). The contribution plot points
-the operator straight at the two tags worth investigating, without having
-to scan all five line plots by eye.
+At the first :math:`T^2` alarm, the shift is **balanced across all five
+process tags** -- they are all about one scaled standard deviation off,
+in the same direction. That is a different diagnostic story from "one
+variable went rogue": it points the operator at the *joint* operating
+point rather than at one valve or one analyser.
 
 .. _APPS_multivariate_monitoring_compare:
 
@@ -369,7 +379,7 @@ What the multivariate chart catches that the univariate chart misses
 
 To make the comparison concrete we plot the ``Feed rate`` subgroup mean
 (left axis, blue) and the multivariate Hotelling's :math:`T^2` (right
-axis, red) on the same time axis -- 610 phase-2 subgroups, each two
+axis, red) on the same time axis -- 360 phase-2 subgroups, each two
 minutes apart:
 
 .. code-block:: python
@@ -405,29 +415,32 @@ minutes apart:
 	:math:`T^2` of the 5-variable subgroup mean (right axis, red), on a
 	shared subgroup-index x-axis. Dashed lines on each axis are the 95 %
 	limits; vertical dotted lines mark the first alarm on each chart. The
-	multivariate :math:`T^2` (subgroup 5) leads the univariate Shewhart
-	(subgroup 62) by 57 subgroups, or about 114 minutes.
+	multivariate :math:`T^2` (subgroup 6) leads the univariate Shewhart
+	(subgroup 105) by 99 subgroups, or about 198 minutes (~3.3 hours).
 
 Putting the two stories side by side:
 
 * The univariate Shewhart chart on ``Feed rate`` is silent through all
-  of phase 1 (as it should be) and only alarms at subgroup 62 of phase 2,
-  about **two hours** into the new day. By the time it alarms, the
-  disturbance has grown large enough to push the subgroup mean past the
-  3-sigma limit on this *single* tag.
+  of phase 1 (as it should be) and only alarms at subgroup 105 of
+  phase 2, about **3.5 hours** into the monitoring period. By the time
+  it alarms, the disturbance has grown large enough to push the
+  subgroup mean past the 3-sigma limit on this *single* tag.
 * The multivariate :math:`T^2` chart -- on the *same* 2-minute subgroups
-  -- alarms at phase-2 subgroup 5, about **ten minutes** into the new day.
-  The SPE chart alarms at the same subgroup. Both diagnose the cause as a
-  joint shift in ``Pulp level`` and ``Feed rate``.
+  -- alarms at phase-2 subgroup 6, about **twelve minutes** in, and the
+  SPE chart alarms at subgroup 1, almost immediately. The contribution
+  decomposition at the :math:`T^2` alarm shows the upset as a
+  *balanced* joint shift across all five process tags, not as one
+  variable misbehaving.
 
-The ~110-minute gap is the multivariate dividend on this dataset, and
+The ~200-minute gap is the multivariate dividend on this dataset, and
 the fair-comparison qualifier matters: both charts are aggregating the
 same data into the same 2-minute subgroups, so the dividend cannot be
 explained away by saying "the multivariate chart just samples faster".
 It comes from the fact that the disturbance is initially small in each
 individual tag (no single tag is yet outside its own 3-sigma band) but
 it has already broken the *correlation structure* the model learned in
-phase 1 -- and the SPE statistic catches that violation directly.
+phase 1 -- and both the :math:`T^2` and SPE statistics catch that
+violation directly.
 
 This is the same pattern :ref:`monitoring is not feedback control
 <monitoring_is_not_feedback_control>` warned about in chapter 3: catching


### PR DESCRIPTION
## Summary

Two structural updates to the §7.3 multivariate-monitoring case study, requested in this session as a follow-up to PR #92.

### 1. Phase split redefined (drop the unsettled 15-Dec startup)

The old chapter framed phase 1 as the 479 observations of 15 December and phase 2 as everything from 16 December onwards. The 15-December stretch was visibly unsettled (the R script that originally generated the figures already flagged it that way) and was a poor in-control reference. The phase-1 model picked up noise instead of legitimate operating structure, and the resulting phase-2 alarm rates were inflated.

New scheme:

- Drop the first 479 raw observations entirely.
- Take the next 1000 raw observations (250 2-minute subgroups) as phase 1.
- Everything after that is phase 2 (1443 raw observations, 360 subgroups).

### 2. Contribution decomposition via the library API

The contribution code block is now `model.score_contributions(t_at_alarm, weighted=True)` instead of the manual `(row - row_hat) ** 2` arithmetic. It returns a `pd.Series` of T²-style variable contributions decomposed via the loadings and per-component explained variances. The contribution figure is now pinned to the first T² alarm subgroup rather than the first SPE alarm.

`PCA` in `process-improve` doesn't currently expose a per-variable SPE contribution; `score_contributions(weighted=True)` is the closest standard contribution-plot semantics that the library covers.

## Refreshed numbers (reproduced end-to-end)

| Quantity | Old (post-PR-92) | New (this PR) |
|----------|------------------|---------------|
| Phase 1 size | 119 subgroups | 250 subgroups |
| Phase 2 size | 610 subgroups | 360 subgroups |
| R² cumulative (2 comp) | [0.380, 0.611] | [0.334, 0.626] |
| Shewhart target / LCL / UCL | 325.5 / 301.0 / 349.9 | 341.6 / 319.1 / 364.1 |
| 95 % T² limit | 6.25 | 6.11 |
| 95 % SPE limit | 2.38 | 2.36 |
| First multivariate T² alarm | subgroup 5 | **subgroup 6** |
| First multivariate SPE alarm | subgroup 5 | **subgroup 1** |
| First Shewhart Feed-rate alarm | subgroup 62 | **subgroup 105** |
| Dividend | ~114 min | **~198 min (~3.3 h)** |

At the first T² alarm, the score-space contributions are roughly uniform across all five process tags (`Air flow rate` -1.37, `Feed rate` -1.22, `CuSO4 added` -1.22, `Upstream pH` -1.17, `Pulp level` -1.05). That's a "balanced joint shift" story, different from the previous SPE-narrative where one or two tags clearly dominated.

## Companion PR

[`kgdunn/figures` #5](https://github.com/kgdunn/figures/pull/5) -- regenerates the six `Flotation-MSPC-*.png` figures against the new phase split, switches the contribution computation to `score_contributions`, and deletes seven legacy R-script flotation outputs that no chapter referenced.

## Test plan

- [x] All chapter code blocks dry-run verbatim against the openmv CSV; every cited number reproduces.
- [x] `make text` -- clean, zero warnings.
- [x] The seven .. figure:: directives resolve once figures #5 lands.

https://claude.ai/code/session_01Y83gT2kRtM6f97TcGZgSEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y83gT2kRtM6f97TcGZgSEs)_