### PR TITLE
Rename the default branch from master to main

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -2,9 +2,9 @@ name: Build and deploy book
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -111,16 +111,16 @@ jobs:
 
       - name: Bump PDF cache-busting date in README
         if: github.event_name != 'pull_request'
-        # Race-safe: each attempt re-syncs to the current origin/master, re-applies
+        # Race-safe: each attempt re-syncs to the current origin/main, re-applies
         # the sed, and retries the push. This avoids the "fetch first" rejection
-        # that happens when origin/master moved between checkout and push.
+        # that happens when origin/main moved between checkout and push.
         run: |
           TODAY=$(date +%Y-%m-%d)
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           for attempt in 1 2 3 4 5; do
-            git fetch origin master
-            git reset --hard origin/master
+            git fetch origin main
+            git reset --hard origin/main
             sed -i -E "s|PID\.pdf(\?[0-9-]*)?|PID.pdf?${TODAY}|g" README.md
             git add README.md
             if git diff --cached --quiet; then
@@ -128,7 +128,7 @@ jobs:
               exit 0
             fi
             git commit -m "chore: bump PDF link date to ${TODAY} [skip ci]"
-            if git push origin HEAD:master; then
+            if git push origin HEAD:main; then
               exit 0
             fi
             echo "Push attempt ${attempt} failed; will refetch and retry."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ operations cookbook live in [`docs/telemetry/`](docs/telemetry/). Read
 A repeatable pattern for sweeping a chapter (or numbered subsection)
 for technical accuracy and reproducible figures. Work on one chapter
 per PR, on the assigned `claude/<slug>` branch, opened as a single
-non-draft PR against `master`.
+non-draft PR against `main`.
 
 ### Step 1 — Read the section end-to-end
 
@@ -197,7 +197,7 @@ For each `.. figure::` directive, insert a small
 - Commit with a descriptive message focused on the *why*. Never
   mention the model identifier.
 - Push to the assigned `claude/...` branch.
