### PR TITLE
Turn off ECharts line smoothing on the sparkline charts

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.05.24"
-date-released: 2026-05-24
+version: "2026.05.25"
+date-released: 2026-05-25
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/_static/js/telemetry.js
+++ b/_static/js/telemetry.js
@@ -177,7 +177,7 @@
                 type: "line",
                 data: values,
                 showSymbol: false,
-                smooth: true,
+                smooth: false,
                 lineStyle: { width: 1.5 },
                 areaStyle: { opacity: 0.15 },
               },
@@ -277,7 +277,7 @@
               },
               series: [{
                 type: "line",
-                smooth: true,
+                smooth: false,
                 showSymbol: false,
                 data: dailyDates.map(function (d) { return dailyMap[d]; }),
                 lineStyle: { width: 1.5 },


### PR DESCRIPTION
## Summary

Disable ECharts line smoothing on both sparkline charts. Raw points connected by straight line segments now, rather than smoothed curves.

Affects:

- Sidebar 90-day per-page sparkline (every book page)
- Daily-totals chart on `/pid/stats`

Per maintainer preference. Two-character change in `_static/js/telemetry.js`: `smooth: true` → `smooth: false` in both `setOption` calls.

`CITATION.cff` date bumped to 2026-05-25 per CLAUDE.md.

## Test plan

- [x] `grep smooth _static/js/telemetry.js` shows both occurrences are now `false`.
- [ ] After merge + deploy, reload any book page and confirm the sidebar sparkline shows angular segments. Same for `/pid/stats` daily chart.

https://claude.ai/code/session_01VGw7f4BEC1Za4tBeLJ3jcG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGw7f4BEC1Za4tBeLJ3jcG)_