### PR TITLE
Add /pid/stats page and a 90-day reader count in the sidebar

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.05.20"
-date-released: 2026-05-20
+version: "2026.05.24"
+date-released: 2026-05-24
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/_static/css/theme-extended-kgd.css
+++ b/_static/css/theme-extended-kgd.css
@@ -89,3 +89,66 @@ button.copybtn:focus,
 .highlight span {
     font-style: normal !important;
 }
+
+/* ---------------------------------------------------------------------
+   /pid/stats page widgets. Mount points are injected as raw HTML by
+   stats.rst and filled at runtime by _static/js/telemetry.js.
+   Styles are scoped to .pid-stats-* so they cannot leak into the rest
+   of the book.
+   ------------------------------------------------------------------ */
+
+.pid-stats-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin: 1.5rem 0;
+}
+
+.pid-stats-card {
+    flex: 1 1 180px;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--pst-color-border, #ddd);
+    border-radius: 6px;
+    text-align: center;
+    background: var(--pst-color-surface, transparent);
+}
+
+.pid-stats-num {
+    font-size: 1.75rem;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.1;
+}
+
+.pid-stats-label {
+    color: #777;
+    font-size: 0.9rem;
+    margin-top: 0.25rem;
+}
+
+.pid-stats-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.5rem 0 1.5rem;
+}
+
+.pid-stats-table th,
+.pid-stats-table td {
+    padding: 0.4rem 0.6rem;
+    border-bottom: 1px solid var(--pst-color-border, #eee);
+}
+
+.pid-stats-table th.pid-stats-rank,
+.pid-stats-table td.pid-stats-rank {
+    width: 2.5rem;
+    text-align: right;
+    color: #888;
+    font-variant-numeric: tabular-nums;
+}
+
+.pid-stats-table th.pid-stats-count,
+.pid-stats-table td.pid-stats-count {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}

--- a/_static/js/telemetry.js
+++ b/_static/js/telemetry.js
@@ -5,14 +5,18 @@
  * from GitHub Actions). Honours Do-Not-Track. Skips localhost / file://
  * so that CC BY-SA reusers self-hosting the source never phone home.
  *
- * Three responsibilities:
+ * Four responsibilities:
  *   1. Pageview pixel via GoatCounter (loaded async).
  *   2. Search-query event capture from BOTH Sphinx and Pagefind boxes.
- *   3. 90-day pageview sparkline in the sidebar (ECharts, lazy-loaded).
+ *   3. 90-day pageview sparkline in the sidebar (ECharts, lazy-loaded),
+ *      with the per-page 90-day total written into #pid-sparkline-total.
+ *   4. The /pid/stats page: site-wide summary, daily-totals chart, and
+ *      top-N table sourced from the same /_stats/sparklines.json.
  *
  * The ECharts asset (`_static/js/echarts-min.js`) is fetched at build time
  * by .github/workflows/build-deploy.yml; it is NOT in git. If absent the
- * sparkline is silently skipped — pageview/search tracking still works.
+ * sparkline / stats charts are silently skipped — pageview/search tracking
+ * still works.
  *
  * What is collected and what is not is described at /pid/privacy.
  */
@@ -136,6 +140,13 @@
           mount.style.display = "none";
           return;
         }
