### PR TITLE
Tidy the Makefile: sectioned help, accurate .PHONY, clean-all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,28 +15,30 @@ PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 ALLRELAXEDOPTS  =  -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(RELAXOPTS) .
 
-.PHONY: help setup clean distclean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext whoosh pre-commit-install pre-commit-run
+.PHONY: help setup clean clean-all html dirhtml singlehtml pickle json htmlhelp epub latex latexpdf text gettext linkcheck serve pre-commit-install pre-commit-run
 
 .DEFAULT_GOAL := latexpdf
 
 help:
-	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  html       to make standalone HTML files"
-	@echo "  dirhtml    to make HTML files named index.html in directories"
-	@echo "  singlehtml to make a single large HTML file"
-	@echo "  pickle     to make pickle files"
-	@echo "  json       to make JSON files"
-	@echo "  htmlhelp   to make HTML files and a HTML help project"
-	@echo "  qthelp     to make HTML files and a qthelp project"
-	@echo "  devhelp    to make HTML files and a Devhelp project"
-	@echo "  epub       to make an epub"
-	@echo "  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
-	@echo "  latexpdf   to make LaTeX files and run them through pdflatex"
-	@echo "  text       to make text files"
-	@echo "  gettext    to make PO message catalogs"
-	@echo "  linkcheck  to check all external links for integrity"
-	@echo "  pre-commit-install  to install the pre-commit git hook"
-	@echo "  pre-commit-run      to run every pre-commit hook over the tree"
+	@echo "Process Improvement using Data — make targets"
+	@echo
+	@echo "Primary:"
+	@echo "  html       Build the HTML book (also runs Pagefind for search)"
+	@echo "  latexpdf   Build the PDF — needs LaTeX (this is the default target)"
+	@echo "  latex      Build the LaTeX sources only, without running pdflatex"
+	@echo "  epub       Build the EPUB"
+	@echo "  text       Build the plain-text output"
+	@echo
+	@echo "Development:"
+	@echo "  setup               Install uv and sync dependencies"
+	@echo "  serve               Serve the built HTML at http://localhost:8080"
+	@echo "  linkcheck           Check all external links"
+	@echo "  pre-commit-install  Install the pre-commit git hook"
+	@echo "  pre-commit-run      Run every pre-commit hook over the tree"
+	@echo "  clean               Remove build artifacts"
+	@echo "  clean-all           Also remove the venv and lockfile"
+	@echo
+	@echo "Set PAPER=a4 or PAPER=letter for the LaTeX targets."
 
 
 
@@ -49,7 +51,7 @@ clean: 		## Remove build artifacts
 	find . -name '*.egg-info' -exec rm -fr {} +
 	find . -name '*.egg' -exec rm -f {} +
 
-distclean: clean	## Also remove the virtualenv and lockfile (forces a re-resolve next setup)
+clean-all: clean	## Also remove the virtualenv and lockfile (forces a re-resolve next setup)
 	rm -rf .venv/ lib/ lib64/ bin/
 	rm -f uv.lock
 
@@ -129,7 +131,7 @@ latexpdf:
 	cp preface/*.png $(BUILDDIR)/latex
 	cp preface/*.jpg $(BUILDDIR)/latex
 	@echo "Running LaTeX files through pdflatex..."
-	make -C $(BUILDDIR)/latex all-pdf
+	$(MAKE) -C $(BUILDDIR)/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 	@if command -v xdg-open >/dev/null 2>&1; then \
 		xdg-open $(BUILDDIR)/latex/PID.pdf; \

--- a/README.md
+++ b/README.md
@@ -112,10 +112,11 @@ make setup
 | `make html` | Build the HTML book into `_build/html/` and run Pagefind for search |
 | `make serve` | Serve `_build/html/` at <http://localhost:8080> for local preview |
 | `make latexpdf` | Build the PDF (5–10 minutes; needs LaTeX). Output: `_build/latex/PID.pdf?2026-05-16` |
+| `make epub` | Build the EPUB into `_build/epub/` |
 | `make linkcheck` | Verify external links |
 | `make clean` | Remove build artifacts (`_build/`, caches) |
-| `make distclean` | Also remove `.venv/` and `uv.lock` (forces a re-resolve on next `make setup`) |
-| `make` | Default target is `latexpdf` |
+| `make clean-all` | Also remove `.venv/` and `uv.lock` (forces a re-resolve on next `make setup`) |
+| `make` | Default target is `latexpdf`. Run `make help` for the full list |
 
 Compare your PDF against <https://learnche.org/pid/PID.pdf?2026-05-16> to confirm a
 clean build.


### PR DESCRIPTION
Addresses #31.

## Context

Issue #31's headline problem — `make clean` also wiping the venv and
reinstalling the toolchain — was **already fixed** in an earlier modernization
pass: `setup`, `clean` (artifacts only), and a separate venv-removing target
all exist, and the README already documents them correctly. So this PR does
the part of #31 that genuinely remained.

## What changed (all in `Makefile`, plus the README table)

- **`make help`** reorganised into **Primary** and **Development** sections. It
  no longer lists the Sphinx builders the book never uses (`pickle`, `json`,
  `htmlhelp`, `qthelp`, `devhelp`, `gettext`, `dirhtml`, `singlehtml`).
- **`.PHONY`** now lists exactly the real targets. Phantom entries with no
  recipe (`man`, `changes`, `doctest`, `whoosh`, and also `qthelp`/`devhelp`)
  are dropped; the previously-missing `serve` is added.
- **`distclean` → `clean-all`**, so its destructiveness is obvious (per the
  issue). The README build-targets table is updated to match and gains an
  `epub` row.
- **`latexpdf`** calls `$(MAKE)` instead of bare `make`, so `-j`/`--dry-run`
  etc. propagate to the recursive LaTeX build.

## Out of scope / deferred

- The **default-goal flip to `all`** is deferred to #30: `make all` doesn't
  exist yet (it builds HTML+PDF+EPUB, which is #30's deliverable). The default
  stays `latexpdf`.
- The unused builder *targets* are kept (just unlisted in `help`) — dropping
  them from the help text is what #31 asked for.

The HTML / LaTeX / text / epub build **recipes are byte-for-byte unchanged** —
the diff only touches `help`, `.PHONY`, the rename, and `$(MAKE)`.

## Test plan

- [x] `make help` — renders the new two-section layout
- [x] `make -n clean-all` — runs `clean` then removes the venv/lockfile
- [x] `make -n latexpdf` — `$(MAKE)` expands; recursive LaTeX build resolves
- [x] `pre-commit` clean on `Makefile` and `README.md`
- [x] Build recipes unchanged (confirmed via `git diff`); CI compiles HTML+PDF

https://claude.ai/code/session_0165rFN5CfK8Ta2esSq8Tcmk

---
_Generated by [Claude Code](https://claude.ai/code/session_0165rFN5CfK8Ta2esSq8Tcmk)_