### PR TITLE
Fix orphan stats UI on browsers that block telemetry JS

### DIFF
--- a/_static/js/telemetry.js
+++ b/_static/js/telemetry.js
@@ -113,9 +113,14 @@
   }
 
   // 4. Sparkline. Lazy-loads ECharts only if the mount point exists.
+  // The sidebar template ships the whole block (heading + chart) hidden
+  // by default via `<div id="pid-sparkline-block" style="display:none">`.
+  // We only unhide it after the chart actually renders, so a blocked
+  // fetch / DNT / empty data path never leaves an orphan heading visible.
   function renderSparkline() {
     var mount = document.getElementById("pid-sparkline");
     if (!mount) return;
+    var block = document.getElementById("pid-sparkline-block");
     var pageKey = mount.getAttribute("data-page") || "";
     if (!pageKey) {
       // Fallback: derive from the URL when the template didn't supply one.
@@ -134,10 +139,8 @@
       .then(function (data) {
         var series = data && data[pageKey];
         if (!series || !series.length) {
-          // No history yet (e.g. a freshly added page). Hide silently.
-          var heading = mount.previousElementSibling;
-          if (heading && heading.tagName === "P") heading.style.display = "none";
-          mount.style.display = "none";
+          // No history for this page (e.g. fresh page, content blocker
+          // tampered with the JSON). Block stays hidden — nothing to do.
           return;
         }
         // Write the 90-day total into the sidebar heading, if its span
@@ -183,13 +186,16 @@
               },
             ],
           });
+          // Reveal the whole block now that the chart is actually drawn.
+          if (block) block.style.display = "";
           window.addEventListener("resize", function () {
             chart.resize();
           });
         });
       })
       .catch(function () {
-        /* network/JSON error: leave the empty mount; do not break the page */
+        /* network/JSON error or content blocker: block stays hidden;
+           the page never shows an orphan "Page views" heading. */
       });
   }
 
@@ -209,6 +215,10 @@
     var bottomMount = document.getElementById("pid-stats-bottom");
 
     function showEmpty(msg) {
+      // Replace whatever the page shipped (could be the "Statistics
+      // could not load" placeholder, or a previous render's content)
+      // with a JS-specific message. The chart/table mounts are already
+      // hidden by default in stats.rst — re-hide just in case.
       summary.innerHTML =
         '<p style="color:#777"><em>' +
         (msg || "Statistics aren't available yet. The nightly aggregator " +
@@ -277,7 +287,9 @@
             dailyDates.length +
           '</div><div class="pid-stats-label">days of data</div></div>';
 
-        // Daily totals chart.
+        // Daily totals chart. Mount is hidden by default in stats.rst
+        // (so it doesn't show a 280px-tall blank area when JS is blocked
+        // or the fetch fails); unhide after the chart actually renders.
         if (dailyMount && dailyDates.length) {
           loadECharts(function (echarts) {
             if (!echarts) return;
@@ -306,6 +318,7 @@
                 areaStyle: { opacity: 0.15 },
               }],
             });
+            dailyMount.style.display = "";
             window.addEventListener("resize", function () { chart.resize(); });
           });
         }
@@ -313,6 +326,7 @@
         // Top-N table (most-read pages).
         if (topMount) {
           topMount.innerHTML = buildPageTable(pageTotals.slice(0, 20));
+          topMount.style.display = "";
         }
 
         // Bottom-N table (least-read pages — ascending, lowest first).
@@ -321,6 +335,7 @@
         if (bottomMount) {
           var bottom = pageTotals.slice(-10).reverse();
           bottomMount.innerHTML = buildPageTable(bottom);
+          bottomMount.style.display = "";
         }
       })
       .catch(function () { showEmpty(); });

--- a/_templates/pid-sidebar-extra.html
+++ b/_templates/pid-sidebar-extra.html
@@ -23,13 +23,20 @@
        target="_blank">Suggest improvements; provide feedback; point out spelling, grammar, or other errors</a>
   </p>
   {% if pid_telemetry %}
