### PR TITLE
Widen telemetry display window from 15 to 30 days

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.06.14"
-date-released: 2026-06-14
+version: "2026.06.15"
+date-released: 2026-06-15
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/_static/js/telemetry.js
+++ b/_static/js/telemetry.js
@@ -57,7 +57,7 @@
   //   - stats.rst                            ("(last N days)" x3 + body)
   // and the backend (365) stays the same.
   // -------------------------------------------------------------------
-  var DISPLAY_DAYS = 15;
+  var DISPLAY_DAYS = 30;
   var DISPLAY_LABEL = DISPLAY_DAYS + " days";
 
   // Find the most recent date present anywhere in the JSON. Used as

--- a/_templates/pid-sidebar-extra.html
+++ b/_templates/pid-sidebar-extra.html
@@ -31,7 +31,7 @@
   <div id="pid-sparkline-block" style="display:none">
     <hr/>
     <p style="color:#777; font-size:0.85em; margin:0.3em 0 0.1em">
-      Page views (15 days)<span id="pid-sparkline-total"
+      Page views (30 days)<span id="pid-sparkline-total"
         style="float:right; font-variant-numeric:tabular-nums"></span>
     </p>
     <div id="pid-sparkline" style="width:100%; height:38px"

--- a/stats.rst
+++ b/stats.rst
@@ -14,7 +14,7 @@ See :ref:`privacy` for what is and isn't collected.
 
 .. note::
 
-   The in-book figures show the most recent **15 days** while the
+   The in-book figures show the most recent **30 days** while the
    pipeline is still bedding in. Two server-side fixes only took
    effect recently, so wider windows are not yet representative:
 
@@ -45,7 +45,7 @@ Summary
      the data file is reachable.</em></p>
    </div>
 
-Daily reads (last 15 days)
+Daily reads (last 30 days)
 --------------------------
 
 Total reads per day across the whole book. Each daily bucket
@@ -56,10 +56,10 @@ count once.
 
    <div id="pid-stats-daily" style="width:100%; height:280px; display:none"></div>
 
-Most-read pages (last 15 days)
+Most-read pages (last 30 days)
 ------------------------------
 
-The 20 pages with the most reads over the 15-day window. Page names
+The 20 pages with the most reads over the 30-day window. Page names
 are the Sphinx page identifiers (e.g. ``data-visualization/box-plots``);
 click through to read them.
 
@@ -67,10 +67,10 @@ click through to read them.
 
    <div id="pid-stats-top" style="display:none"></div>
 
-Least-read pages (last 15 days)
+Least-read pages (last 30 days)
 -------------------------------
 
-The 10 pages with the *fewest* reads over the 15-day window, lowest
+The 10 pages with the *fewest* reads over the 30-day window, lowest
 first. Useful for spotting sections that may need clearer links,
 better discoverability, or a refresh.
 


### PR DESCRIPTION
## What changed

The in-book statistics display window is widened from the most recent 15 days to the most recent 30 days. This affects the sidebar sparkline, the summary, and the stats page figures and labels.

Updated in lockstep, as the source comment in `telemetry.js` instructs:

- `_static/js/telemetry.js`: `DISPLAY_DAYS` 15 -> 30 (drives the rolling window and the `DISPLAY_LABEL`).
- `_templates/pid-sidebar-extra.html`: sidebar heading "Page views (15 days)" -> "Page views (30 days)".
- `stats.rst`: the note text plus all three "(last 15 days)" section headings and the body references to the "15-day window".

## What did not change

- The backend still keeps the full 365-day window in `sparklines.json`. Only the reader-facing display filter changes.
- No telemetry collection behaviour changed, so `privacy.rst` is untouched.

## Verification

- `make text`: build succeeded. The 332 warnings are all pre-existing "image file not readable" warnings from the symlinked `figures/` repo not being populated in this environment; none relate to these changes.
- `make html`: build succeeded.
- `grep -r goatcounter _build/html/contents`: 0 hits.
- Confirmed the built output shows `DISPLAY_DAYS = 30` and "last 30 days" on the rendered stats page.

Also bumped `CITATION.cff` `version:` to `2026.06.15` and `date-released:` to `2026-06-15` per the repository's release-metadata rule. The README year range already ends in 2026.

https://claude.ai/code/session_01TPes6RFmH4GJM2kZfMFqvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPes6RFmH4GJM2kZfMFqvp)_