### PR TITLE
Correct OMARS enumeration facts and the Núñez Ares and Goos citation

### DIFF
--- a/design-analysis-experiments/judging-and-comparing-designs.rst
+++ b/design-analysis-experiments/judging-and-comparing-designs.rst
@@ -572,5 +572,7 @@ and the number of residual degrees of freedom.
 * Goos and Jones, *Optimal Design of Experiments: A Case Study Approach*, for the
   information-matrix view of the optimality criteria.
 * Núñez Ares and Goos, "Enumeration and Multicriteria Selection of Orthogonal Minimally Aliased
-  Response Surface Designs", and the review by Goos, "OMARS Designs for Factor Screening and
-  Response Surface Experimentation in One Step", for the OMARS family used in the comparison above.
+  Response Surface Designs", *Technometrics*, **62**, 21--36, 2020, and the review by Goos,
+  "OMARS designs for factor screening and response surface experimentation in one step",
+  *WIREs Computational Statistics*, **17**, e70018, 2025, for the OMARS family used in the
+  comparison above.

--- a/design-analysis-experiments/judging-and-comparing-designs.rst
+++ b/design-analysis-experiments/judging-and-comparing-designs.rst
@@ -571,6 +571,6 @@ and the number of residual degrees of freedom.
   the scaled prediction variance, and FDS plots.
 * Goos and Jones, *Optimal Design of Experiments: A Case Study Approach*, for the
   information-matrix view of the optimality criteria.
-* Núñez Ares, Schoen and Goos, "Orthogonal Minimally Aliased Response Surface Designs", and the
-  review by Goos, "OMARS Designs for Factor Screening and Response Surface Experimentation in One
-  Step", for the OMARS family used in the comparison above.
+* Núñez Ares and Goos, "Enumeration and Multicriteria Selection of Orthogonal Minimally Aliased
+  Response Surface Designs", and the review by Goos, "OMARS Designs for Factor Screening and
+  Response Surface Experimentation in One Step", for the OMARS family used in the comparison above.

--- a/design-analysis-experiments/optimal-and-omars-designs.rst
+++ b/design-analysis-experiments/optimal-and-omars-designs.rst
@@ -513,7 +513,9 @@ designs are catalogued so as to keep that aliasing minimal, which is what the na
 held down), **r**\ esponse **s**\ urface (a full second-order model is the target).
 
 The important shift in thinking is this: OMARS is not a single design but a whole *catalogue*.
-For a given number of factors there are many OMARS designs of different run sizes, and they
+The 2020 enumeration found 7,933 basic designs, which become 55,531 in total once zero to six
+centre runs are added to each. For a given number of factors there are many OMARS designs of
+different run sizes, and they
 trade off against one another: a larger design estimates more of the second-order effects, with
 lower correlation among them and more power, at the cost of more runs. The definitive screening
 design turns out to be the smallest member of the family; the largest members rival a central
@@ -521,15 +523,16 @@ composite design. Choosing among them is therefore a genuine multi-criteria deci
 lookup, which is the subject of the next two subsections.
 
 The original catalogue was produced by an enumeration (an integer-programming search) that is
-complete for three to five factors up to 24 runs, and partial for six and seven factors, with the
-seven-factor search restricted to foldover designs. It is a sizeable catalogue: 7,933 basic
-designs, rising to 55,531 once zero to six centre runs are added to each. Many of these are
-foldover designs, built as the DSD was by folding a base matrix whose columns are orthogonal.
-Folding is one way to force the odd moments to vanish and leave the main effects clean, but it is
-not the only way: the catalogue also contains non-foldover designs whose main effects are equally
-clean. The family has since been extended to mixed-level designs (continuous factors together with
-two-level categorical factors), to orthogonally blocked designs, and to large designs constructed
-by concatenating two definitive screening designs.
+complete for three to five factors at the smaller run sizes (up to 14 runs for three factors, and
+up to 24 runs for four and five factors), and partial for six and seven factors, where the
+seven-factor search was restricted to foldover designs. Many of these designs are foldover
+designs, built as the DSD was by folding over a base matrix whose columns are orthogonal. The
+orthogonality of the main effects, however, comes from the construction itself: all odd design
+moments through order three are set to zero, so the non-foldover designs in the catalogue have
+equally clean main effects. The family has since been extended to mixed-level designs (three-level
+quantitative factors together with two-level categorical factors) and to orthogonally blocked
+designs, and the same line of work noted that two definitive screening designs, or more generally
+two OMARS designs, can be concatenated to build a larger design.
 
 **Readings**
 

