### PR TITLE
Citation metadata: ORCID, calendar version, and release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Publish release
+
+# Cutting a release is deliberate, not automatic. Pushing a calendar-version
+# tag (vYYYY.MM.DD) is the trigger; see "Cutting a release" in CLAUDE.md.
+on:
+  push:
+    tags:
+      - 'v[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]'
+
+permissions:
+  contents: write
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the tagged commit
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          TITLE="Process Improvement using Data: ${TAG#v} edition"
+          # The annotated tag's message is the release notes. Fall back to
+          # auto-generated notes only if the tag carries no message.
+          NOTES="$(git for-each-ref "refs/tags/${TAG}" --format='%(contents)')"
+          if [ -n "${NOTES//[[:space:]]/}" ]; then
+            printf '%s\n' "$NOTES" > release-notes.md
+            gh release create "$TAG" --title "$TITLE" --notes-file release-notes.md
+          else
+            gh release create "$TAG" --title "$TITLE" --generate-notes
+          fi

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,7 +22,7 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.05"
+version: "2026.05.19"
 date-released: 2026-05-19
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,6 +6,7 @@ authors:
   - family-names: Dunn
     given-names: Kevin G.
     email: kgdunn@gmail.com
+    orcid: "https://orcid.org/0000-0002-0681-6794"
 abstract: >-
   An open-access textbook covering data visualization, univariate statistics,
   process monitoring, least-squares modelling, design and analysis of
@@ -21,6 +22,7 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
+version: "2026.05"
 date-released: 2026-05-19
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,24 +11,31 @@ comma, parentheses, or two separate sentences instead. En-dashes (`–`) in
 numeric ranges such as the `2010–2026` year range are correct and should
 stay.
 
-## Bump the citation date whenever you plan a PR
+## Bump the version and citation date whenever you plan a PR
 
-This repository ships citation metadata in two places:
+This repository ships release metadata in three places that reusers and
+GitHub's "Cite this repository" button depend on:
 
-- `CITATION.cff` — the `date-released:` field
-- `README.md` — the suggested attribution line, which carries a year range
-  ending in the most recent update (e.g. `2010–2026`)
+- `CITATION.cff` `version:`, a calendar version written as `YYYY.MM`.
+- `CITATION.cff` `date-released:`, written as `YYYY-MM-DD`.
+- `README.md`, the suggested attribution line, which carries a year range
+  ending in the most recent update (e.g. `2010–2026`).
 
 **Whenever you are planning a pull request that contains substantive changes
-(content edits, new sections, build changes, anything beyond a pure
-typo / link fix), update both fields before committing:**
+(content edits, new sections, build changes, anything beyond a pure typo or
+link fix), update all three before committing:**
 
-1. Set `CITATION.cff` `date-released:` to today's date (`YYYY-MM-DD`).
-2. Update the trailing year of the year range in the README's suggested
+1. Set `CITATION.cff` `version:` to the current `YYYY.MM`.
+2. Set `CITATION.cff` `date-released:` to today's date (`YYYY-MM-DD`).
+3. Update the trailing year of the year range in the README's suggested
    attribution line to the current year, if it isn't already.
 
-If you skip this step, GitHub's "Cite this repository" button will keep
-showing a stale year and reusers of the book will undercredit the latest
+The `CITATION.cff` `version:` is the citation's own calendar version. It is
+independent of the `pyproject.toml` `version` covered under "Where the
+canonical version lives" below.
+
+If you skip this step, the "Cite this repository" button keeps showing a
+stale version and date, and reusers of the book undercredit the latest
 revision.
 
 ## Where the canonical version lives

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ stay.
 This repository ships release metadata in three places that reusers and
 GitHub's "Cite this repository" button depend on:
 
-- `CITATION.cff` `version:`, a calendar version written as `YYYY.MM`.
+- `CITATION.cff` `version:`, a calendar version written as `YYYY.MM.DD`.
 - `CITATION.cff` `date-released:`, written as `YYYY-MM-DD`.
 - `README.md`, the suggested attribution line, which carries a year range
   ending in the most recent update (e.g. `2010–2026`).
@@ -25,18 +25,48 @@ GitHub's "Cite this repository" button depend on:
 (content edits, new sections, build changes, anything beyond a pure typo or
 link fix), update all three before committing:**
 
