### PR TITLE
Bottom-10 stats widget + GoAccess 1.4 fixes backported to repo

### DIFF
--- a/_static/js/telemetry.js
+++ b/_static/js/telemetry.js
@@ -194,17 +194,19 @@
   }
 
   // 4b. Stats page widgets. Run only if the /pid/stats page is loaded,
-  // detected by the presence of #pid-stats-summary in the DOM. Three
+  // detected by the presence of #pid-stats-summary in the DOM. Four
   // mounts are filled from the same sparklines.json the sidebar uses:
   //   #pid-stats-summary  — three big-number cards (reads, pages, days)
   //   #pid-stats-daily    — daily-totals line chart across all pages
   //   #pid-stats-top      — top-20 most-read pages table
+  //   #pid-stats-bottom   — bottom-10 least-read pages table
   function renderStatsPage() {
     var summary = document.getElementById("pid-stats-summary");
     if (!summary) return;
 
     var dailyMount = document.getElementById("pid-stats-daily");
     var topMount = document.getElementById("pid-stats-top");
+    var bottomMount = document.getElementById("pid-stats-bottom");
 
     function showEmpty(msg) {
       summary.innerHTML =
@@ -214,6 +216,26 @@
         "</em></p>";
       if (dailyMount) dailyMount.style.display = "none";
       if (topMount) topMount.style.display = "none";
+      if (bottomMount) bottomMount.style.display = "none";
+    }
+
+    // Build a [rank, page-link, count] HTML table from an array of
+    // [pagename, count] entries already in display order.
+    function buildPageTable(entries) {
+      var rows = entries.map(function (kv, i) {
+        var page = kv[0], count = kv[1];
+        // Sphinx pagename → URL. /index suffix means the directory
+        // landing page; other pages are direct.
+        var href = "/pid/" + page.replace(/\/index$/, "/");
+        return '<tr><td class="pid-stats-rank">' + (i + 1) +
+          '</td><td><a href="' + href + '">' + page + "</a></td>" +
+          '<td class="pid-stats-count">' + count.toLocaleString() +
+          "</td></tr>";
+      }).join("");
+      return '<table class="pid-stats-table"><thead><tr>' +
+        '<th class="pid-stats-rank">#</th><th>Page</th>' +
+        '<th class="pid-stats-count">Reads</th></tr></thead>' +
+        "<tbody>" + rows + "</tbody></table>";
     }
 
     fetch("/_stats/sparklines.json", { cache: "force-cache" })
@@ -288,24 +310,17 @@
           });
         }
 
-        // Top-N table.
+        // Top-N table (most-read pages).
         if (topMount) {
-          var N = 20;
-          var rows = pageTotals.slice(0, N).map(function (kv, i) {
-            var page = kv[0], count = kv[1];
-            // Sphinx pagename → URL. /index suffix means the directory
-            // landing page; other pages are direct.
-            var href = "/pid/" + page.replace(/\/index$/, "/");
-            return '<tr><td class="pid-stats-rank">' + (i + 1) +
-              '</td><td><a href="' + href + '">' + page + "</a></td>" +
-              '<td class="pid-stats-count">' + count.toLocaleString() +
-              "</td></tr>";
-          }).join("");
-          topMount.innerHTML =
-            '<table class="pid-stats-table"><thead><tr>' +
-            '<th class="pid-stats-rank">#</th><th>Page</th>' +
-            '<th class="pid-stats-count">Reads</th></tr></thead>' +
-            "<tbody>" + rows + "</tbody></table>";
+          topMount.innerHTML = buildPageTable(pageTotals.slice(0, 20));
+        }
+
+        // Bottom-N table (least-read pages — ascending, lowest first).
+        // Pages with zero hits never reach the JSON, so this only
+        // surfaces pages with at least one read in the window.
+        if (bottomMount) {
+          var bottom = pageTotals.slice(-10).reverse();
+          bottomMount.innerHTML = buildPageTable(bottom);
         }
       })
       .catch(function () { showEmpty(); });

--- a/docs/telemetry/operations.md
+++ b/docs/telemetry/operations.md
@@ -472,6 +472,56 @@ same JSON echoed back, the filter is rejecting the input — inspect the
 JSON shape against `parse_caddy_json` in
 [`build-sparklines.py`](../../scripts/server/build-sparklines.py).
 
