### PR TITLE
§7.3: replace ≈ (U+2248) with :math: \approx to fix the PDF build

### DIFF
--- a/product-development-product-improvement/multivariate-process-monitoring.rst
+++ b/product-development-product-improvement/multivariate-process-monitoring.rst
@@ -122,11 +122,12 @@ envelope:
 	there is a slow negative-then-positive oscillation that reflects
 	real periodic structure in the flotation cell, not noise.
 
-The short-range autocorrelation is large (`rho_1` is around 0.87, and
-`rho_k` does not drop within the noise band until k ≈ 9) so monitoring
-the raw 30-second samples with Shewhart limits would over-flag. Averaging
-each block of :math:`n = 8` consecutive samples into a 4-minute subgroup
-mean takes us through the most autocorrelated lags; the residual
+The short-range autocorrelation is large (:math:`\rho_1` is around 0.87,
+and :math:`\rho_k` does not drop within the noise band until
+:math:`k \approx 9`) so monitoring the raw 30-second samples with
+Shewhart limits would over-flag. Averaging each block of :math:`n = 8`
+consecutive samples into a 4-minute subgroup mean takes us through the
+most autocorrelated lags; the residual
 oscillation at longer lags is process behaviour that we want the chart to
 *see*, not noise we want to smooth out. We therefore use :math:`n_\text{sub} = 8`
 throughout the case study, for both the univariate chart below and the


### PR DESCRIPTION
## Summary

The PDF (LaTeX) build of `pid-book` uses pdflatex, which doesn't know the Unicode "approximately equal" character `≈` (U+2248). I introduced it in PR #94's ACF prose:

```
... `rho_k` does not drop within the noise band until k ≈ 9 ...
```

That made the LaTeX build die with:

```
! LaTeX Error: Unicode character ≈ (U+2248) not set up for use with LaTeX.
```

This PR replaces `≈` with `:math:`k \approx 9`` and, for consistency, promotes the adjacent `` `rho_k` `` and `` `rho_1` `` text references to `:math:` so the symbols render correctly in both HTML and PDF.

No other content changes. `make text` is clean; the PDF build should now compile.

## Test plan

- [x] `grep '≈' product-development-product-improvement/multivariate-process-monitoring.rst` returns zero hits.
- [x] `make text` -- clean.
- [ ] CI's `Build PDF` step will run; expected to pass.

https://claude.ai/code/session_01Y83gT2kRtM6f97TcGZgSEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y83gT2kRtM6f97TcGZgSEs)_