### PR TITLE
Add PDF theme comparison harness (preface + monitoring chapter)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,6 +21,6 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-date-released: 2026-05-14
+date-released: 2026-05-16
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,16 @@ SPHINXBUILD   = uv run sphinx-build
 PAPER         =
 BUILDDIR      = _build
 
+# Theme used by `make theme-pdf`: tufte | academic | business
+THEME         ?= tufte
+
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 ALLRELAXEDOPTS  =  -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(RELAXOPTS) .
 
-.PHONY: help setup clean distclean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext whoosh
+.PHONY: help setup clean distclean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext whoosh theme-pdf theme-pdf-all
 
 .DEFAULT_GOAL := latexpdf
 
@@ -35,6 +38,9 @@ help:
 	@echo "  text       to make text files"
 	@echo "  gettext    to make PO message catalogs"
 	@echo "  linkcheck  to check all external links for integrity"
+	@echo "  theme-pdf  to build a carved-off PDF sample (preface + ch.3)"
+	@echo "             with THEME=tufte|academic|business"
+	@echo "  theme-pdf-all  to build all three theme samples"
 
 
 
@@ -136,6 +142,39 @@ latexpdf:
 	else \
 		echo "PDF built at $(BUILDDIR)/latex/PID.pdf (no opener found)."; \
 	fi
