### PR TITLE
ci: build HTML before installing TeX Live

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -49,17 +49,6 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install TeX Live
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            texlive-latex-recommended \
-            texlive-latex-extra \
-            texlive-fonts-recommended \
-            texlive-fonts-extra \
-            texlive-xetex \
-            latexmk
-
       - name: Fetch ECharts (for sidebar sparklines)
         # Pinned official Apache ECharts build, line/bar/pie subset.
         # ~280 KB minified / ~80 KB gzip; served from same origin so no
@@ -72,11 +61,25 @@ jobs:
             https://cdn.jsdelivr.net/npm/echarts@5.5.1/dist/echarts.simple.min.js
           test -s _static/js/echarts-min.js
 
+      # Build HTML runs before the TeX Live install: the apt-get step is slow
+      # and is not a prerequisite for the HTML build, so a broken HTML build
+      # surfaces as a fast early signal.
       - name: Build HTML
         env:
           PID_BOOK_TELEMETRY: ${{ github.event_name != 'pull_request' && '1' || '0' }}
           PID_BOOK_GC_CODE: ${{ vars.GOATCOUNTER_CODE || 'learnche-pid' }}
         run: uv run make html
+
+      - name: Install TeX Live
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            texlive-latex-recommended \
+            texlive-latex-extra \
+            texlive-fonts-recommended \
+            texlive-fonts-extra \
+            texlive-xetex \
+            latexmk
 
       - name: Build PDF
         # Sidestep the xdg-open step at the end of the `latexpdf` target,

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,6 +21,6 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-date-released: 2026-05-18
+date-released: 2026-05-19
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"


### PR DESCRIPTION
## Summary

- Moved the `Build HTML` step earlier in `.github/workflows/build-deploy.yml` so it runs **before** the slow `Install TeX Live` apt-get step.
- The TeX Live install is not a prerequisite for the HTML build, so a broken HTML build now surfaces as a fast early signal instead of waiting through the texlive download.
- Bumped `CITATION.cff` `date-released:` to 2026-05-19 per repo instructions.

## Details

`Build HTML` is placed as high as its dependencies allow — right after `Fetch ECharts`. It still needs:

- Python deps (`uv sync`)
- Node.js (for the Pagefind step inside `make html`)
- the fetched `_static/js/echarts-min.js` (sidebar sparklines, non-PR builds only)

So the new step order is: ... → Set up Node.js → Fetch ECharts → **Build HTML** → Install TeX Live → Build PDF.

No build behaviour changes — this is a pure step reorder within the same job.

https://claude.ai/code/session_015b9KvGgvqFHu9VZQeKgRTo

---
_Generated by [Claude Code](https://claude.ai/code/session_015b9KvGgvqFHu9VZQeKgRTo)_