### PR TITLE
Style HTML code blocks with the GitHub palette; no italic code

### DIFF
--- a/_static/css/theme-extended-kgd.css
+++ b/_static/css/theme-extended-kgd.css
@@ -82,3 +82,10 @@ button.copybtn:focus,
 .highlight:hover button.copybtn {
     opacity: 1;
 }
+
+/* Code listings: keep every token upright. Some Pygments styles (e.g.
+   github-dark) italicise comments; this guarantees no slanted code in
+   either colour mode. */
+.highlight span {
+    font-style: normal !important;
+}

--- a/conf.py
+++ b/conf.py
@@ -82,9 +82,10 @@ exclude_patterns = [
 ]
 
 add_function_parentheses = True
-# A copy of Sphinx's "sphinx" style with non-italic code comments; see
-# my-extensions/pygments_upright.py. Applies to both the HTML and PDF builds.
-pygments_style = "my-extensions.pygments_upright.UprightCommentSphinxStyle"
+# A copy of Sphinx's "sphinx" style with every token upright (no slanted
+# comments/docstrings); see my-extensions/pygments_upright.py. Drives the PDF
+# build; HTML code styling is set via html_theme_options below.
+pygments_style = "my-extensions.pygments_upright.UprightSphinxStyle"
 
 # These substitutions apply to every RST file
 rst_prolog = """

--- a/conf.py
+++ b/conf.py
@@ -152,6 +152,9 @@ html_theme_options = {
     # Remove the navbar search button so Pagefind in the sidebar is the only search.
     "navbar_persistent": [],
     "extra_footer": "",
+    # Syntax-highlighting palette for HTML code blocks, per colour mode.
+    "pygments_light_style": "github-light",
+    "pygments_dark_style": "github-dark",
 }
 
 html_static_path = ["_static"]

--- a/my-extensions/pygments_upright.py
+++ b/my-extensions/pygments_upright.py
@@ -1,9 +1,11 @@
-"""Pygments style with upright code comments.
+"""Pygments style with no slanted code.
 
 A copy of Sphinx's built-in ``sphinx`` style with ``italic`` swapped to
-``noitalic`` on every comment token, so code-listing comments render upright
-rather than slanted. Wired up as ``pygments_style`` in ``conf.py``; it applies
-to both the HTML and the PDF builds.
+``noitalic`` on every token, so nothing in a code listing renders slanted
+(the stock style italicises comments, docstrings and string interpolation).
+Wired up as ``pygments_style`` in ``conf.py`` for the PDF build. The HTML
+build uses the theme's own Pygments styles; it is kept upright by a CSS rule
+in ``_static/css/theme-extended-kgd.css``.
 """
 
 from sphinx.pygments_styles import SphinxStyle
@@ -17,10 +19,7 @@ def _upright(value):
     return " ".join("noitalic" if word == "italic" else word for word in value.split())
 
 
-class UprightCommentSphinxStyle(SphinxStyle):
-    """The ``sphinx`` style, but with non-italic comments."""
+class UprightSphinxStyle(SphinxStyle):
+    """The ``sphinx`` style, but with every token rendered upright."""
 
-    styles = {
-        token: (_upright(value) if "Comment" in str(token) else value)
-        for token, value in SphinxStyle.styles.items()
-    }
+    styles = {token: _upright(value) for token, value in SphinxStyle.styles.items()}


### PR DESCRIPTION
## Summary

Two related changes to code-listing styling.

### 1. GitHub Pygments palette for HTML

The HTML code listings used whatever palette sphinx-book-theme defaults to —
`conf.py` never set one. Now set explicitly as a matched light/dark pair:
`github-light` for light mode, `github-dark` for dark mode, via
`pygments_light_style` / `pygments_dark_style` in `html_theme_options`.

### 2. No italic code, anywhere

`github-dark` italicises comments; and the PDF's `sphinx` style italicises
comments, **docstrings, and string interpolation** — the old upright tweak
only de-slanted *comments*. Both are now fixed:

- **HTML** — a CSS rule in `_static/css/theme-extended-kgd.css` forces every
  token in a `.highlight` block upright, in both colour modes, independent of
  the Pygments palette.
- **PDF** — `my-extensions/pygments_upright.py` now de-italicises *every*
  token, not just comments. `UprightCommentSphinxStyle` is renamed
  `UprightSphinxStyle` to match; the generated `PID.tex` emits no `\textit`
  at all.

## Test plan

- [x] `make html` — succeeds; GitHub colours in the generated Pygments CSS;
      the `.highlight span { font-style: normal !important }` rule ships
- [x] `make latex` — succeeds; `grep -c textit PID.tex` → 0
- [x] `make text` — zero warnings
- [x] `grep -r goatcounter _build/html/contents` → 0 hits
- [x] `pre-commit` clean on the changed files
- [ ] `pdflatex` compile — verified by CI

https://claude.ai/code/session_0165rFN5CfK8Ta2esSq8Tcmk