+        // Write the 90-day total into the sidebar heading, if its span
+        // is present (template ships it; older builds may not).
+        var totalEl = document.getElementById("pid-sparkline-total");
+        if (totalEl) {
+          var total = series.reduce(function (a, p) { return a + p[1]; }, 0);
+          totalEl.textContent = total.toLocaleString() + " reads";
+        }
         loadECharts(function (echarts) {
           if (!echarts) return;
           var dates = series.map(function (p) {
@@ -182,6 +193,124 @@
       });
   }
 
+  // 4b. Stats page widgets. Run only if the /pid/stats page is loaded,
+  // detected by the presence of #pid-stats-summary in the DOM. Three
+  // mounts are filled from the same sparklines.json the sidebar uses:
+  //   #pid-stats-summary  — three big-number cards (reads, pages, days)
+  //   #pid-stats-daily    — daily-totals line chart across all pages
+  //   #pid-stats-top      — top-20 most-read pages table
+  function renderStatsPage() {
+    var summary = document.getElementById("pid-stats-summary");
+    if (!summary) return;
+
+    var dailyMount = document.getElementById("pid-stats-daily");
+    var topMount = document.getElementById("pid-stats-top");
+
+    function showEmpty(msg) {
+      summary.innerHTML =
+        '<p style="color:#777"><em>' +
+        (msg || "Statistics aren't available yet. The nightly aggregator " +
+               "may not have run, or this is a local build.") +
+        "</em></p>";
+      if (dailyMount) dailyMount.style.display = "none";
+      if (topMount) topMount.style.display = "none";
+    }
+
+    fetch("/_stats/sparklines.json", { cache: "force-cache" })
+      .then(function (r) {
+        if (!r.ok) throw new Error("sparklines.json " + r.status);
+        return r.json();
+      })
+      .then(function (data) {
+        var pages = data && Object.keys(data);
+        if (!pages || !pages.length) { showEmpty(); return; }
+
+        // Aggregate.
+        var totalReads = 0;
+        var dailyMap = {};
+        var pageTotals = [];
+        pages.forEach(function (page) {
+          var series = data[page] || [];
+          var pageTotal = 0;
+          series.forEach(function (p) {
+            var date = p[0], count = p[1] | 0;
+            totalReads += count;
+            pageTotal += count;
+            dailyMap[date] = (dailyMap[date] || 0) + count;
+          });
+          if (pageTotal > 0) pageTotals.push([page, pageTotal]);
+        });
+        pageTotals.sort(function (a, b) { return b[1] - a[1]; });
+        var dailyDates = Object.keys(dailyMap).sort();
+
+        // Summary cards.
+        summary.innerHTML =
+          '<div class="pid-stats-card"><div class="pid-stats-num">' +
+            totalReads.toLocaleString() +
+          '</div><div class="pid-stats-label">reads (90 days)</div></div>' +
+          '<div class="pid-stats-card"><div class="pid-stats-num">' +
+            pageTotals.length.toLocaleString() +
+          '</div><div class="pid-stats-label">pages with traffic</div></div>' +
+          '<div class="pid-stats-card"><div class="pid-stats-num">' +
+            dailyDates.length +
+          '</div><div class="pid-stats-label">days of data</div></div>';
+
+        // Daily totals chart.
+        if (dailyMount && dailyDates.length) {
+          loadECharts(function (echarts) {
+            if (!echarts) return;
+            var chart;
+            try { chart = echarts.init(dailyMount, null, { renderer: "svg" }); }
+            catch (e) { return; }
+            chart.setOption({
+              grid: { left: 50, right: 16, top: 16, bottom: 36 },
+              xAxis: { type: "category", data: dailyDates,
+                       axisLabel: { hideOverlap: true } },
+              yAxis: { type: "value", name: "Reads / day" },
+              tooltip: {
+                trigger: "axis",
+                formatter: function (params) {
+                  var p = params[0];
+                  return p.name + "<br/>" + p.value.toLocaleString() +
+                         " reads";
+                },
+              },
+              series: [{
+                type: "line",
+                smooth: true,
+                showSymbol: false,
+                data: dailyDates.map(function (d) { return dailyMap[d]; }),
+                lineStyle: { width: 1.5 },
+                areaStyle: { opacity: 0.15 },
+              }],
+            });
+            window.addEventListener("resize", function () { chart.resize(); });
+          });
+        }
+
+        // Top-N table.
+        if (topMount) {
+          var N = 20;
+          var rows = pageTotals.slice(0, N).map(function (kv, i) {
+            var page = kv[0], count = kv[1];
+            // Sphinx pagename → URL. /index suffix means the directory
+            // landing page; other pages are direct.
+            var href = "/pid/" + page.replace(/\/index$/, "/");
+            return '<tr><td class="pid-stats-rank">' + (i + 1) +
+              '</td><td><a href="' + href + '">' + page + "</a></td>" +
+              '<td class="pid-stats-count">' + count.toLocaleString() +
+              "</td></tr>";
+          }).join("");
+          topMount.innerHTML =
+            '<table class="pid-stats-table"><thead><tr>' +
+            '<th class="pid-stats-rank">#</th><th>Page</th>' +
+            '<th class="pid-stats-count">Reads</th></tr></thead>' +
+            "<tbody>" + rows + "</tbody></table>";
+        }
+      })
+      .catch(function () { showEmpty(); });
+  }
+
   function loadECharts(cb) {
     if (window.echarts) return cb(window.echarts);
     var s = document.createElement("script");
@@ -210,6 +339,7 @@
       }, 15000);
     }
     renderSparkline();
+    renderStatsPage();
   }
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", boot);

--- a/_templates/pid-sidebar-extra.html
+++ b/_templates/pid-sidebar-extra.html
@@ -24,12 +24,16 @@
   </p>
   {% if pid_telemetry %}
   <hr/>
