### PR TITLE
Use Inconsolata for PDF code listings

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -540,7 +540,13 @@ _PREAMBLE = r"""
 latex_elements = {
     "papersize": "a4paper",  # paper size ('letter' or 'a4paper').
     "pointsize": "11pt",  # font size ('10pt', '11pt' or '12pt')
-    "fontpkg": "\\usepackage{charter}",
+    "fontpkg": (
+        "\\usepackage{charter}\n"
+        # Inconsolata for code listings, replacing the default Computer
+        # Modern Typewriter. varqu gives upright quotes and varl a straight
+        # lowercase l — both aid code legibility.
+        "\\usepackage[varqu,varl]{inconsolata}\n"
+    ),
     "preamble": _PREAMBLE,
     "figure_align": "H",  # put figures where told
     # fncychap is disabled so titlesec (see _PREAMBLE) can restyle \chapter.


### PR DESCRIPTION
## Summary

The LaTeX build loaded no monospace package, so code listings rendered in
**Computer Modern Typewriter** — the dated academic-LaTeX look that clashes
with the modern Charter body text and the sans-serif headings.

This loads **Inconsolata**, a humanist monospace designed specifically for
code: narrow enough to suit the 9pt listings and a clean pairing with
Charter. The `varqu` and `varl` package options give upright quotes and a
straight lowercase `l`, both of which help code read accurately.

One line of `conf.py` — the `fontpkg` entry of `latex_elements`. HTML is
untouched (it has its own code-font styling); only the PDF changes.

`inconsolata` ships in `texlive-fonts-extra`, which the CI workflow already
installs, so no toolchain change is needed.

## Test plan

- [x] `make latex` — build succeeded; `PID.tex` loads `\usepackage[varqu,varl]{inconsolata}`
- [x] `make text` — build succeeded, zero warnings
- [x] `make html` — build succeeded; `grep -r goatcounter _build/html/contents` → 0 hits
- [ ] **`pdflatex` compile** — not runnable here (no TeX toolchain). CI builds the real PDF, so the font compile is verified there.

https://claude.ai/code/session_0165rFN5CfK8Ta2esSq8Tcmk

---
_Generated by [Claude Code](https://claude.ai/code/session_0165rFN5CfK8Ta2esSq8Tcmk)_