-- Open a single non-draft PR per chapter against `master`. Body
+- Open a single non-draft PR per chapter against `main`. Body
   covers: what changed, what didn't, headline numbers verified,
   `make text` / `make html` results. If the underlying analysis is
   unchanged, say so explicitly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,14 +20,14 @@ the [Google Form](https://docs.google.com/forms/d/1IpO-bvJwQwhK64eid4YXwJBvGxN5c
 
 ## Workflow
 
-1. Fork the repo and create a topic branch off `master`.
+1. Fork the repo and create a topic branch off `main`.
 2. Build the book locally (see [README.md](README.md)) and verify your change
    renders correctly in **both HTML and PDF** if it touches content. Math,
    figures, and tables often render differently in the two backends.
 3. Run `make linkcheck` if you added or changed external links.
 4. Commit with a descriptive message. Reference an issue number when relevant
    (e.g. `Fix off-by-one in EWMA limit (#42)`).
-5. Open a pull request against `master`. Describe what changed and, where
+5. Open a pull request against `main`. Describe what changed and, where
    useful, attach a before/after screenshot of the rendered page.
 
 Small, focused PRs are reviewed faster than sweeping ones. If you have a large

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Kevin Dunn. Actively written and updated since August 2010.
 [![License: CC BY-SA 4.0](https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-sa/4.0/)
 [![Read online](https://img.shields.io/badge/read-learnche.org%2Fpid-blue.svg)](https://learnche.org/pid)
 [![Download PDF](https://img.shields.io/badge/download-PDF-red.svg)](https://learnche.org/pid/PID.pdf?2026-05-16)
-[![Build status](https://img.shields.io/github/actions/workflow/status/kgdunn/pid-book/build-deploy.yml?branch=master&label=build)](https://github.com/kgdunn/pid-book/actions/workflows/build-deploy.yml)
+[![Build status](https://img.shields.io/github/actions/workflow/status/kgdunn/pid-book/build-deploy.yml?branch=main&label=build)](https://github.com/kgdunn/pid-book/actions/workflows/build-deploy.yml)
 [![Last commit](https://img.shields.io/github/last-commit/kgdunn/pid-book.svg)](https://github.com/kgdunn/pid-book/commits)
 [![Issues](https://img.shields.io/github/issues/kgdunn/pid-book.svg)](https://github.com/kgdunn/pid-book/issues)
 
@@ -178,9 +178,9 @@ figures/  ───┘                LaTeX ──pdflatex──► PDF    ├�
    search box wired into the sidebar.
 5. **CI/CD.**
    [`.github/workflows/build-deploy.yml`](.github/workflows/build-deploy.yml)
-   runs on every push to and PR against `master`. It checks out both repos,
+   runs on every push to and PR against `main`. It checks out both repos,
    sets up Python 3.12, `uv`, and Node.js, installs a full TeX Live, builds
-   HTML and PDF, and asserts both artifacts exist. On pushes to `master`
+   HTML and PDF, and asserts both artifacts exist. On pushes to `main`
    only, it then rsyncs `_build/html/` and `_build/latex/PID.pdf?2026-05-16` over SSH to
    the learnche.org host (using the `LEARNCHE_SSH_KEY` and
    `LEARNCHE_SSH_USER` repository secrets).
@@ -195,7 +195,7 @@ figures/  ───┘                LaTeX ──pdflatex──► PDF    ├�
   as `text/html`. Reverting this would break inbound links silently.
 * **Pull requests build but do not deploy.** PRs run the full HTML and PDF
   build to catch breakage, but the SSH and rsync steps are gated on
-  `github.event_name != 'pull_request'`. Only pushes to `master` reach the
+  `github.event_name != 'pull_request'`. Only pushes to `main` reach the
   server.
 * **Pagefind needs a custom glob.** Because output files have no `.html`
   extension, Pagefind's default `**/*.html` glob would match nothing. The

--- a/conf.py
+++ b/conf.py
@@ -261,7 +261,7 @@ html_secnumber_suffix = r". "
 
 
 # -- Optional production-only telemetry ----------------------------------------
-# Off by default; enabled in CI for the master/deploy build via env vars.
+# Off by default; enabled in CI for the main/deploy build via env vars.
 # See `_static/js/telemetry.js` and `privacy.rst` for what is collected.
 TELEMETRY_ENABLED = os.environ.get("PID_BOOK_TELEMETRY", "0") == "1"
 TELEMETRY_GC_CODE = os.environ.get("PID_BOOK_GC_CODE", "")

--- a/docs/telemetry/build-and-deploy.md
+++ b/docs/telemetry/build-and-deploy.md
@@ -122,7 +122,7 @@ Two changes in [`.github/workflows/build-deploy.yml`](../../.github/workflows/bu
 ```
 
 * The ternary `github.event_name != 'pull_request' && '1' || '0'`
-  evaluates to `"1"` for `push` (master) and `workflow_dispatch`,
+  evaluates to `"1"` for `push` (main) and `workflow_dispatch`,
   and to `"0"` for `pull_request`. Belt-and-braces: even if this
   condition were wrong, the existing `if: github.event_name !=
   'pull_request'` on the Deploy step (line 126) prevents PR HTML

--- a/docs/telemetry/operations.md
+++ b/docs/telemetry/operations.md
@@ -66,10 +66,10 @@ code and override the GitHub variable.
      `pid-book`).
    * Use a **variable**, not a secret. The site code is not
      credentials — it ends up in every page's HTML.
-4. **Trigger a non-PR build.** Push a small commit to master, or use
+4. **Trigger a non-PR build.** Push a small commit to main, or use
    the **Actions → Build and deploy book → Run workflow** button on
    GitHub. PR builds intentionally ship with telemetry off, so you
-   need a master push or a `workflow_dispatch` to verify.
+   need a main push or a `workflow_dispatch` to verify.
 5. **Verify** by opening any production page in a private window
    with extensions disabled, then watching the GoatCounter dashboard
    for 30 seconds. The hit should appear under "Pages". Type
@@ -191,7 +191,7 @@ and force the env var to `'0'`:
   run: uv run make html
 ```
 
-Push to master. The next deploy ships HTML with no script tag and no
+Push to main. The next deploy ships HTML with no script tag and no
 sparkline mount. The Privacy page remains (it's a published URL; we
 don't 404 it on a whim).
 

--- a/docs/telemetry/server-runbook.md
+++ b/docs/telemetry/server-runbook.md
@@ -31,7 +31,7 @@ your install differs.
   build-sparklines.py         # symlink → /opt/pid-book/scripts/server/build-sparklines.py
   caddy-json-to-combined.py   # symlink → /opt/pid-book/scripts/server/caddy-json-to-combined.py
 
-/opt/pid-book/                # git checkout of kgdunn/pid-book master
+/opt/pid-book/                # git checkout of kgdunn/pid-book main
   scripts/server/             # owns the canonical scripts
 
 /var/log/caddy/
@@ -42,7 +42,7 @@ your install differs.
   access.log*                 # archived pre-Hetzner Apache logs (combined)
 
 /var/www/learnche.org/
-  pid/                        # rsync'd from CI on master push
+  pid/                        # rsync'd from CI on main push
   _stats/                     # public dashboards
     index.html                # GoAccess output
     sparklines.json           # sparkline series


### PR DESCRIPTION
Updates every in-repo reference to the default branch, ahead of the
GitHub-side rename. **See the merge/rename ordering note below — this PR
is one half of a two-part change.**

## What changed

- **`.github/workflows/build-deploy.yml`** — the `push` / `pull_request`
  branch filters (`[master]` → `[main]`), and the README date-bump step's
  `git fetch` / `reset` / `push` commands.
- **`README.md`** — the build-status badge URL (`?branch=master` →
  `?branch=main`) and the CI/CD description prose.
- **`CONTRIBUTING.md`**, **`CLAUDE.md`** — the "open a PR against …"
  guidance.
- **`docs/telemetry/*`** — operational notes that name the deploy branch.
- **`conf.py`** — one comment describing the telemetry build.

Deliberately **not** changed: Sphinx's `master_doc` setting name, the
"master table of contents" wording for `contents.rst`, and a `TODO.md`
URL that legitimately points at another project's own `master` branch.

## Ordering — important

This is safe to merge in **either order** relative to the GitHub rename,
because the README date-bump step only ever runs *inside* a workflow run,
and the workflow only runs once the branch is already `main`. Worst case
is one skipped deploy of unchanged content. Recommended:

1. Rename the default branch on GitHub first (`master` → `main`).
2. Then merge this PR. GitHub auto-retargets this PR to `main` on rename.

While the branch is `main` but this PR is unmerged, CI is briefly dormant
(the live workflow still filters on `master`); merging this PR resumes it.

Note: this PR may itself run **without CI**, since its base is `master`
while the updated workflow filters on `main`. It is a workflow/docs-only
change with no book content; builds were verified locally instead.

## Test plan

- [x] `pre-commit run --all-files` — all hooks pass (incl. `check-yaml` on the workflow)
- [x] `make text` — zero warnings
- [x] `make html` — build succeeded; `grep -r goatcounter _build/html/contents` → 0 hits
- [x] `make latex` — build succeeded
- [x] No stray branch-`master` references remain (`grep` audited)

https://claude.ai/code/session_0165rFN5CfK8Ta2esSq8Tcmk

---
_Generated by [Claude Code](https://claude.ai/code/session_0165rFN5CfK8Ta2esSq8Tcmk)_