### PR TITLE
Add the Zenodo DOI to CITATION.cff and the README

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,3 +26,8 @@ version: "2026.05.19"
 date-released: 2026-05-19
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.20284934"
+    description: "Concept DOI: always resolves to the latest release"
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,14 +47,18 @@ each one. Releases are deliberate: not every merge to `main` warrants one,
 so they are never created automatically.
 
 **After a pull request with substantive changes merges to `main`, ask the
-user whether to cut a release.** If they decline, do nothing. If they agree:
+user whether to cut a release.** If they decline, do nothing. If they agree,
+the tag has to be pushed by the maintainer: a Claude-on-the-web session
+cannot push tags, because its git proxy accepts only the working branch.
+Claude's job is to prepare everything and hand over the commands:
 
-1. Check out `main` and make sure it is up to date with `origin/main`.
-2. Create an annotated, calendar-versioned tag on the merge commit:
-   `git tag -a vYYYY.MM.DD -m "<release notes>"`. Use today's date. The tag
-   message becomes the GitHub Release notes, so write a short summary of
-   what changed since the previous release.
-3. Push the tag: `git push origin vYYYY.MM.DD`.
+1. Make sure `main` is up to date with `origin/main`.
+2. Write the release notes to a file. They become the GitHub Release body,
+   so summarise what changed since the previous release.
+3. Give the maintainer an annotated, calendar-versioned tag command to run,
+   using today's date:
+   `git tag -a vYYYY.MM.DD origin/main -F <notes-file>`
+   followed by `git push origin vYYYY.MM.DD`.
 
 Pushing a `vYYYY.MM.DD` tag triggers `.github/workflows/release.yml`, which
 creates the GitHub Release automatically. Zenodo then archives that release

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 > Continuously written and refined in industry-facing classrooms since 2010.
 
 [![License: CC BY-SA 4.0](https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-sa/4.0/)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20284934.svg)](https://doi.org/10.5281/zenodo.20284934)
 [![Read online](https://img.shields.io/badge/read-learnche.org%2Fpid-blue.svg)](https://learnche.org/pid)
 [![Download PDF](https://img.shields.io/badge/download-PDF-red.svg)](https://learnche.org/pid/PID.pdf)
 [![Build status](https://img.shields.io/github/actions/workflow/status/kgdunn/pid-book/build-deploy.yml?branch=main&label=build)](https://github.com/kgdunn/pid-book/actions/workflows/build-deploy.yml)
@@ -146,10 +147,11 @@ your derivative work under the same terms.
 
 Suggested attribution:
 
-> Dunn, K. G. (2010–2026). *Process Improvement using Data.* learnche.org/pid (CC BY-SA 4.0).
+> Dunn, K. G. (2010–2026). *Process Improvement using Data* (CC BY-SA 4.0). Zenodo. https://doi.org/10.5281/zenodo.20284934
 
-Machine-readable citation metadata is available in
-[`CITATION.cff`](CITATION.cff).
+Each tagged release is archived on Zenodo. The DOI above is the concept DOI:
+it always resolves to the latest archived edition. Machine-readable citation
+metadata, including the DOI, is in [`CITATION.cff`](CITATION.cff).
 
 ## Privacy and readership data
 


### PR DESCRIPTION
## Summary

- Added an `identifiers:` block to `CITATION.cff` with the Zenodo **concept DOI** `10.5281/zenodo.20284934`, minted for the first archived release (`v2026.05.19`). The concept DOI always resolves to the latest archived edition, so it stays correct as future releases are cut.
- Surfaced the DOI in `README.md` for credibility:
  - a **DOI badge** in the header badge row, next to the licence badge;
  - the **suggested-attribution line** now cites the Zenodo DOI, with a short note that it is the concept DOI (always resolves to the latest edition).
- Corrected the `CLAUDE.md` "Cutting a release" section. It previously told Claude to push the release tag, but a Claude-on-the-web session cannot: the git proxy accepts only the working branch and returns `403` for tag refs. The section now states that the maintainer pushes the tag, and Claude's role is to prepare the notes and hand over the `git tag` / `git push` commands.

## Notes

- Uses the **concept** DOI, not the version-specific DOI (`10.5281/zenodo.20284935`), which is correct for both the badge and the citation.
- The first release's archived snapshot does not contain its own DOI inside `CITATION.cff`; this is the inherent v1 chicken-and-egg. From the next release onward, the DOI ships inside the archive.

## Verification

- `CITATION.cff` parses as valid YAML; the `identifiers` block reads back correctly.
- No em-dashes introduced in the README edits.

## Test plan

- [ ] Confirm GitHub's "Cite this repository" panel shows the DOI.
- [ ] Confirm the DOI badge renders and links to https://doi.org/10.5281/zenodo.20284934

https://claude.ai/code/session_013W53BmeuZ4JwFwo2sKzdGG