### PR TITLE
Add "business-ragged" PDF theme (business look, ragged-right, compact code)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ help:
 	@echo "  gettext    to make PO message catalogs"
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  theme-pdf  to build a carved-off PDF sample (preface + ch.3)"
-	@echo "             with THEME=tufte|academic|business"
-	@echo "  theme-pdf-all  to build all three theme samples"
+	@echo "             with THEME=tufte|academic|business|business-ragged"
+	@echo "  theme-pdf-all  to build every theme sample"
 
 
 
@@ -149,9 +149,9 @@ latexpdf:
 # book. The theme machinery lives in conf.py, gated on PID_PDF_THEME.
 # Cross-references into the chapters left out of the sample render as plain
 # text; that is expected for a layout preview.
-theme-pdf:	## Build a PDF sample with THEME=tufte|academic|business
-	@case "$(THEME)" in tufte|academic|business) ;; *) \
-		echo "ERROR: THEME must be tufte, academic or business (got '$(THEME)')."; \
+theme-pdf:	## Build a PDF sample with THEME=tufte|academic|business|business-ragged
+	@case "$(THEME)" in tufte|academic|business|business-ragged) ;; *) \
+		echo "ERROR: THEME must be tufte, academic, business or business-ragged (got '$(THEME)')."; \
 		exit 1;; esac
 	@command -v latexmk >/dev/null 2>&1 || { \
 		echo "ERROR: latexmk not found. See 'make setup'."; \
@@ -166,15 +166,17 @@ theme-pdf:	## Build a PDF sample with THEME=tufte|academic|business
 	@echo
 	@echo "Theme sample: $(BUILDDIR)/theme-$(THEME)/PID-sample-$(THEME).pdf"
 
-theme-pdf-all:	## Build all three theme samples for side-by-side comparison
+theme-pdf-all:	## Build every theme sample for side-by-side comparison
 	$(MAKE) theme-pdf THEME=tufte
 	$(MAKE) theme-pdf THEME=academic
 	$(MAKE) theme-pdf THEME=business
+	$(MAKE) theme-pdf THEME=business-ragged
 	@echo
 	@echo "Theme samples ready:"
 	@echo "  $(BUILDDIR)/theme-tufte/PID-sample-tufte.pdf"
 	@echo "  $(BUILDDIR)/theme-academic/PID-sample-academic.pdf"
 	@echo "  $(BUILDDIR)/theme-business/PID-sample-business.pdf"
+	@echo "  $(BUILDDIR)/theme-business-ragged/PID-sample-business-ragged.pdf"
 
 text:
 	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text

--- a/conf.py
+++ b/conf.py
@@ -92,6 +92,9 @@ exclude_patterns = [
 #   make theme-pdf THEME=tufte       Tufte-inspired (Palatino, wide outer margin)
 #   make theme-pdf THEME=academic    Classic thesis (Latin Modern, justified)
 #   make theme-pdf THEME=business    Business report (Charter + sans headings)
+#   make theme-pdf THEME=business-ragged
+#                                    business, but ragged-right throughout and
+#                                    with compact, upright-comment code listings
 #
 # Cross-references from the monitoring chapter into chapters that are *not*
 # part of the sample cannot resolve and render as plain text. That is expected:
@@ -99,7 +102,7 @@ exclude_patterns = [
 #
 # When PID_PDF_THEME is unset every builder behaves exactly as before.
 pdf_theme = os.environ.get("PID_PDF_THEME", "").strip().lower()
-_PDF_THEMES = ("tufte", "academic", "business")
+_PDF_THEMES = ("tufte", "academic", "business", "business-ragged")
 
 if pdf_theme:
     if pdf_theme not in _PDF_THEMES:
@@ -383,7 +386,14 @@ latex_show_urls = "footnote"
 class CustomLatexFormatter(LatexFormatter):
     def __init__(self, **options):
         super(CustomLatexFormatter, self).__init__(**options)
-        self.verboptions = r"formatcom=\footnotesize,frame=lines"
+        if pdf_theme == "business-ragged":
+            # Compact code listings (8pt/10pt), matching the current book —
+            # that theme runs at an 11pt base where \footnotesize is larger.
+            self.verboptions = (
+                r"formatcom=\fontsize{8pt}{10pt}\selectfont,frame=lines"
+            )
+        else:
+            self.verboptions = r"formatcom=\footnotesize,frame=lines"
 
 
 PygmentsBridge.latex_formatter = CustomLatexFormatter
@@ -809,6 +819,18 @@ _PREAMBLE_BUSINESS = r"""
 % ==== END BUSINESS PROFESSIONAL THEME ====
 """
 
+# Ragged-right snippet — no fully justified text anywhere, after
+# tufte-latex.github.io. Appended to a theme's preamble.
+_PREAMBLE_RAGGED = r"""
+% ==== RAGGED-RIGHT (no full justification) ====
+\usepackage{ragged2e}
+\makeatletter
+\setlength{\RaggedRightRightskip}{\z@ plus 0.08\hsize}
+\makeatother
+\AtBeginDocument{\RaggedRight}
+% ==== END RAGGED-RIGHT ====
+"""
+
 _THEME_ELEMENTS = {
     "tufte": {
         "fontpkg": "\\usepackage{palatino}",
@@ -825,6 +847,14 @@ _THEME_ELEMENTS = {
         "fontpkg": "\\usepackage{charter}",
         "fncychap": "",
         "preamble": _PREAMBLE_COMMON + _PREAMBLE_BUSINESS,
+    },
+    # The business theme, but ragged-right throughout (no justified text).
+    # Code listings are compact (see CustomLatexFormatter) with upright
+    # comments (see pygments_style, set in the PID_PDF_THEME block below).
+    "business-ragged": {
+        "fontpkg": "\\usepackage{charter}",
+        "fncychap": "",
+        "preamble": _PREAMBLE_COMMON + _PREAMBLE_BUSINESS + _PREAMBLE_RAGGED,
     },
 }
 
@@ -843,6 +873,10 @@ if pdf_theme:
     # Page references to chapters outside the sample cannot resolve; drop them
     # so the preview is not littered with "??".
     latex_show_pagerefs = False
+    if pdf_theme == "business-ragged":
+        # Upright (non-italic) comments in code listings. Only the LaTeX
+        # builder runs during a theme build, so the HTML book is untouched.
+        pygments_style = "my-extensions.pygments_upright.UprightCommentSphinxStyle"
 
 # -- Options for Epub output ---------------------------------------------------
 

--- a/my-extensions/pygments_upright.py
+++ b/my-extensions/pygments_upright.py
@@ -1,0 +1,28 @@
+"""Pygments style for the PDF theme harness.
+
+A copy of Sphinx's built-in ``sphinx`` style with ``italic`` swapped to
+``noitalic`` on every comment token, so code-listing comments render upright.
+Used only by the ``business-ragged`` PDF theme — see the PID_PDF_THEME block
+in ``conf.py``. Nothing else (the full book, the HTML build) is affected.
+"""
+
+from sphinx.pygments_styles import SphinxStyle
+
+
+def _upright(value):
+    """Return *value* with the standalone ``italic`` keyword turned upright.
+
+    Word-wise so that ``noitalic`` (which contains ``italic``) is left alone.
+    """
+    return " ".join(
+        "noitalic" if word == "italic" else word for word in value.split()
+    )
+
+
+class UprightCommentSphinxStyle(SphinxStyle):
+    """The ``sphinx`` style, but with non-italic comments."""
+
+    styles = {
+        token: (_upright(value) if "Comment" in str(token) else value)
+        for token, value in SphinxStyle.styles.items()
+    }


### PR DESCRIPTION
## Summary

Adds a fourth theme, **`business-ragged`**, to the PDF comparison harness
(follow-up to #96). It mixes the parts of the existing themes that worked
best, per review feedback on the `business` sample:

- **business typography + compact spacing** — Charter body, sans accent
  headings, the tighter business margins;
- **ragged-right throughout** — no fully justified paragraphs anywhere
  (reuses the same `ragged2e` setup as the `tufte` theme);
- **code listings restored to the current book's look** —
  - compact `8pt/10pt` (the business theme runs an 11pt base, where
    `\footnotesize` renders larger than in the current book);
  - upright, **non-italic comments**.

### How the upright comments work

`my-extensions/pygments_upright.py` is a small Pygments style subclass of
Sphinx's `SphinxStyle` that swaps `italic` → `noitalic` on comment tokens.
It is selected via `pygments_style` **only** inside the `business-ragged`
LaTeX build, so the full book and the HTML build keep their italic comments.
Verified in the generated `sphinxhighlight.sty`:

- `business`:        `PYG@tok@c` → `\let\PYG@it=\textit ...` (italic)
- `business-ragged`: `PYG@tok@c` → `...` (no `\textit` — upright)

## Usage

```
make theme-pdf THEME=business-ragged
make theme-pdf-all                     # now builds all four
```

## Test plan

- [x] `make text` (full book) — 0 warnings
- [x] `business-ragged` generates `PID-sample-business-ragged.tex`; ragged-right,
      `\fontsize{8pt}{10pt}` and upright comment tokens all present
- [x] No-theme LaTeX build still emits italic comment tokens — full book and
      HTML unaffected
- [ ] `make theme-pdf THEME=business-ragged` through `latexmk` — **must be run
      locally**; this environment has no TeX toolchain.

https://claude.ai/code/session_0165rFN5CfK8Ta2esSq8Tcmk

---
_Generated by [Claude Code](https://claude.ai/code/session_0165rFN5CfK8Ta2esSq8Tcmk)_