+### "GoAccess writes 0 bytes despite parsing millions of log lines."
+
+You'll see the progress counter complete (`Parsing... [N,NNN,NNN]`),
+the wrapper print `wrote ... (0 bytes)`, and the report file is
+empty. RC is 0 — silent failure.
+
+Likely causes (in order of how often they bite):
+
+1. **GoAccess 1.4 silently refuses any `--output` path whose final
+   extension isn't `.html`, `.csv`, or `.json`.** `mktemp
+   /tmp/run-goaccess.html.XXXXXX` produces filenames like
+   `/tmp/run-goaccess.html.aBcDeF` — the last extension is `.aBcDeF`,
+   not `.html`, and goaccess emits an error to stderr (often hidden by
+   shell pipelines) and exits 0. The fix in `run-goaccess.sh` is to use
+   `mktemp --suffix=.html /tmp/run-goaccess.XXXXXX` so the random part
+   is in the middle.
+
+2. **`--anonymize-ip` was added in GoAccess 1.6.** On 1.4 the flag is
+   silently accepted but causes 0-byte output. Drop the flag (and the
+   matching `anonymize-ip true` directive from `goaccessrc`) on 1.4;
+   use `ignore-panel HOSTS` for equivalent privacy (raw IPs never reach
+   the rendered HTML).
+
+3. **`html-prefs` was added in GoAccess 1.6.** Same silent 0-byte
+   failure on 1.4 if the directive is in the config file.
+
+Confirm which by running goaccess against a single small log
+**without** the wrapper:
+
+```sh
+sudo cat /var/www/logs/learnche.org/access.log \
+  | /usr/local/bin/caddy-json-to-combined.py \
+  | goaccess - --no-global-config --config-file=/dev/null \
+      --log-format=COMBINED --output=/tmp/diag.html 2>&1
+ls -la /tmp/diag.html
+```
+
+This bypasses the conf and uses an unambiguous `.html` filename. If
+*this* produces a real file but the wrapper doesn't, the conf or the
+mktemp template is the culprit — patch the relevant fix above.
+
+### "Bottom-10 stats page shows weird URLs like `_downloads/...`"
+
+`build-sparklines.py`'s `normalise_pagename()` filters out
+`/_static/`, `/_sources/`, `/_images/`, `/_downloads/`, and
+`/pagefind/` so Sphinx-generated download artifacts don't pollute the
+page list. If a new Sphinx category appears (e.g. `/_modules/`), add
+it to the filter list and re-run `build-sparklines.py` — the next
+nightly rebuild will drop it.
+
 ## Periodic maintenance
 
 * **Quarterly**: review `/etc/pid-book/bots.txt` against current

--- a/scripts/server/build-sparklines.py
+++ b/scripts/server/build-sparklines.py
@@ -362,7 +362,8 @@ def normalise_pagename(path: str) -> str | None:
     # Internal endpoints that aren't book pages.
     if rest in ("search", "genindex", "py-modindex"):
         return None
-    if rest.startswith("_static/") or rest.startswith("_sources/") or rest.startswith("_images/"):
+    if (rest.startswith("_static/") or rest.startswith("_sources/")
+            or rest.startswith("_images/") or rest.startswith("_downloads/")):
         return None
     if rest.startswith("pagefind/") or rest == "pagefind":
         return None

--- a/scripts/server/goaccessrc.example
+++ b/scripts/server/goaccessrc.example
@@ -3,41 +3,18 @@
 # Install as /etc/pid-book/goaccessrc (or pass via GOACCESS_CONF env var
 # to scripts/server/run-goaccess.sh).
 #
+# This file is compatible with GoAccess >= 1.4 (the Debian 11 / stable
+# version). Directives added in later versions are intentionally absent;
+# see "Why directives are missing" at the bottom for details.
+#
 # Reference: https://goaccess.io/man
 
 # ---------------------------------------------------------------------------
-# Display
+# Bot filtering.
 # ---------------------------------------------------------------------------
 
-html-report-title learnche.org/pid — readership
-html-prefs {"theme":"darkBlue","perPage":20}
-
-# ---------------------------------------------------------------------------
-# Bot filtering. Mirror this list with scripts/server/build-sparklines.py
-# (the FALLBACK_BOT_SUBSTRINGS list there) so both pipelines exclude the
-# same crawlers.
-# ---------------------------------------------------------------------------
-
-# Built-in crawler list (Googlebot, bingbot, ...).
+# Use GoAccess's built-in crawler list (Googlebot, bingbot, ...).
 ignore-crawlers true
-
-# Specific UA strings GoAccess may not catch by default.
-ignore-referer GPTBot
-ignore-referer ClaudeBot
-ignore-referer anthropic-ai
-ignore-referer CCBot
-ignore-referer PerplexityBot
-ignore-referer Bytespider
-ignore-referer AhrefsBot
-ignore-referer SemrushBot
-ignore-referer MJ12bot
-ignore-referer DotBot
-ignore-referer PetalBot
-ignore-referer Amazonbot
-ignore-referer Applebot
-ignore-referer archive.org_bot
-ignore-referer ia_archiver
-ignore-referer wayback
 
 # ---------------------------------------------------------------------------
 # Static-asset filtering. These are served, but they aren't pageviews.
@@ -64,15 +41,37 @@ static-file .map
 static-file .txt
 
 # ---------------------------------------------------------------------------
-# Privacy. We never serve raw IPs in the dashboard.
-# ---------------------------------------------------------------------------
-
-anonymize-ip true
-
-# ---------------------------------------------------------------------------
-# Panels. Keep things scannable; geography and visit-by-OS are interesting,
-# but raw referrers are noisy and IPs are sensitive.
+# Panels. Keep things scannable; geography and visit-by-OS are
+# interesting; raw visitor IPs are sensitive (HOSTS panel suppressed
+# so the public dashboard never displays them).
 # ---------------------------------------------------------------------------
 
 ignore-panel HOSTS
 ignore-panel KEYPHRASES
+
+# ---------------------------------------------------------------------------
+# Why directives are missing (compatibility notes)
+# ---------------------------------------------------------------------------
+#
+# * html-prefs   — added in GoAccess 1.6. On 1.4 it is silently rejected
+#                  but causes the HTML output to be empty (0 bytes).
+#                  Override the theme via --html-prefs on the CLI if
+#                  needed on 1.6+.
+#
+# * anonymize-ip — added in GoAccess 1.6. Same 0-byte failure on 1.4.
+#                  We mitigate by setting "ignore-panel HOSTS" above,
+#                  which keeps IPs out of the rendered report even if
+#                  they reach GoAccess internally. If you upgrade to
+#                  1.6+ you can re-add this for defence in depth.
+#
+# * ignore-referer — this directive filters Referer headers (URLs), not
+#                    User-Agent substrings. Previous versions of this
+#                    file listed UA names like "GPTBot" under it, which
+#                    was a no-op. UA-based bot filtering is done via
+#                    --ignore-crawlers and build-sparklines.py's bot
+#                    list. If you want to drop spam referers (e.g.
+#                    semalt.com), add lines here.
+#
+# * html-report-title — the wrapper passes this as a CLI flag instead,
+#                       partly to avoid encoding issues with unicode
+#                       (em-dashes) in the config file value.

--- a/scripts/server/run-goaccess.sh
+++ b/scripts/server/run-goaccess.sh
@@ -1,19 +1,31 @@
 #!/usr/bin/env bash
 # Nightly GoAccess report for /var/www/learnche.org/_stats/index.html.
 #
-# Designed to be invoked from cron. Atomic write: builds to a .tmp file
-# and renames into place so the public dashboard never serves a partial
-# file.
+# Designed to be invoked from cron. Stages the HTML in /tmp first
+# (so goaccess writes can't bump into permissions or AppArmor on the
+# /var/www/ path), then moves into place.
 #
-# The production webserver is Caddy, whose default access log is JSON
-# (one object per line). GoAccess does not understand Caddy JSON
-# natively, so we pipe through scripts/server/caddy-json-to-combined.py
-# which converts JSON lines to Apache combined format and passes any
-# already-combined lines (e.g. archived pre-Hetzner Apache logs) through
-# unchanged. The unioned stream is then fed to goaccess as combined.
+# The pipeline pipes log input through caddy-json-to-combined.py, which
+# converts Caddy JSON lines to Apache combined format and passes
+# already-combined lines (Apache logs) through unchanged. Both formats
+# in the same input stream are fine.
 #
-# Configuration is read from /etc/pid-book/goaccessrc by default
-# (see scripts/server/goaccessrc.example for a template).
+# Configuration:
+#   * /etc/pid-book/goaccessrc is loaded if present (see
+#     scripts/server/goaccessrc.example for a template; the example is
+#     known compatible with GoAccess 1.4 — the Debian 11 version).
+#   * LOG_GLOBS env var overrides the default log paths. Set this for
+#     Apache servers; the default below tries Caddy first, Apache
+#     second.
+#
+# Known GoAccess 1.4 gotchas the wrapper accounts for:
+#   1. --output=<path> rejects any path whose final extension is not
+#      .html/.csv/.json. We use mktemp --suffix=.html for that reason.
+#   2. --anonymize-ip was added in 1.6; passing it on 1.4 is silently
+#      accepted but causes 0-byte output. Omitted here.
+#   3. goaccess errors during HTML generation may be printed only to
+#      stderr; the wrapper redirects stderr into the pipeline so cron
+#      mail and /var/log/pid-book-stats.log catch them.
 
 set -euo pipefail
 
@@ -22,11 +34,12 @@ set -euo pipefail
 # --------------------------------------------------------------------------
 
 LOG_GLOBS_DEFAULT=(
-    # Caddy's default per-host access log on Debian/Ubuntu installs
-    # (the path you use depends on the Caddyfile `output file` directive;
-    #  see docs/telemetry/server-runbook.md).
+    # Try common Caddy / Apache / Nginx default per-host log locations.
+    # If your server is elsewhere, set LOG_GLOBS in the cron file.
     "/var/log/caddy/learnche.org.access.log*"
-    # Archived pre-Hetzner Apache logs (combined format; passed through).
+    "/var/www/logs/learnche.org/access.log*"
+    "/var/log/apache2/learnche.org-access.log*"
+    "/var/log/nginx/learnche.org.access.log*"
     "/var/log/learnche-archive/access.log*"
 )
 
@@ -74,15 +87,17 @@ if [[ ${#log_files[@]} -eq 0 ]]; then
     exit 3
 fi
 
-TMP="$(mktemp -p "${OUTPUT_DIR}" .index.html.XXXXXX)"
+# Stage in /tmp first. Two reasons:
+#   (a) some goaccess builds (and AppArmor profiles) refuse writes
+#       outside /tmp when running as root.
+#   (b) mktemp --suffix=.html ensures the output filename ends in
+#       .html, which goaccess 1.4 requires.
+TMP="$(mktemp --suffix=.html /tmp/run-goaccess.XXXXXX)"
 trap 'rm -f "${TMP}"' EXIT
 
 # --------------------------------------------------------------------------
-# Run.
-#
-# zcat -f handles both plain and .gz files. The JSON filter passes
-# combined-format lines through unchanged, so a mixed stream is fine.
-# Bot, static-asset and panel filters live in goaccessrc.
+# Run. stderr is merged into stdout so any goaccess errors land in the
+# same place cron's MAILTO / journal logs already capture.
 # --------------------------------------------------------------------------
 
 zcat -f "${log_files[@]}" |
@@ -92,13 +107,18 @@ zcat -f "${log_files[@]}" |
         --log-format=COMBINED \
         --no-global-config \
         --ignore-crawlers \
-        --anonymize-ip \
         --4xx-to-unique-count \
-        --html-report-title='learnche.org/pid — readership' \
-        --output="${TMP}"
+        --html-report-title='learnche.org/pid readership' \
+        --output="${TMP}" 2>&1
 
-# Move into place atomically. mv on the same filesystem is atomic,
-# so HTTP clients never see a half-written file.
+# Sanity check: goaccess sometimes returns 0 even after a write error.
+# Refuse to publish a zero-byte report — leaves the previous good one
+# in place.
+if [[ ! -s "${TMP}" ]]; then
+    echo "run-goaccess: goaccess produced zero bytes; not publishing." >&2
+    exit 4
+fi
+
 chmod 0644 "${TMP}"
 mv -f "${TMP}" "${OUTPUT_FILE}"
 trap - EXIT

--- a/stats.rst
+++ b/stats.rst
@@ -43,6 +43,26 @@ click through to read them.
 
    <div id="pid-stats-top"></div>
 
+Least-read pages (last 90 days)
+-------------------------------
+
+The 10 pages with the *fewest* reads over the 90-day window, lowest
+first. Useful for spotting sections that may need clearer links,
+better discoverability, or a refresh.
+
+.. note::
+
+   Pages with **zero** hits in the window do not appear in
+   ``sparklines.json`` and therefore never reach this table. So this
+   is "least-read pages that got at least one reader", not "unread
+   pages". To find truly unread pages, diff the Sphinx page list
+   against the JSON keys (see
+   ``docs/telemetry/operations.md``).
+
+.. raw:: html
+
+   <div id="pid-stats-bottom"></div>
+
 Raw data
 --------
 


### PR DESCRIPTION
## Summary

Two unrelated polish streams that came out of the live Apache deployment, bundled together because they touch overlapping files.

### 1. Bottom-10 widget on `/pid/stats`

New "Least-read pages (last 90 days)" section listing the 10 pages with the fewest reads, ascending. Useful for spotting sections that may need clearer links, better discoverability, or a refresh.

- `stats.rst` — new section with `#pid-stats-bottom` mount and an explicit note that pages with **zero** hits don't appear in `sparklines.json` (so this is "least-read but still read", not "unread"). To find unread pages, diff the Sphinx page list against the JSON keys — recipe in `docs/telemetry/operations.md`.
- `_static/js/telemetry.js` — `renderStatsPage()` fills the new bottom mount. Refactored the existing top-20 table builder into a shared `buildPageTable(entries)` helper so both top and bottom share the same row/style code.

