### PR TITLE
Add a PCA model-inversion worked example (#89)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,6 +21,6 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-date-released: 2026-05-16
+date-released: 2026-05-17
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"

--- a/latent-variable-modelling/PCA-model-inversion.ipynb
+++ b/latent-variable-modelling/PCA-model-inversion.ipynb
@@ -1,0 +1,268 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d7e5d190",
+   "metadata": {},
+   "source": [
+    "# PCA model inversion — food texture worked example\n",
+    "\n",
+    "This notebook accompanies the *Applications of Latent Variable Models* section of [Process Improvement using Data](https://learnche.org/pid). It builds a two-component PCA model of the food-texture data and then **inverts** it: starting from a desired score, it recovers the pastry recipe that would land an observation there.\n",
+    "\n",
+    "The final figure is interactive — hover (or tap) anywhere in the score plot and the tooltip shows the inverted recipe for that target.\n",
+    "\n",
+    "Requirements: `pip install process-improve numpy pandas plotly`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86b53b36",
+   "metadata": {},
+   "source": [
+    "## 1. Load and preprocess the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d62a7d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import plotly.graph_objects as go\n",
+    "from plotly.subplots import make_subplots\n",
+    "from process_improve.multivariate import PCA, MCUVScaler\n",
+    "\n",
+    "food = pd.read_csv(\"https://openmv.net/file/food-texture.csv\")\n",
+    "scaler = MCUVScaler().fit(food)\n",
+    "food_mcuv = scaler.transform(food)\n",
+    "food.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ecf55faa",
+   "metadata": {},
+   "source": [
+    "## 2. Fit a two-component PCA model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae6801ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = 2\n",
+    "model = PCA(n_components=A).fit(food_mcuv)\n",
+    "print(model.r2_cumulative_)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9af6628",
+   "metadata": {},
+   "source": [
+    "## 3. Check the model\n",
+    "\n",
+    "Before using the model to *generate* recipes, confirm it is a faithful summary of the data: the SPE and Hotelling's $T^2$ of each pastry, with their 95% limits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea1405f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spe = model.spe_.iloc[:, -1]\n",
+    "t2 = model.hotellings_t2_.iloc[:, -1]\n",
+    "spe_limit = float(model.spe_limit(conf_level=0.95))\n",
+    "t2_limit = float(model.hotellings_t2_limit(conf_level=0.95))\n",
+    "\n",
+    "fig = go.Figure()\n",
+    "fig.add_trace(go.Scatter(y=spe.values, mode=\"lines+markers\", name=\"SPE\"))\n",
+    "fig.add_hline(y=spe_limit, line_color=\"red\", line_dash=\"dash\",\n",
+    "              annotation_text=\"95% limit\")\n",
+    "fig.update_layout(title=\"SPE per pastry\", xaxis_title=\"Pastry number\",\n",
+    "                  yaxis_title=\"SPE\", height=320)\n",
+    "fig.show()\n",
+    "\n",
+    "fig = go.Figure()\n",
+    "fig.add_trace(go.Scatter(y=t2.values, mode=\"lines+markers\", name=\"T2\"))\n",
+    "fig.add_hline(y=t2_limit, line_color=\"red\", line_dash=\"dash\",\n",
+    "              annotation_text=\"95% limit\")\n",
+    "fig.update_layout(title=\"Hotelling's T-squared per pastry\",\n",
+    "                  xaxis_title=\"Pastry number\", yaxis_title=\"T-squared\",\n",
+    "                  height=320)\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "874d38e5",
+   "metadata": {},
+   "source": [
+    "## 4. Score and loadings plots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2919d4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scores = model.scores_\n",
+    "ci_x, ci_y = model.ellipse_coordinates(score_horiz=1, score_vert=2,\n",
+    "                                       conf_level=0.95)\n",
+    "\n",
+    "fig = make_subplots(rows=1, cols=2, subplot_titles=(\"Scores\", \"Loadings\"))\n",
+    "fig.add_trace(go.Scatter(x=scores.iloc[:, 0], y=scores.iloc[:, 1],\n",
+    "                         mode=\"markers\", marker=dict(color=\"black\"),\n",
+    "                         showlegend=False), row=1, col=1)\n",
+    "fig.add_trace(go.Scatter(x=ci_x, y=ci_y, mode=\"lines\",\n",
+    "                         line=dict(color=\"palevioletred\"),\n",
+    "                         showlegend=False), row=1, col=1)\n",
+    "fig.add_trace(go.Scatter(x=model.loadings_.iloc[:, 0],\n",
+    "                         y=model.loadings_.iloc[:, 1], mode=\"markers+text\",\n",
+    "                         text=model.loadings_.index,\n",
+    "                         textposition=\"bottom center\",\n",
+    "                         showlegend=False), row=1, col=2)\n",
+    "fig.update_xaxes(title_text=\"t1\", row=1, col=1)\n",
+    "fig.update_yaxes(title_text=\"t2\", row=1, col=1)\n",
+    "fig.update_xaxes(title_text=\"p1\", row=1, col=2)\n",
+    "fig.update_yaxes(title_text=\"p2\", row=1, col=2)\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02b98648",
+   "metadata": {},
+   "source": [
+    "## 5. Invert the model for a single target\n",
+    "\n",
+    "With the loadings matrix $\\mathbf{P}$ and a target score $\\mathbf{t} = [t_1, t_2]$, the scaled variables are $\\mathbf{x}_\\text{scaled} = \\mathbf{t}\\,\\mathbf{P}^{T}$; the scaler then undoes the centering and scaling."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98a95814",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "P = model.loadings_.values\n",
+    "\n",
+    "def invert(t1, t2):\n",
+    "    \"\"\"Return the pastry recipe for a target score (t1, t2).\"\"\"\n",
+    "    x_scaled = np.array([[t1, t2]]) @ P.T\n",
+    "    recipe = scaler.inverse_transform(pd.DataFrame(x_scaled, columns=food.columns))\n",
+    "    return recipe.iloc[0]\n",
+    "\n",
+    "print(invert(0, 0))     # the origin returns the average pastry\n",
+    "print(invert(2, -1))    # a point in the profitable quadrant"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2328d54",
+   "metadata": {},
+   "source": [
+    "## 6. Interactive inversion across the whole score plot\n",
+    "\n",
+    "The trick: lay a high-resolution heatmap behind the scores, make it fully transparent, and precompute the inverted recipe for every grid cell. Plotly's native hover tooltip then acts as a live inset — no callbacks, works on desktop hover and mobile tap alike."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb1e3ed7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pad = 0.5\n",
+    "t1_range = (float(min(scores.iloc[:, 0].min(), ci_x.min())) - pad,\n",
+    "            float(max(scores.iloc[:, 0].max(), ci_x.max())) + pad)\n",
+    "t2_range = (float(min(scores.iloc[:, 1].min(), ci_y.min())) - pad,\n",
+    "            float(max(scores.iloc[:, 1].max(), ci_y.max())) + pad)\n",
+    "\n",
+    "GRID = 60\n",
+    "t1_grid = np.linspace(t1_range[0], t1_range[1], GRID)\n",
+    "t2_grid = np.linspace(t2_range[0], t2_range[1], GRID)\n",
+    "TT1, TT2 = np.meshgrid(t1_grid, t2_grid)\n",
+    "T_flat = np.column_stack([TT1.ravel(), TT2.ravel()])\n",
+    "\n",
+    "# Vectorised inversion of the whole grid.\n",
+    "X_orig = scaler.inverse_transform(\n",
+    "    pd.DataFrame(T_flat @ P.T, columns=food.columns)).values\n",
+    "\n",
+    "hover = np.empty(T_flat.shape[0], dtype=object)\n",
+    "for idx in range(T_flat.shape[0]):\n",
+    "    t1, t2 = T_flat[idx]\n",
+    "    lines = [f\"<b>Target</b>  t1={t1:.2f}  t2={t2:.2f}\", \"<b>Inverted recipe</b>\"]\n",
+    "    for name, v in zip(food.columns, X_orig[idx]):\n",
+    "        lines.append(f\"  {name}: {v:.2f}\")\n",
+    "    hover[idx] = \"<br>\".join(lines)\n",
+    "hover = hover.reshape((GRID, GRID))\n",
+    "\n",
+    "loadings_scale = 0.9 * min(scores.iloc[:, 0].abs().max(),\n",
+    "                           scores.iloc[:, 1].abs().max())\n",
+    "\n",
+    "fig = go.Figure()\n",
+    "fig.add_trace(go.Heatmap(\n",
+    "    x=t1_grid, y=t2_grid, z=np.zeros((GRID, GRID)),\n",
+    "    text=hover, hoverinfo=\"text\",\n",
+    "    colorscale=[[0, \"rgba(0,0,0,0)\"], [1, \"rgba(0,0,0,0)\"]],\n",
+    "    showscale=False, name=\"\"))\n",
+    "fig.add_trace(go.Scatter(x=scores.iloc[:, 0], y=scores.iloc[:, 1],\n",
+    "    mode=\"markers\", marker=dict(size=7, color=\"black\"),\n",
+    "    name=\"Observed pastries\", hoverinfo=\"skip\"))\n",
+    "fig.add_trace(go.Scatter(x=ci_x, y=ci_y, mode=\"lines\",\n",
+    "    line=dict(color=\"palevioletred\", width=2),\n",
+    "    name=\"95% T-squared ellipse\", hoverinfo=\"skip\"))\n",
+    "fig.add_trace(go.Scatter(\n",
+    "    x=P[:, 0] * loadings_scale, y=P[:, 1] * loadings_scale,\n",
+    "    mode=\"markers+text\", marker=dict(size=12, symbol=\"x\", color=\"lightskyblue\"),\n",
+    "    text=list(food.columns), textposition=\"bottom center\",\n",
+    "    name=\"Loadings\", hoverinfo=\"skip\"))\n",
+    "fig.update_layout(\n",
+    "    title=\"PCA model inversion: hover anywhere to see the inverted recipe\",\n",
+    "    xaxis_title=\"t1\", yaxis_title=\"t2\",\n",
+    "    xaxis=dict(range=t1_range),\n",
+    "    yaxis=dict(range=t2_range, scaleanchor=\"x\", scaleratio=1),\n",
+    "    hovermode=\"closest\", height=560, margin=dict(l=70, r=20, t=70, b=50))\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d30e72ff",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    "* A target is only realistic if it lies **within** the model — inside the $T^2$ ellipse and implying a low SPE. A target far outside the cloud of pastries inverts to a recipe the process has never been shown to produce.\n",
+    "* The inversion here is **unconstrained**: all five variables move freely. If some variables are fixed (a hardness specification, say), the constrained inversion projects onto the remaining free subspace.\n",
+    "* Further reading: Jaeckle and MacGregor, *Product design through multivariate statistical analysis of process data*, AIChE Journal, 44, 1105-1118, 1998."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/latent-variable-modelling/applications-of-latent-variable-models.rst
+++ b/latent-variable-modelling/applications-of-latent-variable-models.rst
@@ -141,9 +141,129 @@ New product development follows a similar line of thought, but uses more of a "w
 
 But if our manager asks, can we readily produce a pastry with the 5 variables set at [Oil=14%, Density=2600, Crispy=14, Fracture can be any value, Hardness=100]. We can treat this as a new observation, and following the steps described in the earlier :ref:`section on using a PCA model <LVM-using-a-PCA-model>`, we will find that :math:`\mathbf{e} = [2.50, 1.57, -1.10,  -0.18,  0.67]`, and the SPE value is 10.4. This is well above the 95% limit of SPE, indicating that such a pastry is not consistent with how we have run our process in the past. So there isn't a quick solution.
 
-Fortunately, there are systematic tools to move on from this step, but they are beyond the level of this introductory material. They involve the inversion and optimization of latent variable models. This paper is a good starting point if you are interested in more information: Christiane Jaeckle and John MacGregor, "`Product design through multivariate statistical analysis of process data <https://literature.learnche.org/item/61/product-design-through-multivariate-statistical-analysis-of-process-data>`_". *AIChE Journal*, **44**, 1105-1118, 1998.
+Fortunately, there are systematic tools to move on from this step. They involve the *inversion* of a latent variable model: running the model backwards, from a desired result to the recipe that would produce it. The :ref:`worked example below <LVM_model_inversion_example>` introduces the idea on the food texture data. A good starting point for further reading is the paper by Christiane Jaeckle and John MacGregor, "`Product design through multivariate statistical analysis of process data <https://literature.learnche.org/item/61/product-design-through-multivariate-statistical-analysis-of-process-data>`_". *AIChE Journal*, **44**, 1105-1118, 1998.
 
 The general principle in model inversion problems is to manipulate the any degrees of freedom in the process (variables that can be manipulated in a process control sense) to obtain a product as close as possible to the required specification, but with low SPE in the model. A PLS model built with these manipulated variables, and other process measurements in |X|, and collecting the required product specifications in |Y| can be used for these model inversion problems.
+
+.. _LVM_model_inversion_example:
+
+Worked example: PCA model inversion
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. index::
+	pair: model inversion; latent variable modelling
+	single: inversion of a latent variable model
+
+The previous section ended with a manager's question: *what recipe will give us the pastry we want?* A latent variable model can be run in reverse to answer it. This is called model inversion. The forward calculation takes a new observation and projects it onto the model to obtain its scores; inversion does the opposite, starting from a desired score and recovering the raw variables that would place an observation there.
+
+For a two-component PCA model the idea is geometric. The model is a flat plane embedded in the five-dimensional space of pastry properties, and every pastry projects onto that plane at a score :math:`(t_1, t_2)`. To invert the model we choose a *target* score and read off the point on the plane it corresponds to. With the loadings matrix |P| (here :math:`5 \times 2`) and a target score :math:`\mathbf{t} = [t_1, t_2]`:
+
+.. math::
+
+	\mathbf{x}_\text{scaled} = \mathbf{t}\,\mathbf{P}^{T}
+
+This result is in the model's mean-centered and scaled units; undoing the centering and scaling returns a recipe in the original units of percentage oil, density, and so on.
+
+We build the model on the same :ref:`food texture data <LVM_food_texture_example>` as before, mean-centered and scaled to unit variance:
+
+.. code-block:: python
+
+	import numpy as np
+	import pandas as pd
+	import plotly.graph_objects as go
+	from plotly.subplots import make_subplots
+	from process_improve.multivariate import PCA, MCUVScaler
+
+	food = pd.read_csv("https://openmv.net/file/food-texture.csv")
+	scaler = MCUVScaler().fit(food)
+	food_mcuv = scaler.transform(food)
+
+Two components are enough for this small data set:
+
+.. code-block:: python
+
+	A = 2
+	model = PCA(n_components=A).fit(food_mcuv)
+	print(model.r2_cumulative_)
+
+The first component explains 60.6% of the variability in the five measurements and the second a further 25.9%, for a cumulative :math:`R^2` of 86.5%.
+
+Before trusting the model to *generate* recipes, we should check that it is a faithful summary of the data. We plot the SPE and Hotelling's |T2| value of each pastry, together with their 95% limits:
+
+.. code-block:: python
+
+	spe = model.spe_.iloc[:, -1]
+	t2 = model.hotellings_t2_.iloc[:, -1]
+	spe_limit = float(model.spe_limit(conf_level=0.95))
+	t2_limit = float(model.hotellings_t2_limit(conf_level=0.95))
+
+	fig = go.Figure()
+	fig.add_trace(go.Scatter(y=spe.values, mode="lines+markers", name="SPE"))
+	fig.add_hline(y=spe_limit, line_color="red", line_dash="dash",
+	              annotation_text="95% limit")
+	fig.update_layout(title="SPE per pastry", xaxis_title="Pastry number",
+	                  yaxis_title="SPE", height=320)
+	fig.show()
+
+	fig = go.Figure()
+	fig.add_trace(go.Scatter(y=t2.values, mode="lines+markers", name="T2"))
+	fig.add_hline(y=t2_limit, line_color="red", line_dash="dash",
+	              annotation_text="95% limit")
+	fig.update_layout(title="Hotelling's T-squared per pastry",
+	                  xaxis_title="Pastry number", yaxis_title="T-squared",
+	                  height=320)
+	fig.show()
+
+The 95% limits work out to :math:`\text{SPE} = 1.38` and |T2| :math:`= 6.65`. Two pastries sit just above the SPE limit and one just above the |T2| limit — about what a 95% limit implies for 50 observations, and none is a gross outlier. The two-component plane is a sound summary of how this product has been made, so it is a sensible basis for inversion.
+
+The score plot is the model's two-dimensional map of the data, and the loadings give that map its meaning:
+
+.. code-block:: python
+
+	scores = model.scores_
+	ci_x, ci_y = model.ellipse_coordinates(score_horiz=1, score_vert=2,
+	                                       conf_level=0.95)
+
+	fig = make_subplots(rows=1, cols=2, subplot_titles=("Scores", "Loadings"))
+	fig.add_trace(go.Scatter(x=scores.iloc[:, 0], y=scores.iloc[:, 1],
+	                         mode="markers", marker=dict(color="black"),
+	                         showlegend=False), row=1, col=1)
+	fig.add_trace(go.Scatter(x=ci_x, y=ci_y, mode="lines",
+	                         line=dict(color="palevioletred"),
+	                         showlegend=False), row=1, col=1)
+	fig.add_trace(go.Scatter(x=model.loadings_.iloc[:, 0],
+	                         y=model.loadings_.iloc[:, 1], mode="markers+text",
+	                         text=model.loadings_.index,
+	                         textposition="bottom center",
+	                         showlegend=False), row=1, col=2)
+	fig.update_xaxes(title_text="t1", row=1, col=1)
+	fig.update_yaxes(title_text="t2", row=1, col=1)
+	fig.update_xaxes(title_text="p1", row=1, col=2)
+	fig.update_yaxes(title_text="p2", row=1, col=2)
+	fig.show()
+
+Earlier we noted that the lower-right quadrant of the score plot — high :math:`t_1`, low :math:`t_2` — is the economically attractive region. Model inversion turns a chosen point in that quadrant into a concrete recipe. We extract the loadings as a plain array and project a target score back through them:
+
+.. code-block:: python
+
+	P = model.loadings_.values
+
+	def invert(t1, t2):
+	    """Return the pastry recipe for a target score (t1, t2)."""
+	    x_scaled = np.array([[t1, t2]]) @ P.T
+	    recipe = scaler.inverse_transform(pd.DataFrame(x_scaled, columns=food.columns))
+	    return recipe.iloc[0]
+
+	print(invert(0, 0))     # the origin returns the average pastry
+	print(invert(2, -1))    # a point in the profitable quadrant
+
+Inverting the origin :math:`(0, 0)` returns Oil = 17.2%, Density = 2858, Crispy = 11.5, Fracture = 20.9, Hardness = 128. These are the column means: a useful sanity check, since the centre of the score plot must correspond to the average pastry.
+
+The target :math:`(t_1 = 2,\ t_2 = -1)` inverts to a recipe of Oil = 19.2%, Density = 2694, Crispy = 13.1, Fracture = 16.6, Hardness = 113. Next to the average pastry this one is oilier, less dense, and crispier — exactly the trade-off the loadings plot predicts for that quadrant, now written as numbers a process engineer can aim for.
+
+Two cautions apply. First, a target is only realistic if it lies within the model: inside the |T2| ellipse, and implying a low SPE. Asking for a score far outside the cloud of pastries inverts to a recipe the process has never been shown to produce. Second, the inversion above is *unconstrained* — it is free to move all five variables at once. In practice some variables are fixed (a hardness specification, say) and the rest must be solved for; that constrained problem is a modest extension of the same projection idea.
+
+To explore the inversion interactively — hovering over any target in the score plot and reading off the recipe it implies — download and run this notebook: :download:`PCA-model-inversion.ipynb <PCA-model-inversion.ipynb>`.
 
 .. _LVM_inferential_sensors:
 

--- a/latent-variable-modelling/applications-of-latent-variable-models.rst
+++ b/latent-variable-modelling/applications-of-latent-variable-models.rst
@@ -214,6 +214,18 @@ Before trusting the model to *generate* recipes, we should check that it is a fa
 	                  height=320)
 	fig.show()
 
+.. figure:: ../figures/examples/food-texture/pca-on-food-texture-model-inversion-spe.png
+	:alt:	../figures/examples/food-texture/pca-on-food-texture-model-inversion.py
+	:scale: 80
+	:width: 600px
+	:align: center
+
+.. figure:: ../figures/examples/food-texture/pca-on-food-texture-model-inversion-t2.png
+	:alt:	../figures/examples/food-texture/pca-on-food-texture-model-inversion.py
+	:scale: 80
+	:width: 600px
+	:align: center
+
 The 95% limits work out to :math:`\text{SPE} = 1.38` and |T2| :math:`= 6.65`. Two pastries sit just above the SPE limit and one just above the |T2| limit — about what a 95% limit implies for 50 observations, and none is a gross outlier. The two-component plane is a sound summary of how this product has been made, so it is a sensible basis for inversion.
 
 The score plot is the model's two-dimensional map of the data, and the loadings give that map its meaning:
@@ -241,6 +253,12 @@ The score plot is the model's two-dimensional map of the data, and the loadings 
 	fig.update_xaxes(title_text="p1", row=1, col=2)
 	fig.update_yaxes(title_text="p2", row=1, col=2)
 	fig.show()
+
+.. figure:: ../figures/examples/food-texture/pca-on-food-texture-model-inversion-scores-and-loadings.png
+	:alt:	../figures/examples/food-texture/pca-on-food-texture-model-inversion.py
+	:scale: 80
+	:width: 750px
+	:align: center
 
 Earlier we noted that the lower-right quadrant of the score plot — high :math:`t_1`, low :math:`t_2` — is the economically attractive region. Model inversion turns a chosen point in that quadrant into a concrete recipe. We extract the loadings as a plain array and project a target score back through them:
 


### PR DESCRIPTION
Closes #89.

## Summary

The *Applications of Latent Variable Models* chapter previously mentioned model
inversion only in passing — *"beyond the level of this introductory material"*.
This adds a concrete worked example of it.

A new **"Worked example: PCA model inversion"** subsection
(`latent-variable-modelling/applications-of-latent-variable-models.rst`):

- builds a two-component PCA model of the food-texture data,
- checks it (SPE, Hotelling's T²),
- and **inverts** it — from a target score, recovers the pastry recipe that
  would place an observation there (`x_scaled = t·Pᵀ`, then un-scale).

The lead-in sentence is reworded from "beyond the level of this introductory
material" to point at the example.

## Verification

Every number quoted in the prose was reproduced by running the code against
the dataset:

- `R²` = 60.6% (PC1) → 86.5% cumulative
- SPE 95% limit 1.38, T² 95% limit 6.65; 2 pastries above the SPE limit and
  1 above the T² limit — as expected for a 95% limit over 50 observations
- inverting `(0,0)` → the mean pastry; `(t₁=2, t₂=−1)` → Oil 19.2, Density
  2694, Crispy 13.1, Fracture 16.6, Hardness 113

## Figures

Three static figures (SPE, T², scores-and-loadings) are embedded via
`.. figure::`. They were generated and committed to the figures repo in a
companion PR — **kgdunn/figures#7** — and are wired in here.

## Downloadable notebook

The fully interactive version — hover over any target in the score plot to
read off its recipe — ships as `latent-variable-modelling/PCA-model-inversion.ipynb`,
linked from the section with `:download:`. The notebook was **executed
end-to-end** (all 6 code cells) to confirm it runs.

## Test plan

- [x] `make text` — zero warnings
- [x] `make html` — succeeds; 3 figures embedded; notebook in `_downloads/`; `grep -r goatcounter _build/html/contents` → 0
- [x] `make latex` — succeeds
- [x] notebook executed end-to-end against the dataset
- [x] `pre-commit` clean (incl. `rstcheck`) on the changed files
- [ ] `pdflatex` compile — verified by CI

https://claude.ai/code/session_0165rFN5CfK8Ta2esSq8Tcmk