### PR TITLE
Capture Apache deployment lessons (mod_remoteip + logrotate) in the runbook

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.05.25"
-date-released: 2026-05-25
+version: "2026.05.26"
+date-released: 2026-05-26
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/docs/telemetry/server-runbook.md
+++ b/docs/telemetry/server-runbook.md
@@ -189,6 +189,86 @@ chown caddy:caddy /var/www/learnche.org/_stats
 (The Caddy package on Debian/Ubuntu creates a `caddy` system user that
 owns the served paths; substitute whatever user your install uses.)
 
+### 5b. Apache alternative
+
+If you're on Apache rather than Caddy (the original learnche.org host
+ran Apache 2.4 on Debian 11 through mid-2026; the docs target Caddy
+because that's the post-migration setup), three things differ.
+
+**Vhost.** The `learnche.org` `<VirtualHost *:443>` block needs
+`DocumentRoot /var/www/learnche.org` (so `/_stats/` and `/pid/` are
+both served from the same tree), and a `CustomLog` pointing at the
+per-vhost access log:
+
+```apache
+<VirtualHost *:443>
+    ServerName  learnche.org
+    DocumentRoot /var/www/learnche.org
+
+    <Directory "/var/www/learnche.org">
+        Options All Includes Indexes
+        AllowOverride All
+    </Directory>
+
+    # Cloudflare reverse-proxy: log the real client IP, not the CF
+    # edge IP. Without this, every visitor looks like one of ~5–10
+    # Cloudflare IPs per region per day and the sparkline dedup
+    # silently undercounts by ~10–50×.
+    RemoteIPHeader CF-Connecting-IP
+    RemoteIPTrustedProxyList /etc/apache2/cloudflare-ips-v4.txt
+    RemoteIPTrustedProxyList /etc/apache2/cloudflare-ips-v6.txt
+
+    ErrorLog  /var/www/logs/learnche.org/error.log
+    CustomLog /var/www/logs/learnche.org/access.log combined
+
+    # ... TLS directives ...
+</VirtualHost>
+```
+
+The `cloudflare-ips-v4.txt` / `-v6.txt` files come from
+<https://www.cloudflare.com/ips-v4> / `ips-v6`. Refresh them
+occasionally — Cloudflare updates the list every few months.
+
+**Log rotation.** Debian's default `/etc/logrotate.d/apache2` ships
+with `rotate 4`, which keeps only **4 days** of history for busy
+vhosts. With a 365-day sparkline window, that's catastrophic — the
+script reads 4 days of recent data and silently shows almost nothing.
+For 5 years of history bump it to **`rotate 1825`**:
+
+```sh
+sudo sed -i 's/^\s*rotate 4$/    rotate 1825/' /etc/logrotate.d/apache2
+grep rotate /etc/logrotate.d/apache2    # expect: rotate 1825
+
+# Dry-run; should print "1825 rotations" in the pattern header
+sudo logrotate -d /etc/logrotate.d/apache2 2>&1 | head -10
+
+# Force one rotation to test the postrotate apache2 reload hook
+sudo logrotate -f /etc/logrotate.d/apache2
+sudo systemctl status apache2 --no-pager | head -3
+curl -sI 'https://learnche.org/pid/contents' | head -3
+```
+
+Note the warning `'size' overrides previously specified 'daily'` —
+that's expected: Debian's default has both `size 10M` and `daily`,
+and when `size` is set, the time-based directive is ignored. In
+practice cron fires logrotate daily, and busy access logs always
+exceed 10 MB, so it's "one rotation per day" anyway. Low-traffic
+vhosts may go weeks or months between rotations (their files just
+grow until they cross 10 MB) — not a problem for sparklines, just a
+quirk to know.
+
+**`_stats/` directory.** Apache serves it automatically since
+`DocumentRoot` covers it; you only need to create the directory and
+make sure `www-data` can write to it:
+
+```sh
+mkdir -p /var/www/learnche.org/_stats
+chown www-data:www-data /var/www/learnche.org/_stats
+chmod 755 /var/www/learnche.org/_stats
+```
+
+No `<Location>` or `Alias` block needed.
+
 ### 6. Cron
 
 ```sh

--- a/stats.rst
+++ b/stats.rst
@@ -14,13 +14,27 @@ See :ref:`privacy` for what is and isn't collected.
 
 .. note::
 
-   The site moved to logging real client IPs (via Apache's
-   ``mod_remoteip``) on **2026-05-24**. Before that date, every
-   reader behind Cloudflare appeared as one of a handful of edge IPs,
-   so the daily unique-reader counts for the pre-cutover portion of
-   the year-long window are dramatically undercounted. The visible
-   step-up around late May 2026 is a measurement artefact, not real
-   growth.
+   Two unrelated server-side issues distort the historical portion of
+   the year-long window. The post-fix data (roughly **2026-05-22
+   onward**) is accurate; everything before that has caveats:
+
+   * **Real client IPs only since 2026-05-24.** Until then every
+     reader behind Cloudflare appeared as one of a handful of edge
+     IPs per region per day, and the script's daily-unique-IP
+     deduplication collapsed real reader counts ~10–50×. The visible
+     step-up in late May 2026 is a measurement artefact, not real
+     growth. (Fixed by configuring Apache ``mod_remoteip`` to honour
+     the ``CF-Connecting-IP`` header.)
+   * **No access logs from Feb 2022 to May 2026.** Debian's default
+     Apache ``logrotate`` configuration kept only 4 days of history.
+     For ~4 years that quietly purged the access logs the next day,
+     so we have nothing to aggregate for that period. (Fixed by
+     bumping the ``rotate`` count to 1825.)
+
+   The 2021/2022 archive *does* exist in the log directory but falls
+   outside the 365-day window so doesn't appear here. Bumping the
+   window to 5 years would surface it as a "valley" of empty days
+   between two dense regions.
 
 Summary
 -------


### PR DESCRIPTION
## Summary

Two unrelated lessons from the live Apache deployment that aren't obvious from the Caddy-flavoured docs. Both quietly destroy data; both have one-line fixes once you know.

### 1. `mod_remoteip` is mandatory behind Cloudflare

Without it, every reader looks like one of ~5–10 Cloudflare edge IPs per region per day. The sparkline dedup collapses real reader counts ~10–50× silently. Looks like "the site has no traffic" rather than "the data is broken". Took an afternoon of debugging to notice.

### 2. Debian's default Apache `logrotate` keeps 4 days of history

`/etc/logrotate.d/apache2` ships with `rotate 4`. For busy access logs that means the 5th-oldest day gets deleted nightly. With a 365-day sparkline window the script reads ~4 days of recent data and shows almost nothing. **Fix is one line:** `rotate 4` → `rotate 1825` for 5 years.

## Changes

- **`docs/telemetry/server-runbook.md`** — new "5b. Apache alternative" section after the existing Caddy block. Covers: vhost snippet with `mod_remoteip` directives + the Cloudflare IP-list refresh note, the `rotate 4` trap and its `sed` fix with a force-rotate verification, and the `_stats/` directory permissions. Documents the `'size' overrides previously specified 'daily'` warning that appears in `logrotate -d` output so future readers don't chase it.
- **`stats.rst`** — broadened the in-book caveat from a single mod_remoteip paragraph to a two-bullet list covering both the IP issue and the logrotate gap. Notes that the 2021/2022 archive exists in the log directory but falls outside the current 365-day window, with a pointer to bumping the window for a 5-year view.
- **`CITATION.cff`** — date bump per `CLAUDE.md`.

## Test plan

- [x] `make text` builds clean (the 330 warnings are preexisting sandbox-stub artefacts).
- [x] All new content reads correctly as RST + Markdown (manually inspected).
- [ ] After merge + deploy: confirm the broadened caveat renders cleanly on `/pid/stats`.

https://claude.ai/code/session_01VGw7f4BEC1Za4tBeLJ3jcG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGw7f4BEC1Za4tBeLJ3jcG)_