### PR TITLE
Narrow the in-book display window to 10 days (backend stays at 365)

### DIFF
--- a/_static/js/telemetry.js
+++ b/_static/js/telemetry.js
@@ -42,6 +42,53 @@
   var cfg = window.__PID_TELEMETRY || {};
   if (!cfg.gc) return;
 
+  // -------------------------------------------------------------------
+  // Front-end display window.
+  //
+  // The backend (build-sparklines.py + /etc/pid-book/sparklines.conf)
+  // keeps a 365-day window in /_stats/sparklines.json. The in-book UI
+  // is intentionally narrower: showing 365-day totals on a young
+  // deployment (or one with historical log gaps) makes pages look
+  // unread when they are actually being read every day.
+  //
+  // Change DISPLAY_DAYS in lockstep with the labels that mention "N
+  // days" in:
+  //   - _templates/pid-sidebar-extra.html   ("Page views (10 days)")
+  //   - stats.rst                            ("(last 10 days)" x3)
+  // and the backend (365) stays the same.
+  // -------------------------------------------------------------------
+  var DISPLAY_DAYS = 10;
+  var DISPLAY_LABEL = DISPLAY_DAYS + " days";
+
+  // Find the most recent date present anywhere in the JSON. Used as
+  // the anchor for the rolling display window. Series are sorted
+  // ascending in the producer, so the last element holds the latest.
+  function globalAnchorDate(data) {
+    var max = "";
+    for (var page in data) {
+      var s = data[page];
+      if (s && s.length) {
+        var last = s[s.length - 1][0];
+        if (last > max) max = last;
+      }
+    }
+    return max;
+  }
+
+  // "YYYY-MM-DD" arithmetic: return the date `days-1` days before
+  // anchor, so a window of `days` includes the anchor day itself.
+  function cutoffDateString(anchor, days) {
+    if (!anchor) return "";
+    var d = new Date(anchor + "T00:00:00Z");
+    d.setUTCDate(d.getUTCDate() - days + 1);
+    return d.toISOString().slice(0, 10);
+  }
+
+  function filterToWindow(series, cutoff) {
+    if (!series || !cutoff) return series || [];
+    return series.filter(function (p) { return p[0] >= cutoff; });
+  }
+
   // 1. Path normalisation: extensionless URLs, fold trailing slash and /index.
   function normPath() {
     var p = location.pathname.replace(/\/+$/, "") || "/";
@@ -137,10 +184,16 @@
         return r.json();
       })
       .then(function (data) {
-        var series = data && data[pageKey];
+        // The JSON is the full 365-day window; the UI shows only
+        // the most recent DISPLAY_DAYS days from the global anchor
+        // (so different pages compare against the same date range).
+        var anchor = globalAnchorDate(data);
+        var cutoff = cutoffDateString(anchor, DISPLAY_DAYS);
+        var series = filterToWindow(data && data[pageKey], cutoff);
         if (!series || !series.length) {
-          // No history for this page (e.g. fresh page, content blocker
-          // tampered with the JSON). Block stays hidden — nothing to do.
+          // No history for this page in the display window (fresh
+          // page, content blocker tampering, or genuinely unread for
+          // DISPLAY_DAYS). Block stays hidden — nothing to do.
           return;
         }
         // Write the total-reads-in-window into the sidebar heading, if
@@ -257,12 +310,17 @@
         var pages = data && Object.keys(data);
         if (!pages || !pages.length) { showEmpty(); return; }
 
-        // Aggregate.
+        // The JSON holds 365 days; the UI shows the most recent
+        // DISPLAY_DAYS days only. Compute the cutoff once and filter
+        // every per-page series through it before aggregating.
+        var anchor = globalAnchorDate(data);
+        var cutoff = cutoffDateString(anchor, DISPLAY_DAYS);
+
         var totalReads = 0;
         var dailyMap = {};
         var pageTotals = [];
         pages.forEach(function (page) {
-          var series = data[page] || [];
+          var series = filterToWindow(data[page], cutoff);
           var pageTotal = 0;
           series.forEach(function (p) {
             var date = p[0], count = p[1] | 0;
@@ -275,11 +333,14 @@
         pageTotals.sort(function (a, b) { return b[1] - a[1]; });
         var dailyDates = Object.keys(dailyMap).sort();
 
+        // If the window has no data at all, fall back to the empty UI.
+        if (!pageTotals.length) { showEmpty(); return; }
+
         // Summary cards.
         summary.innerHTML =
           '<div class="pid-stats-card"><div class="pid-stats-num">' +
             totalReads.toLocaleString() +
-          '</div><div class="pid-stats-label">reads (365 days)</div></div>' +
+          '</div><div class="pid-stats-label">reads (' + DISPLAY_LABEL + ')</div></div>' +
           '<div class="pid-stats-card"><div class="pid-stats-num">' +
             pageTotals.length.toLocaleString() +
           '</div><div class="pid-stats-label">pages with traffic</div></div>' +

--- a/_templates/pid-sidebar-extra.html
+++ b/_templates/pid-sidebar-extra.html
@@ -31,7 +31,7 @@
   <div id="pid-sparkline-block" style="display:none">
     <hr/>
     <p style="color:#777; font-size:0.85em; margin:0.3em 0 0.1em">
-      Page views (365 days)<span id="pid-sparkline-total"
+      Page views (10 days)<span id="pid-sparkline-total"
         style="float:right; font-variant-numeric:tabular-nums"></span>
     </p>
     <div id="pid-sparkline" style="width:100%; height:38px"

--- a/scripts/server/sparklines.conf.example
+++ b/scripts/server/sparklines.conf.example
@@ -1,9 +1,11 @@
 # Configuration for scripts/server/build-sparklines.py.
 #
-# Default window is 365 days (1 year). Change [windows] days = N
-# below if you want a different period. The in-book labels assume
-# 365 days, so changing this also requires editing the heading text
-# in _templates/pid-sidebar-extra.html and stats.rst.
+# Default backend window is 365 days (1 year). This controls what
+# /_stats/sparklines.json contains. The in-book UI display window is
+# independent: the JS in _static/js/telemetry.js filters this JSON to
+# a shorter window (look for DISPLAY_DAYS) before rendering. Change
+# this value to widen/narrow the backend; change DISPLAY_DAYS to
+# widen/narrow what readers see.
 #
 # Install as /etc/pid-book/sparklines.conf. Any value can also be passed
 # on the command line; CLI flags win.

--- a/stats.rst
+++ b/stats.rst
@@ -14,27 +14,23 @@ See :ref:`privacy` for what is and isn't collected.
 
 .. note::
 
-   Two unrelated server-side issues distort the historical portion of
-   the year-long window. The post-fix data (roughly **2026-05-22
-   onward**) is accurate; everything before that has caveats:
+   The in-book figures show the most recent **10 days** while the
+   pipeline is still bedding in. Two server-side fixes only took
+   effect recently, so wider windows are not yet representative:
 
-   * **Real client IPs only since 2026-05-24.** Until then every
-     reader behind Cloudflare appeared as one of a handful of edge
-     IPs per region per day, and the script's daily-unique-IP
-     deduplication collapsed real reader counts ~10–50×. The visible
-     step-up in late May 2026 is a measurement artefact, not real
-     growth. (Fixed by configuring Apache ``mod_remoteip`` to honour
-     the ``CF-Connecting-IP`` header.)
-   * **No access logs from Feb 2022 to May 2026.** Debian's default
-     Apache ``logrotate`` configuration kept only 4 days of history.
-     For ~4 years that quietly purged the access logs the next day,
-     so we have nothing to aggregate for that period. (Fixed by
-     bumping the ``rotate`` count to 1825.)
+   * **Real client IPs since 2026-05-24** (Apache ``mod_remoteip`` +
+     Cloudflare ``CF-Connecting-IP``). Earlier data deduplicated by
+     Cloudflare edge IPs and undercounted by ~10–50×.
+   * **Access logs retained 5 years since 2026-05-26** (logrotate
+     ``rotate 1825``). Earlier rotations purged everything after 4
+     days, so almost nothing from Feb 2022 to May 2026 exists on
+     disk.
 
-   The 2021/2022 archive *does* exist in the log directory but falls
-   outside the 365-day window so doesn't appear here. Bumping the
-   window to 5 years would surface it as a "valley" of empty days
-   between two dense regions.
+   The backend keeps a full 365-day window in
+   `sparklines.json <https://learnche.org/_stats/sparklines.json>`_;
+   the in-book display is filtered to a shorter window so a young
+   deployment doesn't look unread. The window will gradually widen
+   over the next few weeks.
 
 Summary
 -------
@@ -49,8 +45,8 @@ Summary
      the data file is reachable.</em></p>
    </div>
 
-Daily reads (last 365 days)
----------------------------
+Daily reads (last 10 days)
+--------------------------
 
 Total reads per day across the whole book. Each daily bucket
 de-duplicates by IP, so two visits from the same reader on the same day
@@ -60,10 +56,10 @@ count once.
 
    <div id="pid-stats-daily" style="width:100%; height:280px; display:none"></div>
 
-Most-read pages (last 365 days)
--------------------------------
+Most-read pages (last 10 days)
+------------------------------
 
-The 20 pages with the most reads over the 365-day window. Page names
+The 20 pages with the most reads over the 10-day window. Page names
 are the Sphinx page identifiers (e.g. ``data-visualization/box-plots``);
 click through to read them.
 
@@ -71,10 +67,10 @@ click through to read them.
 
    <div id="pid-stats-top" style="display:none"></div>
 
-Least-read pages (last 365 days)
---------------------------------
+Least-read pages (last 10 days)
+-------------------------------
 
-The 10 pages with the *fewest* reads over the 365-day window, lowest
+The 10 pages with the *fewest* reads over the 10-day window, lowest
 first. Useful for spotting sections that may need clearer links,
 better discoverability, or a refresh.
 


### PR DESCRIPTION
## Summary

Showing 365-day totals on a young deployment makes pages look unread when they're actually being read every day. This narrows the **in-book display** to the most recent 10 days while leaving the **backend aggregation** at 365 days (where it should stay).

The backend (`build-sparklines.py` + `/etc/pid-book/sparklines.conf`) is unchanged — `sparklines.json` still contains 365 days of data. The JS in the book applies a window filter before computing totals or rendering.

## How it works

A new `DISPLAY_DAYS = 10` constant at the top of `_static/js/telemetry.js`. Three helpers:

- `globalAnchorDate(data)` — finds the latest date present anywhere in the JSON. Used as the rolling anchor so every page filters against the same date range.
- `cutoffDateString(anchor, days)` — `YYYY-MM-DD` arithmetic, returns the start of the window.
- `filterToWindow(series, cutoff)` — drops series points before the cutoff.

Both `renderSparkline()` and `renderStatsPage()` now filter through these before computing anything. An empty filtered series falls through the existing empty-state path (sidebar block stays hidden, stats page shows the "could not load" message).

## Bumping the window

To widen the in-book display (e.g. 10 → 30):

1. Edit `DISPLAY_DAYS` in `_static/js/telemetry.js`.
2. `sed -i 's/(10 days)/(30 days)/g; s/(last 10 days)/(last 30 days)/g; s/10-day window/30-day window/g' _templates/pid-sidebar-extra.html stats.rst`.

There's a comment block at the top of `telemetry.js` listing exactly which files to edit in lockstep, so future-you doesn't have to remember.

## Changes

- `_static/js/telemetry.js` — new constant, helpers, filter calls in both render paths. ~50 lines.
- `_templates/pid-sidebar-extra.html` — `"Page views (365 days)"` → `"(10 days)"`.
- `stats.rst` — three section headings + matching body sentences switched. Caveat note rewritten: previously framed around the year-window's historical artefacts (mod_remoteip cutover, logrotate gap), now framed around the deliberate 10-day window with brief explainers about both fixes and a sentence noting the backend still keeps 365.
- `scripts/server/sparklines.conf.example` — comment now correctly says the backend and frontend windows are independent.

## Test plan

- [x] `node --check` on `telemetry.js` clean.
- [x] Window-filter logic spot-tested in node against synthetic data: correct anchor, correct cutoff math (10-day window includes anchor day), correct empty result for fully-historical pages.
- [x] `make text` builds clean (the 330 sandbox-stub warnings are preexisting).
- [ ] After deploy + hard-reload: sidebar shows "Page views (10 days): NNN reads" with a chart spanning roughly the last 10 days of data we have (5 days right now, will grow daily). `/pid/stats` summary card shows "reads (10 days)" with proportionally smaller numbers; three section headings say "(last 10 days)"; daily-totals chart shows only the recent ~10 days.

https://claude.ai/code/session_01VGw7f4BEC1Za4tBeLJ3jcG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGw7f4BEC1Za4tBeLJ3jcG)_