### PR TITLE
Fix PDF code listings overflowing the page bottom

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -349,8 +349,11 @@ latex_show_urls = "footnote"
 class CustomLatexFormatter(LatexFormatter):
     def __init__(self, **options):
         super().__init__(**options)
-        # Compact-but-readable code listings (9pt on an 11pt body).
-        self.verboptions = r"formatcom=\fontsize{9pt}{11pt}\selectfont,frame=lines"
+        # Compact-but-readable code listings (9pt on an 11pt body). No
+        # fancyvrb frame — that makes the block an unbreakable box; the
+        # listing background is styled via sphinxsetup instead, which stays
+        # breakable across pages.
+        self.verboptions = r"formatcom=\fontsize{9pt}{11pt}\selectfont"
 
 
 PygmentsBridge.latex_formatter = CustomLatexFormatter
@@ -406,12 +409,10 @@ _PREAMBLE = r"""
 \g@addto@macro\UrlSpecials{\do\/{\Url@twoslashes}}
 \makeatother
 
-% VerbatimColor/VerbatimBorderColor are white so Sphinx's outer box is
-% invisible; the only visible border is fancyvrb's own frame=lines rule, and
-% framesep widens the gap between that rule and the code.
-\definecolor{VerbatimColor}{rgb}{1,1,1}
-\definecolor{VerbatimBorderColor}{rgb}{1,1,1}
-\fvset{framesep=8pt}
+% Code listings sit on a light-grey background tint with no border (the
+% frame is turned off via sphinxsetup). VerbatimColor is Sphinx's verbatim
+% background colour.
+\definecolor{VerbatimColor}{rgb}{0.95,0.95,0.95}
 
 \makeatletter
 \def\@subtitle{\relax}
@@ -548,6 +549,9 @@ latex_elements = {
         "\\usepackage[varqu,varl]{inconsolata}\n"
     ),
     "preamble": _PREAMBLE,
+    # Code listings: no frame (so the block stays breakable across pages),
+    # just the light-grey VerbatimColor tint with a little inner padding.
+    "sphinxsetup": "verbatimwithframe=false, verbatimsep=6pt",
     "figure_align": "H",  # put figures where told
     # fncychap is disabled so titlesec (see _PREAMBLE) can restyle \chapter.
     "fncychap": "",


### PR DESCRIPTION
## Summary

Long code blocks ran off the bottom of the page in the PDF, overprinting the
footnotes and the page footer (visible e.g. on the "Least Squares Modelling
Review" model-comparison page).

**Cause:** `CustomLatexFormatter` set the Pygments verbatim option
`frame=lines`. A fancyvrb-*framed* block is typeset as a single **unbreakable
box** — a listing that doesn't fit the space left on the page cannot split, so
it spills past the bottom margin. (The book hid Sphinx's own frame and leaned
on `frame=lines` for the visible rules; that reliance is what disabled
page-breaking.)

**Fix:** drop `frame=lines` so listings use Sphinx's own verbatim, which
**breaks across pages**. The styling is now a light-grey background tint with
no border — set via `sphinxsetup` (`verbatimwithframe=false`) and
`VerbatimColor` — replacing the old white-out of Sphinx's frame. The grey-tint,
no-border look was the chosen design.

All three changes are in `conf.py`: `CustomLatexFormatter`, a new `sphinxsetup`
key in `latex_elements`, and the `_PREAMBLE` verbatim colour block. HTML is
unaffected (these are LaTeX-only settings).

## Test plan

- [x] `make latex` — succeeds; `PID.tex` has zero `frame=lines` and carries `\sphinxsetup{verbatimwithframe=false, verbatimsep=6pt}`, `VerbatimColor` = grey
- [x] `make text` — zero warnings
- [x] `make html` — succeeds; `grep -r goatcounter _build/html/contents` → 0 hits
- [x] `pre-commit` (ruff) clean on `conf.py`
- [ ] **`pdflatex` compile** — not runnable here (no TeX toolchain). CI compiles the real PDF; confirm there that a long code block now splits across pages with the grey tint instead of overflowing into the footnotes/footer.

https://claude.ai/code/session_0165rFN5CfK8Ta2esSq8Tcmk

---
_Generated by [Claude Code](https://claude.ai/code/session_0165rFN5CfK8Ta2esSq8Tcmk)_