### PR TITLE
Switch sparkline window from 90 to 365 days

### DIFF
--- a/_static/js/telemetry.js
+++ b/_static/js/telemetry.js
@@ -8,8 +8,8 @@
  * Four responsibilities:
  *   1. Pageview pixel via GoatCounter (loaded async).
  *   2. Search-query event capture from BOTH Sphinx and Pagefind boxes.
- *   3. 90-day pageview sparkline in the sidebar (ECharts, lazy-loaded),
- *      with the per-page 90-day total written into #pid-sparkline-total.
+ *   3. Yearly pageview sparkline in the sidebar (ECharts, lazy-loaded),
+ *      with the per-page total written into #pid-sparkline-total.
  *   4. The /pid/stats page: site-wide summary, daily-totals chart, and
  *      top-N table sourced from the same /_stats/sparklines.json.
  *
@@ -143,8 +143,8 @@
           // tampered with the JSON). Block stays hidden — nothing to do.
           return;
         }
-        // Write the 90-day total into the sidebar heading, if its span
-        // is present (template ships it; older builds may not).
+        // Write the total-reads-in-window into the sidebar heading, if
+        // its span is present (template ships it; older builds may not).
         var totalEl = document.getElementById("pid-sparkline-total");
         if (totalEl) {
           var total = series.reduce(function (a, p) { return a + p[1]; }, 0);
@@ -279,7 +279,7 @@
         summary.innerHTML =
           '<div class="pid-stats-card"><div class="pid-stats-num">' +
             totalReads.toLocaleString() +
-          '</div><div class="pid-stats-label">reads (90 days)</div></div>' +
+          '</div><div class="pid-stats-label">reads (365 days)</div></div>' +
           '<div class="pid-stats-card"><div class="pid-stats-num">' +
             pageTotals.length.toLocaleString() +
           '</div><div class="pid-stats-label">pages with traffic</div></div>' +

--- a/_templates/pid-sidebar-extra.html
+++ b/_templates/pid-sidebar-extra.html
@@ -31,7 +31,7 @@
   <div id="pid-sparkline-block" style="display:none">
     <hr/>
     <p style="color:#777; font-size:0.85em; margin:0.3em 0 0.1em">
-      Page views (90 days)<span id="pid-sparkline-total"
+      Page views (365 days)<span id="pid-sparkline-total"
         style="float:right; font-variant-numeric:tabular-nums"></span>
     </p>
     <div id="pid-sparkline" style="width:100%; height:38px"

--- a/docs/telemetry/README.md
+++ b/docs/telemetry/README.md
@@ -66,10 +66,10 @@ self-hosting reusers.
 3. **Search-query events** — what readers type into the sidebar
    search box, debounced and PII-stripped, sent to GoatCounter as
    custom events.
-4. **Per-page 90-day sparkline + reader count** — derived from the
+4. **Per-page year-long sparkline + reader count** — derived from the
    access logs by `scripts/server/build-sparklines.py` into a public
    `sparklines.json`, rendered with a same-origin ECharts build in
-   the sidebar of every page. The 90-day total reads for the current
+   the sidebar of every page. The 365-day total reads for the current
    page are written next to the heading. Because it is log-derived it
    counts ad-blocked readers — the *honest* signal.
 5. **In-book stats page** — [`/pid/stats`](https://learnche.org/pid/stats)

--- a/docs/telemetry/architecture.md
+++ b/docs/telemetry/architecture.md
@@ -96,7 +96,7 @@ spots.
 * **Limitations:** same ad-block undercounting as Layer B; the
   email-regex guard is heuristic, not bulletproof.
 
-### Layer D — Per-page 90-day sparkline
+### Layer D — Per-page year-long sparkline
 
 * **Source:** same access logs as Layer A, processed by
   [`scripts/server/build-sparklines.py`](../../scripts/server/build-sparklines.py)

--- a/docs/telemetry/build-and-deploy.md
+++ b/docs/telemetry/build-and-deploy.md
@@ -158,7 +158,7 @@ has two telemetry-related blocks:
 ```jinja
 {% if pid_telemetry %}
 <hr/>
-<p style="color:#777; font-size:0.85em; margin:0.3em 0 0.1em">Page views (90 days)</p>
+<p style="color:#777; font-size:0.85em; margin:0.3em 0 0.1em">Page views (365 days)</p>
 <div id="pid-sparkline" style="width:100%; height:38px"
      data-page="{{ pagename }}"></div>
 {% endif %}

--- a/docs/telemetry/client.md
+++ b/docs/telemetry/client.md
@@ -290,10 +290,10 @@ if (!series || !series.length) {
 
 A page with no historical data (e.g. a freshly added page like
 `privacy` itself) gets **no UI at all** — we hide both the mount
-and the "Page views (90 days)" heading. The alternative (showing a
+and the "Page views (365 days)" heading. The alternative (showing a
 "0 hits" placeholder) would be misleading and visually noisy.
 
-### Phase 4c.5 — 90-day reader count in the heading
+### Phase 4c.5 — reader count in the heading
 
 After confirming the series is non-empty, but before any ECharts
 work, we compute the sum and write it into the sidebar heading:
@@ -308,7 +308,7 @@ if (totalEl) {
 
 The `<span id="pid-sparkline-total">` ships from
 `_templates/pid-sidebar-extra.html`, floated to the right of the
-"Page views (90 days)" heading. Tabular-numeric CSS keeps the digits
+"Page views (365 days)" heading. Tabular-numeric CSS keeps the digits
 aligned across pages. The `if (totalEl)` guard makes this a no-op
 when an older cached template doesn't have the span — pageview
 tracking and the sparkline still work.
@@ -389,7 +389,7 @@ When the mount is present, the function fetches the same
 |---|---|
 | `#pid-stats-summary` | Three "big number" cards: total reads in the window, number of pages with at least one read, number of distinct days in the data. |
 | `#pid-stats-daily` | A daily-totals line chart — sum of reads across all pages per day, smoothed, with an area fill and axis-trigger tooltip. ECharts SVG renderer; lazy-loaded via the same `loadECharts()` the sparkline uses. |
-| `#pid-stats-top` | A table of the top-20 pages by 90-day total. Each row links to `/pid/<pagename>` (with `/index` stripped, so `data-visualization/index` → `/pid/data-visualization/`). |
+| `#pid-stats-top` | A table of the top-20 pages by 365-day total. Each row links to `/pid/<pagename>` (with `/index` stripped, so `data-visualization/index` → `/pid/data-visualization/`). |
 
 Aggregation is a single pass over `Object.keys(data)`:
 
@@ -409,7 +409,7 @@ pageTotals.sort(function (a, b) { return b[1] - a[1]; });
 ```
 
 The `| 0` coerces to int (defends against a future schema change
-that emits floats). Pages whose 90-day total is zero are dropped
+that emits floats). Pages whose 365-day total is zero are dropped
 from the top-N consideration but still count in `totalReads`.
 
 Empty-state behaviour is uniform across all three widgets: if

--- a/docs/telemetry/operations.md
+++ b/docs/telemetry/operations.md
@@ -174,7 +174,7 @@ If you **rename or move** an existing page (e.g.
 * New pagename starts with empty history; sparkline mount is hidden.
 * Old pagename keeps its history but no new hits accrue (because the
   URL no longer resolves). The orphan key stays in the JSON until it
-  scrolls out of the 90-day window. This is fine — just expected.
+  scrolls out of the 365-day window. This is fine — just expected.
 
 ## Disabling telemetry, partially or fully
 
@@ -334,7 +334,7 @@ section for the canonical talking points.
 
 ### "The sparkline shows nothing on a page that should have data."
 
-Symptoms: sidebar shows the "Page views (90 days)" heading but no
+Symptoms: sidebar shows the "Page views (365 days)" heading but no
 chart underneath, or shows no heading at all when the page does have
 hits.
 

--- a/docs/telemetry/server-runbook.md
+++ b/docs/telemetry/server-runbook.md
@@ -151,11 +151,13 @@ learnche.org {
     }
 
     # Per-host access log. JSON encoder is the default; we keep it.
+    # Retention must be ≥ the sparkline window (default 365 days; see
+    # sparklines.conf.example). 400 days = 365 + ~5 weeks of slack.
     log {
         output file /var/log/caddy/learnche.org.access.log {
             roll_size 50MiB
-            roll_keep 95
-            roll_keep_for 95d
+            roll_keep 400
+            roll_keep_for 400d
         }
         format json
     }
@@ -169,8 +171,8 @@ Key points:
   `console` formatter, update `caddy-json-to-combined.py` or set the
   Caddyfile back to `json`.
 * **`roll_size` / `roll_keep` / `roll_keep_for`** — Caddy rotates the
-  log itself. The 95-day retention is ≥ the 90-day sparkline window
-  with a few days slack. Increase if you want longer history.
+  log itself. The 400-day retention is ≥ the 365-day sparkline window
+  with ~5 weeks of slack. Increase if you want longer history.
 * **`/_stats/*` handle** — same-origin under `learnche.org` so the
   sidebar `fetch("/_stats/sparklines.json")` does not need CORS
   headers. The 1-hour cache is the staleness budget for browser
@@ -278,7 +280,7 @@ is stdlib-only Python. Algorithm:
    * UAs matching the bot list (`/etc/pid-book/bots.txt` or fallback),
    * paths matching `STATIC_EXTS`,
    * paths outside `/pid/`,
-   * timestamps outside the 90-day window.
+   * timestamps outside the 365-day window.
 4. For each surviving hit, normalise the URL to a Sphinx pagename
    via `normalise_pagename` (rules documented in
    [`sparklines-schema.md`](sparklines-schema.md)).

--- a/docs/telemetry/sparklines-schema.md
+++ b/docs/telemetry/sparklines-schema.md
@@ -110,11 +110,11 @@ Each value is an array of `[date, count]` pairs.
   at least one hit appears exactly once. **Days with zero hits are
   omitted.** The consumer should not assume the array length equals
   the window length.
-* The window is **the most recent 90 days** (configurable via the
+* The window is **the most recent 365 days** (configurable via the
   producer's `[windows] days` setting, but the JS assumes 90 in its
   layout). If you change the window length on the server, also
   update the sidebar heading text in
-  `_templates/pid-sidebar-extra.html` (`"Page views (90 days)"`).
+  `_templates/pid-sidebar-extra.html` (`"Page views (365 days)"`).
 * If a page got at least one hit in the window, its entry exists.
 * If a page got **zero hits** in the window, it is **not** in the
   JSON. The consumer treats missing keys and empty arrays
@@ -239,6 +239,6 @@ curl -sf https://learnche.org/_stats/sparklines.json |
 ```
 
 If `sparklines.json` ever becomes a bottleneck (e.g. > 1 MB), revisit
-the schema — but for a book with O(100) pages and 90 days of daily
+the schema — but for a book with O(100) pages and 365 days of daily
 counts, the file is ~50–200 KB depending on activity, well below any
 problematic threshold.

--- a/scripts/server/build-sparklines.py
+++ b/scripts/server/build-sparklines.py
@@ -7,7 +7,7 @@ minimal server install.
 
 Output schema is described in docs/telemetry/sparklines-schema.md.
 The output file is consumed by _static/js/telemetry.js to render the
-90-day pageview sparkline in the sidebar of every book page.
+year-long pageview sparkline in the sidebar of every book page.
 
 Inputs
 ------
@@ -40,7 +40,8 @@ Algorithm
        /pid/data-visualization/box-plots → data-visualization/box-plots
    (Trailing slash means index page.)
 7. Aggregate (pagename, date) → set of unique IPs.
-8. Convert to (pagename, date) → unique-IP count for the last 90 days.
+8. Convert to (pagename, date) → unique-IP count for the configured
+   window (default 365 days).
 9. Atomically write JSON to the output path.
 
 Privacy
@@ -62,7 +63,7 @@ otherwise the defaults below. The config is a tiny INI file:
     bot_list = /etc/pid-book/bots.txt
 
     [windows]
-    days = 90
+    days = 365
 
 The bot list is one user-agent substring per line; lines starting with
 '#' are comments. Any UA containing one of the substrings (case-
@@ -102,7 +103,7 @@ DEFAULT_LOG_GLOBS = [
 ]
 DEFAULT_OUTPUT = "/var/www/learnche.org/_stats/sparklines.json"
 DEFAULT_BOT_LIST = "/etc/pid-book/bots.txt"
-DEFAULT_DAYS = 90
+DEFAULT_DAYS = 365
 
 # Bot UA substrings used when no bot_list file is present. Keep in sync with
 # scripts/server/goaccessrc.example.

--- a/scripts/server/sparklines.conf.example
+++ b/scripts/server/sparklines.conf.example
@@ -1,5 +1,10 @@
 # Configuration for scripts/server/build-sparklines.py.
 #
+# Default window is 365 days (1 year). Change [windows] days = N
+# below if you want a different period. The in-book labels assume
+# 365 days, so changing this also requires editing the heading text
+# in _templates/pid-sidebar-extra.html and stats.rst.
+#
 # Install as /etc/pid-book/sparklines.conf. Any value can also be passed
 # on the command line; CLI flags win.
 
@@ -23,4 +28,4 @@ bot_list = /etc/pid-book/bots.txt
 
 [windows]
 # How many days of history each sparkline shows.
-days = 90
+days = 365

--- a/stats.rst
+++ b/stats.rst
@@ -12,6 +12,16 @@ see in the sidebar of every page.
 
 See :ref:`privacy` for what is and isn't collected.
 
+.. note::
+
+   The site moved to logging real client IPs (via Apache's
+   ``mod_remoteip``) on **2026-05-24**. Before that date, every
+   reader behind Cloudflare appeared as one of a handful of edge IPs,
+   so the daily unique-reader counts for the pre-cutover portion of
+   the year-long window are dramatically undercounted. The visible
+   step-up around late May 2026 is a measurement artefact, not real
+   growth.
+
 Summary
 -------
 
@@ -25,8 +35,8 @@ Summary
      the data file is reachable.</em></p>
    </div>
 
-Daily reads (last 90 days)
---------------------------
+Daily reads (last 365 days)
+---------------------------
 
 Total reads per day across the whole book. Each daily bucket
 de-duplicates by IP, so two visits from the same reader on the same day
@@ -36,21 +46,21 @@ count once.
 
    <div id="pid-stats-daily" style="width:100%; height:280px; display:none"></div>
 
-Most-read pages (last 90 days)
-------------------------------
+Most-read pages (last 365 days)
+-------------------------------
 
-The 20 pages with the most reads over the 90-day window. Page names are
-the Sphinx page identifiers (e.g. ``data-visualization/box-plots``);
+The 20 pages with the most reads over the 365-day window. Page names
+are the Sphinx page identifiers (e.g. ``data-visualization/box-plots``);
 click through to read them.
 
 .. raw:: html
 
    <div id="pid-stats-top" style="display:none"></div>
 
-Least-read pages (last 90 days)
--------------------------------
+Least-read pages (last 365 days)
+--------------------------------
 
-The 10 pages with the *fewest* reads over the 90-day window, lowest
+The 10 pages with the *fewest* reads over the 365-day window, lowest
 first. Useful for spotting sections that may need clearer links,
 better discoverability, or a refresh.
 


### PR DESCRIPTION
## Summary

Switch the sparkline window from 90 to 365 days across labels, defaults, and docs. The production `/etc/pid-book/sparklines.conf` is already at 365 (per maintainer's server-side change earlier); this PR brings the repo into agreement so the in-book UI doesn't lie.

## What changes

**UI labels** (every "90 days" → "365 days"; "90-day window" → "365-day window"):

- `_templates/pid-sidebar-extra.html` — sidebar heading.
- `stats.rst` — three section headings + two body sentences.
- `_static/js/telemetry.js` — summary card label and doc comments.

**Defaults in shipped scripts:**

- `scripts/server/build-sparklines.py` — `DEFAULT_DAYS = 365` (was 90). Docstring updated.
- `scripts/server/sparklines.conf.example` — `days = 365` (was 90). With a header note that the labels assume 365, so any future change requires updating both.

**Docs sweep across all of `docs/telemetry/*.md`** — `README`, `architecture`, `client`, `build-and-deploy`, `operations`, `server-runbook`, `sparklines-schema`. Mostly text replacements; one substantive fix below.

**One non-cosmetic fix in `server-runbook.md`:** the Caddyfile example log-retention was 95 days. With a 365-day window that would lose the back half of the data window. Bumped to **400 days** (365 + ~5 weeks slack). The accompanying "95-day retention ≥ sparkline window" sentence was now wrong; updated.

**New caveat note on `stats.rst`:**

> The site moved to logging real client IPs (via Apache's `mod_remoteip`) on **2026-05-24**. Before that date, every reader behind Cloudflare appeared as one of a handful of edge IPs, so the daily unique-reader counts for the pre-cutover portion of the year-long window are dramatically undercounted. The visible step-up around late May 2026 is a measurement artefact, not real growth.

Readers need to know why the sparkline shape jumps in late May. Without this note the year-window looks like a viral moment, not an instrumentation fix.

## Test plan

- [x] `node --check _static/js/telemetry.js` clean.
- [x] `python3 -m ast` on `build-sparklines.py` clean.
- [x] `make text` builds clean (330 sandbox-stub warnings preexisting).
- [x] `grep -rE "90.day|90-day|90 days"` across source returns no hits.
- [ ] After deploy: hard-reload any book page; sidebar heading says "Page views (365 days)" and the chart spans the full year.
- [ ] On `/pid/stats`: three section headings say "365 days"; the caveat note about mod_remoteip is visible.

https://claude.ai/code/session_01VGw7f4BEC1Za4tBeLJ3jcG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGw7f4BEC1Za4tBeLJ3jcG)_