-  <p style="color:#777; font-size:0.85em; margin:0.3em 0 0.1em">Page views (90 days)</p>
+  <p style="color:#777; font-size:0.85em; margin:0.3em 0 0.1em">
+    Page views (90 days)<span id="pid-sparkline-total"
+      style="float:right; font-variant-numeric:tabular-nums"></span>
+  </p>
   <div id="pid-sparkline" style="width:100%; height:38px"
        data-page="{{ pagename }}"></div>
   {% endif %}
   <hr/>
   <p style="color:#777; font-size:0.85em">
+    <a href="{{ pathto('stats') }}">Stats</a> &nbsp;·&nbsp;
     <a href="{{ pathto('privacy') }}">Privacy</a>
   </p>
 </div>

--- a/contents.rst
+++ b/contents.rst
@@ -8,6 +8,7 @@ Process Improvement Using Data
 
    preface/index
    privacy
+   stats
 
 
 .. toctree::

--- a/docs/telemetry/README.md
+++ b/docs/telemetry/README.md
@@ -30,10 +30,11 @@ dashboards.
 .github/workflows/build-deploy.yml   # ECharts fetch step + telemetry env vars
 .gitignore                           # ignores _static/js/echarts-min.js
 _static/js/telemetry.js              # the entire client; ~220 lines
-_templates/pid-sidebar-extra.html    # sparkline mount + Privacy link
+_templates/pid-sidebar-extra.html    # sparkline mount, total-count, Stats + Privacy links
 conf.py                              # env-var gate + html-page-context hook
-contents.rst                         # adds privacy to hidden toctree
+contents.rst                         # adds privacy + stats to hidden toctree
 privacy.rst                          # reader-facing disclosure page
+stats.rst                            # in-book readership dashboard (filled by JS)
 scripts/server/build-sparklines.py        # nightly JSON builder for sparklines
 scripts/server/run-goaccess.sh            # nightly GoAccess wrapper
 scripts/server/caddy-json-to-combined.py  # filter: Caddy JSON → Apache combined
@@ -65,11 +66,18 @@ self-hosting reusers.
 3. **Search-query events** — what readers type into the sidebar
    search box, debounced and PII-stripped, sent to GoatCounter as
    custom events.
-4. **Per-page 90-day sparkline** — derived from the access logs by
-   `scripts/server/build-sparklines.py` into a public
+4. **Per-page 90-day sparkline + reader count** — derived from the
+   access logs by `scripts/server/build-sparklines.py` into a public
    `sparklines.json`, rendered with a same-origin ECharts build in
