### PR TITLE
Fix stats UI showing stale data: replace `cache: "force-cache"` with `"default"`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.05.26"
-date-released: 2026-05-26
+version: "2026.05.30"
+date-released: 2026-05-30
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/_static/js/telemetry.js
+++ b/_static/js/telemetry.js
@@ -178,7 +178,7 @@
       if (!pageKey) pageKey = "contents";
     }
 
-    fetch("/_stats/sparklines.json", { cache: "force-cache" })
+    fetch("/_stats/sparklines.json", { cache: "default" })
       .then(function (r) {
         if (!r.ok) throw new Error("sparklines.json " + r.status);
         return r.json();
@@ -301,7 +301,7 @@
         "<tbody>" + rows + "</tbody></table>";
     }
 
-    fetch("/_stats/sparklines.json", { cache: "force-cache" })
+    fetch("/_stats/sparklines.json", { cache: "default" })
       .then(function (r) {
         if (!r.ok) throw new Error("sparklines.json " + r.status);
         return r.json();

--- a/docs/telemetry/client.md
+++ b/docs/telemetry/client.md
@@ -261,17 +261,20 @@ if (!pageKey) {
 ### Phase 4b — fetch sparklines.json
 
 ```js
-fetch("/_stats/sparklines.json", { cache: "force-cache" })
+fetch("/_stats/sparklines.json", { cache: "default" })
   .then(...)
   .catch(function () { /* leave the empty mount; do not break */ });
 ```
 
 * **Same-origin fetch** — `learnche.org/_stats/sparklines.json`.
   Same hostname as the book, so no CORS dance.
-* **`cache: "force-cache"`** — the JSON is regenerated nightly, so
-  we let the browser reuse the response across the whole site visit.
-  The HTTP cache headers on the JSON (1 hour `max-age` per the
-  Caddyfile `/_stats/*` handle) bound staleness.
+* **`cache: "default"`** — the JSON is regenerated nightly. Default
+  HTTP caching honours the `Cache-Control: max-age=3600` we send,
+  so the browser reuses the response for an hour and then
+  revalidates. (Earlier versions used `force-cache`, which silently
+  ignores `max-age` and pins the very first response forever — that
+  one bit us: see the "Stats page shows data from a week ago" entry
+  in [`operations.md`](operations.md).)
 * **Catch-all on errors** — network failure, malformed JSON, server
   500 — all silently leave the empty mount. The page must not break
   because sparkline data was unavailable.

--- a/docs/telemetry/operations.md
+++ b/docs/telemetry/operations.md
@@ -522,6 +522,53 @@ page list. If a new Sphinx category appears (e.g. `/_modules/`), add
 it to the filter list and re-run `build-sparklines.py` — the next
 nightly rebuild will drop it.
 
+### "Stats page shows data from a week ago, even though the cron is running."
+
+Symptom: the on-disk `/var/www/learnche.org/_stats/sparklines.json`
+has a fresh `mtime`, `curl -s 'https://learnche.org/_stats/sparklines.json'`
+from any machine returns fresh data, but the chart in a reader's
+browser keeps showing the old data day after day.
+
+Cause we've actually hit: `_static/js/telemetry.js` used to call
+`fetch("/_stats/sparklines.json", { cache: "force-cache" })`.
+**`force-cache` is the Fetch API's most aggressive cache mode**: it
+returns whatever is in the HTTP cache regardless of `max-age`, and
+only refetches when the cache entry is evicted by the browser's own
+quota. On iOS Safari that can mean weeks. We swapped to
+`cache: "default"`, which honours the `Cache-Control: max-age=3600`
+header and revalidates after an hour.
+
+Diagnostic:
+
+```sh
+# Server side — should match curl-from-anywhere
+sudo python3 -c "
+import json
+d = json.load(open('/var/www/learnche.org/_stats/sparklines.json'))
+all_dates = sorted({p[0] for v in d.values() for p in v})
+print(f'on-disk:   {all_dates[0]} -> {all_dates[-1]}')
+"
+
+# Cloudflare side — bypass any local cache with a unique query string
+curl -s 'https://learnche.org/_stats/sparklines.json?v=test' | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+all_dates = sorted({p[0] for v in d.values() for p in v})
+print(f'CF:        {all_dates[0]} -> {all_dates[-1]}')
+"
+
+# Confirm CF isn't caching the JSON (it's marked DYNAMIC by default
+# because .json is not on CF's auto-cache extension list).
+curl -sI 'https://learnche.org/_stats/sparklines.json' | grep -iE 'cache|last-mod'
+```
+
+If on-disk and CF match (both fresh) but a reader's browser still
+shows stale data, the bug is purely client-side: a reader whose JS
+was loaded before the fix shipped is still using `force-cache`. They
+can force-reload the page (Cmd+Shift+R, or in Safari iOS: pull-down
+on the address bar → "Reload Without Content Blockers") to evict
+their cache and pick up the new `telemetry.js`.
+
 ## Periodic maintenance
 
 * **Quarterly**: review `/etc/pid-book/bots.txt` against current


### PR DESCRIPTION
## Summary

Fixes a real bug we just hit on the live deployment: the cron writes fresh `sparklines.json` nightly, on-disk and CF both return today's data to any `curl`, but the chart in a reader's browser kept showing data from a week earlier. Confirmed today on `learnche.org/pid/stats` — chart showed dates ending 2026-05-25 despite the server having data through 2026-05-30.

**Cause:** `_static/js/telemetry.js` called

```js
fetch("/_stats/sparklines.json", { cache: "force-cache" })
```

The Fetch API's `"force-cache"` mode is the most aggressive — it **silently ignores `Cache-Control: max-age`** and returns the cached response until the browser's own quota evicts the entry. On iOS Safari that can be weeks. My intent was "reuse the response across the site visit", but the right mode for that is `"default"`, which respects HTTP cache semantics and revalidates after `max-age` expires (we send `max-age=3600`).

## Changes

- `_static/js/telemetry.js` — both `fetch()` calls (`renderSparkline`, `renderStatsPage`) now use `cache: "default"`.
- `docs/telemetry/client.md` — the inline `fetch(...)` example updated to match; comment explicitly says what `force-cache` does so future readers don't reintroduce it; cross-link to the new operations entry.
- `docs/telemetry/operations.md` — new troubleshooting entry **"Stats page shows data from a week ago, even though the cron is running."** Lists the symptom, the cause, three diagnostic commands (on-disk vs CF vs cache headers, with a `?v=test` cache-buster trick), and the in-browser force-reload to evict stuck client caches.
- `CITATION.cff` — date bump.

## What deploys when

Once this merges and the next non-PR `make html` ships, the new `telemetry.js` is on origin. Cloudflare's edge cache for `.js` files is typically a few hours; readers who fetch a page after that pick up the new JS, which fetches the JSON with `cache: "default"` and respects the 1-hour `max-age`.

Stuck readers (like @kgdunn on the iPad tab open from earlier this week) can fix immediately with a Safari force-reload — pull-down on the address bar → "Reload Without Content Blockers" evicts both the old `telemetry.js` and the old `sparklines.json` from local cache.

## Test plan

- [x] `node --check` clean.
- [x] `make text` builds clean.
- [ ] After merge + CF edge-cache TTL elapses (or you force-reload), the stats page on `/pid/stats` shows dates up to today.
- [ ] One day later, confirm the data has advanced by one day on its own — proving the new caching actually revalidates rather than re-pinning.

https://claude.ai/code/session_01VGw7f4BEC1Za4tBeLJ3jcG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGw7f4BEC1Za4tBeLJ3jcG)_