### 2. GoAccess 1.4 compatibility — server-script fixes

These are the bugs we live-debugged on the Debian 11 Apache box that until now only existed on the production server. Backporting so a fresh `git pull` doesn't regress.

- `scripts/server/run-goaccess.sh`
  - **`mktemp --suffix=.html`** — *the* bug. GoAccess 1.4 silently refuses any `--output=` path whose final extension isn't `.html`/`.csv`/`.json`. Old template `mktemp .index.html.XXXXXX` produced `.aBcDeF` as the final extension. Cost hours of debugging — `goaccess` returns 0, emits its error only to stderr, and we never captured it.
  - **Drop `--anonymize-ip`** — added in 1.6; silently kills output on 1.4. `ignore-panel HOSTS` keeps IPs out of the rendered report instead.
  - **Stage in `/tmp/`** then `mv` — sidesteps a "Permission denied" we couldn't isolate when writing to `/var/www/` directly. The intermediate `mv` runs as root with no goaccess in the loop.
  - Default `LOG_GLOBS` now also tries `/var/www/logs/learnche.org/`, `/var/log/apache2/`, `/var/log/nginx/` — not just Caddy paths.
  - `2>&1` on the `goaccess` invocation so stderr lands in cron mail / `/var/log/pid-book-stats.log` when something is wrong. Never again silently-0-bytes.
  - Refuse to publish a zero-byte report (`-s` check before `mv` — previous good report stays in place).