+
+# PDF theme comparison harness. Builds a small carved-off sample — the
+# preface plus the process-monitoring chapter — with one alternative LaTeX
+# theme, so several PDF designs can be compared without recompiling the whole
+# book. The theme machinery lives in conf.py, gated on PID_PDF_THEME.
+# Cross-references into the chapters left out of the sample render as plain
+# text; that is expected for a layout preview.
+theme-pdf:	## Build a PDF sample with THEME=tufte|academic|business
+	@case "$(THEME)" in tufte|academic|business) ;; *) \
+		echo "ERROR: THEME must be tufte, academic or business (got '$(THEME)')."; \
+		exit 1;; esac
+	@command -v latexmk >/dev/null 2>&1 || { \
+		echo "ERROR: latexmk not found. See 'make setup'."; \
+		exit 1; \
+	}
+	PID_PDF_THEME=$(THEME) $(SPHINXBUILD) -b latex $(SPHINXOPTS) \
+		-d $(BUILDDIR)/theme-doctrees . $(BUILDDIR)/theme-$(THEME)
+	cp preface/*.png $(BUILDDIR)/theme-$(THEME)
+	cp preface/*.jpg $(BUILDDIR)/theme-$(THEME)
+	@echo "Running LaTeX files through pdflatex..."
+	make -C $(BUILDDIR)/theme-$(THEME) all-pdf
+	@echo
+	@echo "Theme sample: $(BUILDDIR)/theme-$(THEME)/PID-sample-$(THEME).pdf"
+
+theme-pdf-all:	## Build all three theme samples for side-by-side comparison
+	$(MAKE) theme-pdf THEME=tufte
+	$(MAKE) theme-pdf THEME=academic
+	$(MAKE) theme-pdf THEME=business
+	@echo
+	@echo "Theme samples ready:"
+	@echo "  $(BUILDDIR)/theme-tufte/PID-sample-tufte.pdf"
+	@echo "  $(BUILDDIR)/theme-academic/PID-sample-academic.pdf"
+	@echo "  $(BUILDDIR)/theme-business/PID-sample-business.pdf"
 
 text:
 	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text

--- a/conf.py
+++ b/conf.py
@@ -81,6 +81,45 @@ exclude_patterns = [
     "scripts",   # server-side helper scripts — not part of the book
 ]
 
+# -- PDF theme comparison harness ----------------------------------------------
+#
+# Setting the PID_PDF_THEME environment variable switches the LaTeX build to a
+# small, self-contained sample — the preface plus the process-monitoring
+# chapter (see pdf-theme-sample.rst) — rendered with one of several alternative
+# PDF "themes". This makes it possible to compare page designs without
+# recompiling the whole book.
+#
+#   make theme-pdf THEME=tufte       Tufte-inspired (Palatino, wide outer margin)
+#   make theme-pdf THEME=academic    Classic thesis (Latin Modern, justified)
+#   make theme-pdf THEME=business    Business report (Charter + sans headings)
+#
+# Cross-references from the monitoring chapter into chapters that are *not*
+# part of the sample cannot resolve and render as plain text. That is expected:
+# the sample is a layout preview, not a navigable book.
+#
+# When PID_PDF_THEME is unset every builder behaves exactly as before.
+pdf_theme = os.environ.get("PID_PDF_THEME", "").strip().lower()
+_PDF_THEMES = ("tufte", "academic", "business")
+
+if pdf_theme:
+    if pdf_theme not in _PDF_THEMES:
+        raise ValueError(f"PID_PDF_THEME={pdf_theme!r} is not one of {_PDF_THEMES}")
+    root_doc = "pdf-theme-sample"
+    exclude_patterns += [
+        "contents.rst",
+        "privacy.rst",
+        "data-visualization",
+        "univariate-review",
+        "least-squares-modelling",
+        "design-analysis-experiments",
+        "latent-variable-modelling",
+        "product-development-product-improvement",
+    ]
+else:
+    # Keep the sample root document out of the normal html / text / epub
+    # builds so it does not warn "isn't included in any toctree".
+    exclude_patterns.append("pdf-theme-sample.rst")
+
 add_function_parentheses = True
 pygments_style = "sphinx"
 
@@ -623,6 +662,187 @@ latex_elements = {
     #   'docclass' 'classoptions' 'title' 'date' 'release' 'author' 'logo' 'releasename'
     #   'makeindex' 'shorthandoff'
 }
+
+# -- PDF theme comparison harness: LaTeX themes --------------------------------
+#
+# Everything below only takes effect when PID_PDF_THEME is set; the full-book
+# LaTeX build above is left untouched. A theme is just an override of a few
+# `latex_elements` keys (fonts, chapter style, preamble). Sphinx hardcodes the
+# `sphinxmanual` document class, so a true tufte-book class swap is not
+# possible — these themes vary fonts, margins and heading design instead.
+
+# Scaffolding every theme preamble needs: the custom title page and the
+# header/footer page styles the preface's raw-LaTeX blocks switch between.
+_PREAMBLE_COMMON = r"""
+% ==== BEGIN SHARED THEME PREAMBLE ====
+\usepackage{float}
+\usepackage{cancel}
+\usepackage{upquote}
+\usepackage{textpos}
+\renewcommand{\PYGZsq}{TO AVOID ERROR MESSAGE}
+
+\hypersetup{
+    colorlinks=true,
+    linkcolor=blue,
+    citecolor=black,
+    filecolor=black,
+    urlcolor=blue
+}
+
+% Nicer URLs
+\usepackage{url}
+\makeatletter
+\def\Url@twoslashes{\mathchar`\/\@ifnextchar/{\kern-.2em}{}}
+\g@addto@macro\UrlSpecials{\do\/{\Url@twoslashes}}
+\makeatother
+
+\definecolor{VerbatimColor}{rgb}{1,1,1}
+\definecolor{VerbatimBorderColor}{rgb}{1,1,1}
+\fvset{framesep=8pt}
+
+\makeatletter
+\def\@subtitle{\relax}
+\newcommand{\subtitle}[1]{\gdef\@subtitle{#1}}
+\makeatother
+
+% Custom title page, shared with the full book.
+\makeatletter
+\renewcommand{\releasename}{Version}
+\renewcommand{\maketitle}{%
+  \begin{titlepage}%
+    \let\footnotesize\small
+    \let\footnoterule\relax
+    \rule{\textwidth}{1pt}%
+    \begin{flushright}%
+      {\rm\Huge\py@HeaderFamily \@title \par}%
+      \vfill
+      {\LARGE\py@HeaderFamily \@author \par}
+      \vfill\vfill
+      \includegraphics[scale=0.35]{textbook-logo-no-text.jpg}
+      \\
+      {\large
+       \@date \par
+       \vfill
+       \py@authoraddress \par
+       \vfill
+       {\Large\py@HeaderFamily Version: \py@release\releaseinfo \par}
+      }%
+    \end{flushright}%
+    \@thanks
+  \end{titlepage}%
+  \setcounter{footnote}{0}%
+  \let\thanks\relax\let\maketitle\relax
+}
+\makeatother
+
+% Header / footer page styles. The preface's raw-LaTeX blocks switch between
+% \pagestyle{plain} and \pagestyle{normal}, so both must exist.
+\makeatletter
+\fancypagestyle{normal}{
+  \fancyhf{}
+  \fancyfoot[LE,RO]{{\py@HeaderFamily\thepage}}
+  \fancyfoot[LO]{{\py@HeaderFamily\nouppercase{\rightmark}}}
+  \fancyfoot[RE]{{\py@HeaderFamily\nouppercase{\leftmark}}}
+  \fancyhead[LE]{{\py@HeaderFamily \@title}}
+  \fancyhead[RO]{{\py@HeaderFamily \py@release}}
+  \renewcommand{\headrulewidth}{0.4pt}
+  \renewcommand{\footrulewidth}{0.4pt}
+}
+\fancypagestyle{plain}{
+  \fancyhf{}
+  \fancyfoot[LE,RO]{{\py@HeaderFamily\thepage}}
+  \renewcommand{\headrulewidth}{0pt}
+  \renewcommand{\footrulewidth}{0.4pt}
+}
+\makeatother
+% ==== END SHARED THEME PREAMBLE ====
+"""
+
+# Theme 1 — Tufte-inspired: Palatino body, wide outer margin, ragged-right.
+# geometry is loaded with no options (Sphinx already loads it; passing options
+# to \usepackage a second time triggers an "option clash"), then configured
+# with \geometry — the same pattern the full-book preamble uses.
+_PREAMBLE_TUFTE = r"""
+% ==== TUFTE-INSPIRED THEME ====
+\usepackage{geometry}
+\geometry{a4paper,left=1.1in,right=1.7in,top=1.0in,height=9.0in,footskip=0.5in}
+\usepackage{microtype}
+% Ragged right with hyphenation, after tufte-latex.github.io.
+\usepackage{ragged2e}
+\makeatletter
+\setlength{\RaggedRightRightskip}{\z@ plus 0.08\hsize}
+\makeatother
+\AtBeginDocument{\RaggedRight}
+% ==== END TUFTE-INSPIRED THEME ====
+"""
+
+# Theme 2 — Classic academic: Latin Modern, symmetric margins, justified.
+_PREAMBLE_ACADEMIC = r"""
+% ==== CLASSIC ACADEMIC / THESIS THEME ====
+\usepackage{geometry}
+\geometry{a4paper,margin=1.25in,footskip=0.5in}
+\usepackage{microtype}
+\linespread{1.05}
+% ==== END CLASSIC ACADEMIC / THESIS THEME ====
+"""
+
+# Theme 3 — Business professional: Charter body, sans accented headings.
+_PREAMBLE_BUSINESS = r"""
+% ==== BUSINESS PROFESSIONAL THEME ====
+\usepackage{geometry}
+\geometry{a4paper,left=1.2in,right=1.2in,top=1.1in,height=9.0in,footskip=0.55in}
+\usepackage{microtype}
+\usepackage[scaled=0.92]{helvet}
+\usepackage{titlesec}
+\definecolor{accent}{HTML}{1F4E79}
+% Sans-serif, accent-coloured headings.
+\titleformat{\chapter}[display]
+  {\sffamily\bfseries\color{accent}}
+  {\filright\Large\MakeUppercase{\chaptertitlename}\ \Huge\thechapter}
+  {1ex}
+  {\titlerule[1.5pt]\vspace{1ex}\filright\Huge}
+\titlespacing*{\chapter}{0pt}{10pt}{2.5ex}
+\titleformat{\section}
+  {\sffamily\Large\bfseries\color{accent}}{\thesection}{1em}{}
+\titleformat{\subsection}
+  {\sffamily\large\bfseries\color{accent!85!black}}{\thesubsection}{1em}{}
+% ==== END BUSINESS PROFESSIONAL THEME ====
+"""
+
+_THEME_ELEMENTS = {
+    "tufte": {
+        "fontpkg": "\\usepackage{palatino}",
+        "fncychap": "\\usepackage[Sonny]{fncychap}",
+        "preamble": _PREAMBLE_COMMON + _PREAMBLE_TUFTE,
+    },
+    "academic": {
+        "fontpkg": "\\usepackage{lmodern}",
+        "fncychap": "\\usepackage[Lenny]{fncychap}",
+        "preamble": _PREAMBLE_COMMON + _PREAMBLE_ACADEMIC,
+    },
+    "business": {
+        # fncychap is disabled so titlesec can restyle \chapter cleanly.
+        "fontpkg": "\\usepackage{charter}",
+        "fncychap": "",
+        "preamble": _PREAMBLE_COMMON + _PREAMBLE_BUSINESS,
+    },
+}
+
+if pdf_theme:
+    latex_documents = [
+        (
+            "pdf-theme-sample",
+            f"PID-sample-{pdf_theme}.tex",
+            "Process Improvement Using Data",
+            "Kevin Dunn",
+            "manual",
+            True,
+        ),
+    ]
+    latex_elements = {**latex_elements, **_THEME_ELEMENTS[pdf_theme]}
+    # Page references to chapters outside the sample cannot resolve; drop them
+    # so the preview is not littered with "??".
+    latex_show_pagerefs = False
 
 # -- Options for Epub output ---------------------------------------------------
 

--- a/pdf-theme-sample.rst
+++ b/pdf-theme-sample.rst
@@ -1,0 +1,31 @@
+.. This is the root document for the PDF theme-comparison harness.
+.. It is NOT part of the book: the normal html / text / epub builds exclude
+.. it (see conf.py, the PID_PDF_THEME block). It is rendered only when the
+.. LaTeX build is run with the PID_PDF_THEME environment variable set, in
+.. which case it carves off a small sample — this preface plus the
+.. process-monitoring chapter — so alternative PDF themes can be compared
+.. without recompiling the whole book.
+..
+.. Build it with, e.g.:   make theme-pdf THEME=academic
+..
+.. Cross-references from the monitoring chapter into chapters that are not
+.. part of the sample cannot resolve and render as plain text. That is
+.. expected: this is a layout preview, not a navigable book.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+Process Improvement Using Data
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+.. toctree::
+   :hidden:
+
+   preface/index
+
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :maxdepth: 3
+   :caption: Table of Contents
+
+   process-monitoring/index


### PR DESCRIPTION
## Summary

The full book is slow to compile, which makes trying alternative PDF page
designs tedious. This adds a **carved-off sample** — the preface plus the
process-monitoring chapter — that builds on its own with one of three
swappable LaTeX themes, so layouts can be compared quickly without
recompiling everything.

### What changed

- **`pdf-theme-sample.rst`** (new) — a sample-only root document with a
  toctree of just `preface/index` + `process-monitoring/index`.
- **`conf.py`** — a `PID_PDF_THEME`-gated block. When the env var is set the
  LaTeX build switches to the sample and applies one theme; when unset
  **every builder behaves exactly as before** (the full-book `latex_documents`
  / `latex_elements` / `_PREAMBLE` are untouched).
- **`Makefile`** — `make theme-pdf THEME=tufte|academic|business` and
  `make theme-pdf-all`.
- **`CITATION.cff`** — `date-released` bumped to 2026-05-16 (build change).

### The three themes

| Theme | Look |
|-------|------|
| `tufte` | Palatino body, wide outer margin, ragged-right — refines today's PDF |
| `academic` | Latin Modern, justified text, symmetric margins, Lenny chapters — thesis feel |
| `business` | Charter body with sans-serif, accent-coloured (`#1F4E79`) headings |

A true `tufte-book` *documentclass* swap is not possible — Sphinx hardcodes
`sphinxmanual` — so the themes vary fonts, margins and heading design instead.

### Expected behaviour

Cross-references from the monitoring chapter into chapters left out of the
sample cannot resolve and render as plain text (~21 "undefined label"
warnings). This is expected: the sample is a layout preview, not a navigable
book. The build still succeeds.

## Test plan

- [x] `make text` (full book) — 0 warnings
- [x] `make html` (full book) — 0 warnings, no `goatcounter` in output
- [x] All three themes generate `PID-sample-<theme>.tex` containing only the
      preface + monitoring chapter
- [ ] `make theme-pdf-all` through `latexmk` — **must be run locally**; this
      environment has no TeX toolchain. `geometry` is loaded with the
      no-option pattern to avoid an option clash with Sphinx's own load.
- [ ] `make latexpdf` (full book) unaffected — the no-theme LaTeX config path
      is unchanged; please confirm locally.

https://claude.ai/code/session_0165rFN5CfK8Ta2esSq8Tcmk

---
_Generated by [Claude Code](https://claude.ai/code/session_0165rFN5CfK8Ta2esSq8Tcmk)_