-1. Set `CITATION.cff` `version:` to the current `YYYY.MM`.
+1. Set `CITATION.cff` `version:` to today's date as `YYYY.MM.DD`.
 2. Set `CITATION.cff` `date-released:` to today's date (`YYYY-MM-DD`).
 3. Update the trailing year of the year range in the README's suggested
    attribution line to the current year, if it isn't already.
 
 The `CITATION.cff` `version:` is the citation's own calendar version. It is
 independent of the `pyproject.toml` `version` covered under "Where the
-canonical version lives" below.
+canonical version lives" below. When a release is cut, this `version:` value
+must equal the release tag with the leading `v` removed (see "Cutting a
+release" below).
 
 If you skip this step, the "Cite this repository" button keeps showing a
 stale version and date, and reusers of the book undercredit the latest
 revision.
+
+## Cutting a release (Zenodo DOI archiving)
+
+GitHub Releases of this book are archived by Zenodo, which mints a DOI for
+each one. Releases are deliberate: not every merge to `main` warrants one,
+so they are never created automatically.
+
+**After a pull request with substantive changes merges to `main`, ask the
+user whether to cut a release.** If they decline, do nothing. If they agree:
+
+1. Check out `main` and make sure it is up to date with `origin/main`.
+2. Create an annotated, calendar-versioned tag on the merge commit:
+   `git tag -a vYYYY.MM.DD -m "<release notes>"`. Use today's date. The tag
+   message becomes the GitHub Release notes, so write a short summary of
+   what changed since the previous release.
+3. Push the tag: `git push origin vYYYY.MM.DD`.
+
+Pushing a `vYYYY.MM.DD` tag triggers `.github/workflows/release.yml`, which
+creates the GitHub Release automatically. Zenodo then archives that release
+and issues a DOI. The tag version without the `v` must match the
+`CITATION.cff` `version:` already merged in the PR.
+
+Once Zenodo has minted the concept DOI (the one that always resolves to the
+latest release), add it to `CITATION.cff` in a follow-up PR under an
+`identifiers:` block of `type: doi`, so the citation metadata is complete.
+
+Enabling the Zenodo archive itself is a one-time manual step the repository
+owner performs in their Zenodo account; it cannot be scripted here.
 
 ## Where the canonical version lives
 


### PR DESCRIPTION
## Summary

- Added the author's ORCID iD (`https://orcid.org/0000-0002-0681-6794`) to `CITATION.cff`.
- Added a calendar `version:` to `CITATION.cff`, in `YYYY.MM.DD` form (`2026.05.19`), so the citation version equals the release tag minus the leading `v`.
- Added `.github/workflows/release.yml`: pushing a `vYYYY.MM.DD` tag creates a GitHub Release automatically. Zenodo (once enabled by the owner) archives each release and mints a DOI.
- Updated `CLAUDE.md`: the citation-bump rule now uses `YYYY.MM.DD`, and a new "Cutting a release" section documents prompting the owner after a substantive merge, then tagging.

## How releasing works now

Releases stay deliberate, never automatic on merge:

1. Owner enables the Zenodo archive for this repo once (manual, in their Zenodo account).
2. After a substantive PR merges, Claude asks whether to cut a release.
3. If agreed, Claude pushes an annotated `vYYYY.MM.DD` tag; the tag message becomes the release notes.
4. `release.yml` creates the GitHub Release; Zenodo archives it and issues a DOI.
5. The Zenodo concept DOI is then added to `CITATION.cff` in a follow-up PR.

## Decisions worth a look

- **DOI still left out.** No `identifiers:` block yet, because there is no real DOI until the first Zenodo-archived release exists. It goes in once Zenodo mints the concept DOI.
- **Release title uses a colon, not an em-dash.** The workflow titles releases `Process Improvement using Data: YYYY.MM.DD edition`, to honour the no-em-dash rule (the originally suggested title had an em-dash).
- **`pyproject.toml` not touched.** Its semver `version` (`0.2.5`) remains the build/package version, separate from the citation's calendar version, as documented in `CLAUDE.md`.

## Verification

- `release.yml` and `CITATION.cff` both parse as valid YAML; `version` reads back as `2026.05.19`.

## Test plan

- [ ] After merge, enable the Zenodo archive for `kgdunn/pid-book`.
- [ ] Push tag `v2026.05.19`; confirm `release.yml` creates the GitHub Release.
- [ ] Confirm Zenodo archives the release and mints a DOI.

https://claude.ai/code/session_013W53BmeuZ4JwFwo2sKzdGG