- `scripts/server/goaccessrc.example`
  - Strip `html-prefs` (1.6+ — silent 0-byte failure on 1.4).
  - Strip `anonymize-ip` (same).
  - Strip the bogus `ignore-referer GPTBot` etc. block. `ignore-referer` filters Referer header URLs, not User-Agent substrings — that block was a no-op. UA filtering is done via `--ignore-crawlers` (built-in) plus `build-sparklines.py`'s bot list.
  - Move `html-report-title` to a CLI flag in the wrapper (also dodges unicode encoding issues with em-dashes in the conf value).
  - New "Why directives are missing" footer so future contributors don't reintroduce the broken ones.

- `scripts/server/build-sparklines.py`
  - `normalise_pagename()` also filters `/_downloads/` paths. Sphinx puts notebook downloads there; one (`_downloads/.../PCA-model-inversion.ipynb`) was polluting the live bottom-10 list.

### 3. Operations cookbook updates

`docs/telemetry/operations.md` — two new troubleshooting entries:

- **"GoAccess writes 0 bytes despite parsing millions of log lines."** — documents the three GoAccess-1.4 incompatibilities (mktemp suffix, `--anonymize-ip`, `html-prefs`) and a one-command diagnostic that bisects them.
- **"Bottom-10 stats page shows weird URLs like `_downloads/...`"** — explains the `normalise_pagename` filter list and how to extend it.

## Test plan

- [x] `make text` builds cleanly. The 330 warnings are preexisting `image.not_readable` artefacts from the sandbox lacking the figures repo; CI checks it out separately.
- [x] `bash -n` on the wrapper, `python -m ast` on `build-sparklines.py`, `node --check` on `telemetry.js` — all clean.
- [x] `normalise_pagename()` spot-checked against `/pid/_downloads/...ipynb` — now returns `None` as expected.
- [ ] CI to confirm `make html` + `make latexpdf` against full figures.
- [ ] After merge + deploy + a manual server-side `cd /opt/pid-book && git pull --ff-only`, run `sudo LOG_GLOBS='/var/www/logs/learnche.org/access.log*' /usr/local/bin/run-goaccess.sh` once and confirm the dashboard still updates with a multi-MB report.
- [ ] On `/pid/stats`, confirm the new Bottom-10 table renders correctly. Hard-reload (Cmd+Shift+R) if CF is caching the old page.

https://claude.ai/code/session_01VGw7f4BEC1Za4tBeLJ3jcG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGw7f4BEC1Za4tBeLJ3jcG)_