-  <hr/>
-  <p style="color:#777; font-size:0.85em; margin:0.3em 0 0.1em">
-    Page views (90 days)<span id="pid-sparkline-total"
-      style="float:right; font-variant-numeric:tabular-nums"></span>
-  </p>
-  <div id="pid-sparkline" style="width:100%; height:38px"
-       data-page="{{ pagename }}"></div>
+  {# Wrapper starts hidden. _static/js/telemetry.js unhides it only after
+     the sparkline data is fetched and a chart actually renders. So:
+     - JS exits early (DNT, localhost, file://, content blocker, fetch
+       error, no data for this page) → whole block stays hidden, no
+       orphan "Page views" heading. #}
+  <div id="pid-sparkline-block" style="display:none">
+    <hr/>
+    <p style="color:#777; font-size:0.85em; margin:0.3em 0 0.1em">
+      Page views (90 days)<span id="pid-sparkline-total"
+        style="float:right; font-variant-numeric:tabular-nums"></span>
+    </p>
+    <div id="pid-sparkline" style="width:100%; height:38px"
+         data-page="{{ pagename }}"></div>
+  </div>
   {% endif %}
   <hr/>
   <p style="color:#777; font-size:0.85em">

--- a/stats.rst
+++ b/stats.rst
@@ -18,7 +18,11 @@ Summary
 .. raw:: html
 
    <div id="pid-stats-summary" class="pid-stats-summary">
-     <p style="color:#777"><em>Loading…</em></p>
+     <p style="color:#777"><em>Statistics could not load. Common reasons:
+     Do Not Track is enabled in your browser, a content blocker is
+     hiding <code>/_stats/sparklines.json</code>, or the nightly
+     aggregator hasn't produced data yet. The numbers will appear when
+     the data file is reachable.</em></p>
    </div>
 
 Daily reads (last 90 days)
@@ -30,7 +34,7 @@ count once.
 
 .. raw:: html
 
-   <div id="pid-stats-daily" style="width:100%; height:280px"></div>
+   <div id="pid-stats-daily" style="width:100%; height:280px; display:none"></div>
 
 Most-read pages (last 90 days)
 ------------------------------
@@ -41,7 +45,7 @@ click through to read them.
 
 .. raw:: html
 
-   <div id="pid-stats-top"></div>
+   <div id="pid-stats-top" style="display:none"></div>
 
 Least-read pages (last 90 days)
 -------------------------------
@@ -61,7 +65,7 @@ better discoverability, or a refresh.
 
 .. raw:: html
 
-   <div id="pid-stats-bottom"></div>
+   <div id="pid-stats-bottom" style="display:none"></div>
 
 Raw data
 --------


### PR DESCRIPTION
## Summary

Fixes the "orphan heading on Android" bug reported from a screenshot: with Do Not Track on (or a content blocker that hides `/_stats/sparklines.json`), the sidebar showed *"Page views (90 days)"* with **nothing** under it. Same problem on `/pid/stats` — the *"Loading…"* placeholder lived forever because the JS that would replace it never ran.

Confirmed by the reporter: opening the same URL in a different browser on the same Android device shows the sparkline correctly. So the source-side HTML wasn't broken; it was just that the visible scaffolding was emitted unconditionally and never cleaned up when the JS early-returned.

## Fix

Make every stats UI element **hidden by default** in the rendered HTML, and have `telemetry.js` unhide each element only at the moment its specific data is on-screen. If JS doesn't run at all, or the fetch fails, the page looks clean instead of broken.

- **`_templates/pid-sidebar-extra.html`** — wrap the whole sparkline block (hr + heading + chart div) in `<div id="pid-sparkline-block" style="display:none">`. `renderSparkline()` reveals it only after `chart.setOption` succeeds.
- **`stats.rst`** — chart and table mounts (`#pid-stats-daily`, `-top`, `-bottom`) ship with `style="display:none"`. The summary div's placeholder was *"Loading…"* — lied forever if JS was blocked. Changed to a concrete fallback that explains the likely causes (DNT, content blocker, no data yet); replaced by real stats when JS runs.
- **`_static/js/telemetry.js`** — track the block element at the start of `renderSparkline()`, drop the now-redundant in-JS hide of heading / mount, and reveal each stats mount (`dailyMount`, `topMount`, `bottomMount`) at the exact moment its data is on-screen.

## Behaviour matrix

| Scenario | Sidebar | `/pid/stats` |
|---|---|---|
| DNT on / fetch blocked | hidden | "could not load" message |
| Fetch returns empty for this page | hidden | message |
| Fetch returns data | revealed | widgets revealed |

## Test plan

- [x] `node --check _static/js/telemetry.js` clean.
- [x] `make text` builds clean (the 330 sandbox warnings are preexisting figures-stub artefacts).
- [x] `make html` (no telemetry) — confirms the sidebar block isn't emitted at all (gated by `{% if pid_telemetry %}` as before).
- [x] `PID_BOOK_TELEMETRY=1 make html` — confirms the sidebar block ships **with** `style="display:none"`, and all three stats mounts (`pid-stats-daily`, `-top`, `-bottom`) ship hidden by default.
- [ ] On Android with DNT on, after merge + deploy + cache bypass — confirm sidebar shows no orphan heading. `/pid/stats` shows the new fallback message instead of "Loading…".
- [ ] On iPad / desktop where JS runs — confirm everything still renders.

https://claude.ai/code/session_01VGw7f4BEC1Za4tBeLJ3jcG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGw7f4BEC1Za4tBeLJ3jcG)_