### PR TITLE
Bump in-book display window from 10 to 15 days

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.05.30"
-date-released: 2026-05-30
+version: "2026.05.31"
+date-released: 2026-05-31
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/_static/js/telemetry.js
+++ b/_static/js/telemetry.js
@@ -53,11 +53,11 @@
   //
   // Change DISPLAY_DAYS in lockstep with the labels that mention "N
   // days" in:
-  //   - _templates/pid-sidebar-extra.html   ("Page views (10 days)")
-  //   - stats.rst                            ("(last 10 days)" x3)
+  //   - _templates/pid-sidebar-extra.html   ("Page views (N days)")
+  //   - stats.rst                            ("(last N days)" x3 + body)
   // and the backend (365) stays the same.
   // -------------------------------------------------------------------
-  var DISPLAY_DAYS = 10;
+  var DISPLAY_DAYS = 15;
   var DISPLAY_LABEL = DISPLAY_DAYS + " days";
 
   // Find the most recent date present anywhere in the JSON. Used as

--- a/_templates/pid-sidebar-extra.html
+++ b/_templates/pid-sidebar-extra.html
@@ -31,7 +31,7 @@
   <div id="pid-sparkline-block" style="display:none">
     <hr/>
     <p style="color:#777; font-size:0.85em; margin:0.3em 0 0.1em">
-      Page views (10 days)<span id="pid-sparkline-total"
+      Page views (15 days)<span id="pid-sparkline-total"
         style="float:right; font-variant-numeric:tabular-nums"></span>
     </p>
     <div id="pid-sparkline" style="width:100%; height:38px"

--- a/stats.rst
+++ b/stats.rst
@@ -14,7 +14,7 @@ See :ref:`privacy` for what is and isn't collected.
 
 .. note::
 
-   The in-book figures show the most recent **10 days** while the
+   The in-book figures show the most recent **15 days** while the
    pipeline is still bedding in. Two server-side fixes only took
    effect recently, so wider windows are not yet representative:
 
@@ -45,7 +45,7 @@ Summary
      the data file is reachable.</em></p>
    </div>
 
-Daily reads (last 10 days)
+Daily reads (last 15 days)
 --------------------------
 
 Total reads per day across the whole book. Each daily bucket
@@ -56,10 +56,10 @@ count once.
 
    <div id="pid-stats-daily" style="width:100%; height:280px; display:none"></div>
 
-Most-read pages (last 10 days)
+Most-read pages (last 15 days)
 ------------------------------
 
-The 20 pages with the most reads over the 10-day window. Page names
+The 20 pages with the most reads over the 15-day window. Page names
 are the Sphinx page identifiers (e.g. ``data-visualization/box-plots``);
 click through to read them.
 
@@ -67,10 +67,10 @@ click through to read them.
 
    <div id="pid-stats-top" style="display:none"></div>
 
-Least-read pages (last 10 days)
+Least-read pages (last 15 days)
 -------------------------------
 
-The 10 pages with the *fewest* reads over the 10-day window, lowest
+The 10 pages with the *fewest* reads over the 15-day window, lowest
 first. Useful for spotting sections that may need clearer links,
 better discoverability, or a refresh.
 


### PR DESCRIPTION
## Summary

Bumps the in-book display window from 10 to 15 days. Backend stays at 365 days unchanged.

## Changes

- `_static/js/telemetry.js` — `DISPLAY_DAYS = 15`. While here, the lockstep-bumping comment now says "N days" instead of citing the current value as an example, so it won't go stale every time you bump.
- `_templates/pid-sidebar-extra.html` — sidebar heading.
- `stats.rst` — three section headings + matching body sentences + caveat-note intro. Preserves "The 10 pages with the *fewest* reads" — that 10 is the bottom-N table size, not the window.
- `CITATION.cff` — date bump.

## Test plan

- [x] `node --check` clean.
- [x] `make text` builds clean.
- [x] `grep -E "10 days|10-day window|DISPLAY_DAYS = 10"` across source returns no hits.
- [ ] After CF edge cache for `.js` expires (~hour) or hard-reload: sidebar shows "Page views (15 days)" and a chart spanning roughly the last 15 days of available data. `/pid/stats` shows three "(last 15 days)" headings and a summary card labelled "reads (15 days)".

https://claude.ai/code/session_01VGw7f4BEC1Za4tBeLJ3jcG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGw7f4BEC1Za4tBeLJ3jcG)_