--- a/design-analysis-experiments/optimal-and-omars-designs.rst
+++ b/design-analysis-experiments/optimal-and-omars-designs.rst
@@ -521,12 +521,15 @@ composite design. Choosing among them is therefore a genuine multi-criteria deci
 lookup, which is the subject of the next two subsections.
 
 The original catalogue was produced by an enumeration (an integer-programming search) that is
-complete for up to five factors and 44 runs, and partial for six and seven factors. Many of the
-designs can also be built, as the DSD was, by folding over a base matrix whose columns are
-orthogonal, which is why the main effects always come out clean. The family has since been
-extended to mixed-level designs (continuous factors together with two-level categorical
-factors), to orthogonally blocked designs, and to large designs constructed by concatenating
-two definitive screening designs.
+complete for three to five factors up to 24 runs, and partial for six and seven factors, with the
+seven-factor search restricted to foldover designs. It is a sizeable catalogue: 7,933 basic
+designs, rising to 55,531 once zero to six centre runs are added to each. Many of these are
+foldover designs, built as the DSD was by folding a base matrix whose columns are orthogonal.
+Folding is one way to force the odd moments to vanish and leave the main effects clean, but it is
+not the only way: the catalogue also contains non-foldover designs whose main effects are equally
+clean. The family has since been extended to mixed-level designs (continuous factors together with
+two-level categorical factors), to orthogonally blocked designs, and to large designs constructed
+by concatenating two definitive screening designs.
 
 **Readings**
 


### PR DESCRIPTION
## What changed

A fact-check of the OMARS material against Núñez Ares and Goos (2020,
*Technometrics* **62**, 21–36) surfaced three inaccuracies. All three are
corrected here.

### 1. Enumeration completeness range (`optimal-and-omars-designs.rst`)

"complete for up to five factors and 44 runs" was wrong: 44 is merely the
largest run size examined for five factors, not the completeness bound. The
paper reports completeness for three to five factors up to 24 runs, partial
for six and seven, with the seven-factor search restricted to foldover
designs. Reworded accordingly, and anchored the catalogue size (7,933 basic
designs, 55,531 after adding zero to six centre runs to each) to ground the
"whole catalogue" framing.

### 2. Foldover causal attribution (`optimal-and-omars-designs.rst`)

"folding over a base matrix ... which is why the main effects always come out
clean" read as if foldover causes clean main effects. Orthogonality is
enforced by construction (odd moments through third order set to zero);
foldover is one route, and the paper's own non-foldover designs have equally
clean main effects. Reworded to present folding as one mechanism, not the
mechanism.

### 3. Citation author list (`judging-and-comparing-designs.rst`)

The Readings entry read "Núñez Ares, Schoen and Goos". The 2020 paper is
Núñez Ares and Goos only. Dropped the stray third author and restored the
paper's full title so this entry matches the correctly-formatted citation in
the other file.

## Out of scope (confirmed, no change)

- The 9-run DSD vs 13-run OMARS efficiency numbers in the comparison table
  are local process-improve computations, not paper claims, and the
  13-run = 12-run basic + 1 centre / 9-run = 8-run basic + 1 centre
  constructions are internally consistent with the catalogue.
- The "generalization of the DSD" framing needs no change: the optimal file
  already gives the broader framing (subsuming CCDs and BBDs).

## Verification

- `make text`: zero warnings.
- `make html`: succeeds, `grep -r goatcounter _build/html/contents` zero hits.
- No em-dashes. CITATION.cff already at 2026.06.15.

https://claude.ai/code/session_01MjTdW5BuKBy1b9iTZAPKC7

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjTdW5BuKBy1b9iTZAPKC7)_