-   the sidebar of every page. Because it is log-derived it counts
-   ad-blocked readers — the *honest* signal.
+   the sidebar of every page. The 90-day total reads for the current
+   page are written next to the heading. Because it is log-derived it
+   counts ad-blocked readers — the *honest* signal.
+5. **In-book stats page** — [`/pid/stats`](https://learnche.org/pid/stats)
+   reads the same `sparklines.json` and shows three site-wide
+   widgets: a summary (total reads / pages with traffic / days of
+   data), a daily totals chart across the whole book, and a top-20
+   most-read pages table. All filled by `telemetry.js` at runtime;
+   empty-state hides the widgets cleanly when no data is available.
 
 ## Operating principles
 

--- a/docs/telemetry/client.md
+++ b/docs/telemetry/client.md
@@ -293,6 +293,26 @@ A page with no historical data (e.g. a freshly added page like
 and the "Page views (90 days)" heading. The alternative (showing a
 "0 hits" placeholder) would be misleading and visually noisy.
 
+### Phase 4c.5 — 90-day reader count in the heading
+
+After confirming the series is non-empty, but before any ECharts
+work, we compute the sum and write it into the sidebar heading:
+
+```js
+var totalEl = document.getElementById("pid-sparkline-total");
+if (totalEl) {
+  var total = series.reduce(function (a, p) { return a + p[1]; }, 0);
+  totalEl.textContent = total.toLocaleString() + " reads";
+}
+```
+
+The `<span id="pid-sparkline-total">` ships from
+`_templates/pid-sidebar-extra.html`, floated to the right of the
+"Page views (90 days)" heading. Tabular-numeric CSS keeps the digits
+aligned across pages. The `if (totalEl)` guard makes this a no-op
+when an older cached template doesn't have the span — pageview
+tracking and the sparkline still work.
+
 ### Phase 4d — render
 
 ```js
@@ -355,6 +375,54 @@ function loadECharts(cb) {
 * `onerror` is non-fatal: if ECharts is somehow missing we just don't
   render the sparkline. Pageview tracking is unaffected.
 
+## Section 4b — stats page (`/pid/stats`)
+
+`renderStatsPage()` runs on every page but exits immediately unless
+`#pid-stats-summary` is in the DOM. Only [`stats.rst`](../../stats.rst)
+ships that mount point, so the whole function is a no-op on every
+other page.
+
+When the mount is present, the function fetches the same
+`sparklines.json` the sidebar uses and fills three widgets:
+
+| Mount point | What's rendered |
+|---|---|
+| `#pid-stats-summary` | Three "big number" cards: total reads in the window, number of pages with at least one read, number of distinct days in the data. |
+| `#pid-stats-daily` | A daily-totals line chart — sum of reads across all pages per day, smoothed, with an area fill and axis-trigger tooltip. ECharts SVG renderer; lazy-loaded via the same `loadECharts()` the sparkline uses. |
+| `#pid-stats-top` | A table of the top-20 pages by 90-day total. Each row links to `/pid/<pagename>` (with `/index` stripped, so `data-visualization/index` → `/pid/data-visualization/`). |
+
+Aggregation is a single pass over `Object.keys(data)`:
+
+```js
+pages.forEach(function (page) {
+  var series = data[page] || [];
+  var pageTotal = 0;
+  series.forEach(function (p) {
+    var date = p[0], count = p[1] | 0;
+    totalReads += count;
+    pageTotal += count;
+    dailyMap[date] = (dailyMap[date] || 0) + count;
+  });
+  if (pageTotal > 0) pageTotals.push([page, pageTotal]);
+});
+pageTotals.sort(function (a, b) { return b[1] - a[1]; });
+```
+
+The `| 0` coerces to int (defends against a future schema change
+that emits floats). Pages whose 90-day total is zero are dropped
+from the top-N consideration but still count in `totalReads`.
+
+Empty-state behaviour is uniform across all three widgets: if
+`sparklines.json` is missing, malformed, or empty, the summary is
+replaced with an italic "Statistics aren't available yet…" message
+and the chart + table mounts are hidden via `style.display = "none"`.
+The page never appears broken — just empty.
+
+CSS for the cards and table lives in
+`_static/css/theme-extended-kgd.css` under the "stats page widgets"
+section; every selector is namespaced to `.pid-stats-*` so it cannot
+leak into the rest of the book.
+
 ## Section 5 — boot
 
 ```js
@@ -362,6 +430,7 @@ function boot() {
   hookSphinxSearch();
   if (!hookPagefindSearch()) { /* MutationObserver */ }
   renderSparkline();
+  renderStatsPage();
 }
 if (document.readyState === "loading") {
   document.addEventListener("DOMContentLoaded", boot);
@@ -374,6 +443,10 @@ The `defer` attribute on the script tag means the browser waits to
 execute until parsing is done, but `defer` doesn't fire its callback
 **after** `DOMContentLoaded` in every browser; we use the
 `readyState` check as belt-and-braces.
+
+`renderStatsPage()` runs on every page but cheaply early-returns when
+`#pid-stats-summary` is absent (which is all but the
+[`/pid/stats`](https://learnche.org/pid/stats) page).
 
 ## Footprint
 

--- a/privacy.rst
+++ b/privacy.rst
@@ -24,7 +24,9 @@ What is collected
 The resulting aggregates — top pages, the 90-day per-page sparklines you see
 in the sidebar, search queries, and an overview report — are **public** at
 `learnche.org/_stats/ <https://learnche.org/_stats/>`_, in keeping with the
-open spirit of this CC BY-SA 4.0 book.
+open spirit of this CC BY-SA 4.0 book. The same numbers are also surfaced
+inside the book itself on the :ref:`stats` page, and as the 90-day reader
+count next to the sparkline in the sidebar of every page.
 
 Opt out
 -------

--- a/stats.rst
+++ b/stats.rst
@@ -1,0 +1,53 @@
+.. _stats:
+
+Readership statistics
+=====================
+
+This page shows aggregated, anonymous readership for the HTML edition of
+the book. The numbers come from the server access logs — so they include
+readers who block JavaScript trackers — and are bucketed into daily
+unique-IP counts per page. The IPs are discarded after aggregation; only
+the daily counts survive. The same dataset feeds the small sparkline you
+see in the sidebar of every page.
+
+See :ref:`privacy` for what is and isn't collected.
+
+Summary
+-------
+
+.. raw:: html
+
+   <div id="pid-stats-summary" class="pid-stats-summary">
+     <p style="color:#777"><em>Loading…</em></p>
+   </div>
+
+Daily reads (last 90 days)
+--------------------------
+
+Total reads per day across the whole book. Each daily bucket
+de-duplicates by IP, so two visits from the same reader on the same day
+count once.
+
+.. raw:: html
+
+   <div id="pid-stats-daily" style="width:100%; height:280px"></div>
+
+Most-read pages (last 90 days)
+------------------------------
+
+The 20 pages with the most reads over the 90-day window. Page names are
+the Sphinx page identifiers (e.g. ``data-visualization/box-plots``);
+click through to read them.
+
+.. raw:: html
+
+   <div id="pid-stats-top"></div>
+
+Raw data
+--------
+
+Every number on this page comes from a single public JSON file:
+`learnche.org/_stats/sparklines.json <https://learnche.org/_stats/sparklines.json>`_.
+The wider GoAccess dashboard
+(`learnche.org/_stats/ <https://learnche.org/_stats/>`_) shows the same
+pageviews plus referrers, devices, and country breakdowns.


### PR DESCRIPTION
## Summary

Surfaces aggregate readership inside the book itself, so readers (and the maintainer) can see what is being read without leaving the HTML. Two new pieces of reader-facing UI, both fed by the same `/_stats/sparklines.json` the existing sidebar sparkline uses.

**Track A** of the original telemetry plan. Track B (deploying the server-side cron + Caddy log directive) stays parked until the migration from the Apache host happens.

## What's added

**Sidebar — 90-day reader count next to the sparkline**

A small `1,234 reads` floats next to the existing "Page views (90 days)" heading. `telemetry.js` sums the per-page series and writes the total into a new `<span id="pid-sparkline-total">` in `pid-sidebar-extra.html`. Tabular-numeric CSS keeps digits aligned across pages.

**New `/pid/stats` page**

Top-level page (`stats.rst`, hidden toctree entry in `contents.rst`). Three runtime-filled widgets, all sourced from the same JSON file:

| Mount | What it shows |
|---|---|
| `#pid-stats-summary` | Three big-number cards: total reads (90 days), pages with traffic, days of data |
| `#pid-stats-daily` | Daily totals ECharts line chart across the whole book |
| `#pid-stats-top` | Top-20 most-read pages table, linking back into the book |

Empty-state hides the chart + table and replaces the summary with an italic *"Statistics aren't available yet…"* message, so the page is never broken — neither in non-telemetry builds nor in production before the cron has produced data.

Aggregation is one pass over `Object.keys(data)`; counts are clamped via `| 0` to defend against a hypothetical future schema with floats. Top-N href construction strips trailing `/index` back to `/` so directory landing pages resolve to the right URLs (e.g. `data-visualization/index` → `/pid/data-visualization/`).

**Other**

- Sidebar gets a `Stats · Privacy` link pair (was just "Privacy").
- `privacy.rst` gets one sentence pointing at the new stats page.
- Stats-page CSS is namespaced to `.pid-stats-*` in `_static/css/theme-extended-kgd.css` so it cannot leak.
- `docs/telemetry/README.md` and `docs/telemetry/client.md` updated with the new UI sections.
- `CITATION.cff` date bumped to 2026-05-24 per `CLAUDE.md`.

## What's not in scope

- Server deployment (`/etc/caddy/Caddyfile` log directive, cron, GoAccess install, GoatCounter Cloud signup) — still parked pending the Apache → Caddy migration.
- Production wouldn't show data until that deploy lands. The new UI gracefully empty-states until then.

## Test plan

- [x] `make text` builds cleanly. 330 warnings are preexisting `image.not_readable` / `Include file` artefacts from the sandbox lacking the `figures/` repo; CI checks out `kgdunn/figures` separately and produces a clean build.
- [x] `make html` (no env vars) builds `/pid/stats` with all three mount divs present; sidebar omits sparkline + total span (gated by `pid_telemetry`).
- [x] `PID_BOOK_TELEMETRY=1 PID_BOOK_GC_CODE=learnche-pid make html` confirms `telemetry.js` is loaded, `__PID_TELEMETRY` inline globals land in `/pid/stats`, and `pid-sparkline-total` lands in regular book pages.
- [x] Aggregation logic verified against a synthetic JSON: totals, per-page sort, daily union, `/index → /` href rewriting all behave as documented in `docs/telemetry/sparklines-schema.md`.
- [ ] CI to confirm `make html` and `make latexpdf` succeed with full `figures/`.
- [ ] After server-side deploy ships, eyeball the stats page on `learnche.org/pid/stats` and confirm the sidebar count appears.

https://claude.ai/code/session_01VGw7f4BEC1Za4tBeLJ3jcG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGw7f4BEC1Za4tBeLJ3jcG)_