### PR TITLE
Fix mis-indented reading-list entries starting with an author initial

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,10 @@ link the two PRs.
 * Math: prefer `:math:` for inline and `.. math::` for displayed equations.
 * Cross-references should use `:ref:` with explicit labels rather than raw
   section names.
+* Do not start a bullet or list item with a bare author initial
+  (`J. Smith`, `S. Wold`): reStructuredText reads the leading `letter.` as
+  an enumerated-list marker and mis-indents the entry. Escape the initial
+  with a backslash (`\J. Smith`), or spell the first name out.
 * Code blocks: use `.. code-block:: python` (or `r`, `matlab`, `text`) so the
   PDF backend syntax-highlights correctly.
 

--- a/latent-variable-modelling/latent-variable-modelling.rst
+++ b/latent-variable-modelling/latent-variable-modelling.rst
@@ -417,14 +417,14 @@ PCA
 
 * Svante Wold, Kim Esbensen, Paul Geladi: "`Principal Component Analysis <https://literature.learnche.org/item/13/principal-component-analysis>`_", *Chemometrics and Intelligent Laboratory Systems*, **2**, 37-52, 1987.
 
-* J. Edward Jackson, `A User's Guide to Principal Components <https://literature.learnche.org/item/38/a-users-guide-to-principal-components>`_, Wiley, 1991.
+* \J. Edward Jackson, `A User's Guide to Principal Components <https://literature.learnche.org/item/38/a-users-guide-to-principal-components>`_, Wiley, 1991.
 
 PLS
 ~~~
 
 * Svante Wold, Michael Sjöström, Lennart Eriksson: "`PLS-regression: A Basic Tool of Chemometrics <https://literature.learnche.org/item/1/pls-regression-a-basic-tool-of-chemometrics>`_", *Chemometrics and Intelligent Laboratory Systems*, **58**, 109-130, 2001.
 
-* S. Wold, S. Hellberg, T. Lundstedt, M. Sjöström and H. Wold, "`PLS Modeling With Latent Variables in Two or More Dimensions <https://literature.learnche.org/item/4/pls-modeling-with-latent-variables-in-two-or-more-dimensions>`_", Frankfurt PLS meeting, 1987 (*available on request, by email to kgdunn@gmail.com*)
+* \S. Wold, S. Hellberg, T. Lundstedt, M. Sjöström and H. Wold, "`PLS Modeling With Latent Variables in Two or More Dimensions <https://literature.learnche.org/item/4/pls-modeling-with-latent-variables-in-two-or-more-dimensions>`_", Frankfurt PLS meeting, 1987 (*available on request, by email to kgdunn@gmail.com*)
 
 * Paul Geladi and Bruce Kowalski, "`Partial Least-Squares Regression: A Tutorial <https://literature.learnche.org/item/44/partial-least-squares-regression-a-tutorial>`_", *Analytica Chimica Acta*, **185**, 1-17, 1986.
 


### PR DESCRIPTION
## Summary

Two entries in the section 6.2 reading list — *J. Edward Jackson* (under PCA)
and *S. Wold, S. Hellberg, …* (under PLS) — rendered with a broken extra
indentation, as shown in the reported screenshot.

**Cause:** when #110 removed the inline `**About PCA**:` / `**PLS**:` topic
prefixes, those two entries began directly with an author initial. A bullet
item whose content starts with `J.` or `S.` is parsed by reStructuredText as a
*nested enumerated list* (a single capital letter + period is a valid list
marker), which mis-indents the text.

**Fix:** escape the leading initial with a backslash (`\J. Edward Jackson`,
`\S. Wold`) so it is read as plain text. The backslash is consumed and does not
appear in the output; the entries now render as normal, aligned bullets.

To stop this recurring, a note is added to the **RST style notes** in
`CONTRIBUTING.md`: do not start a list item with a bare author initial — escape
it or spell the first name out. A repo-wide check confirms these were the only
two such list items; every other reference list spells the first author's given
name in full.

## Test plan

- [x] `make text` succeeds with no new warnings; the PCA and PLS lists now
  render as flat, correctly-aligned bullets (no nested enumerated list).

https://claude.ai/code/session_01TQMgb7m41h16prFCtXLLQs

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQMgb7m41h16prFCtXLLQs)_