### PR TITLE
Voice and clarity pass on the design comparison, plus DOIs for all Readings

### DIFF
--- a/design-analysis-experiments/optimal-and-omars-designs.rst
+++ b/design-analysis-experiments/optimal-and-omars-designs.rst
@@ -122,6 +122,7 @@ subsection.
 
 * St. John and Draper: "`D-Optimality for Regression Designs: A Review
   <https://www.jstor.org/stable/1267995>`_", *Technometrics*, **17**, 15--23, 1975.
+  `doi:10.1080/00401706.1975.10489266 <https://doi.org/10.1080/00401706.1975.10489266>`__
 
 The information matrix and the optimality criteria
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -343,6 +344,7 @@ there to absorb.
 * Meyer, R.K. and Nachtsheim, C.J.: "`The Coordinate-Exchange Algorithm for Constructing Exact
   Optimal Experimental Designs <https://www.jstor.org/stable/1269153>`_", *Technometrics*, **37**,
   60--69, 1995.
+  `doi:10.1080/00401706.1995.10485889 <https://doi.org/10.1080/00401706.1995.10485889>`__
 
 .. _DOE-constrained-optimal-example:
 
@@ -488,6 +490,7 @@ precisely what the next family of designs sets out to manage.
 * Jones, B. and Nachtsheim, C.J.: "`A Class of Three-Level Designs for Definitive Screening in
   the Presence of Second-Order Effects <https://yint.org/dsdesign>`_", *Journal of Quality
   Technology*, **43**, 1--15, 2011.
+  `doi:10.1080/00224065.2011.11917841 <https://doi.org/10.1080/00224065.2011.11917841>`__
 * John Lawson: "`DefScreen: Definitive Screening Designs, in package "daewr"
   <https://rdrr.io/cran/daewr/man/DefScreen.html>`_", *Design and Analysis of Experiments with
   R*.
@@ -655,5 +658,7 @@ book.
 
 * Jones, B. and Nachtsheim, C.J.: "Effective Design-Based Model Selection for Definitive
   Screening Designs", *Technometrics*, **59**, 319--329, 2017.
+  `doi:10.1080/00401706.2016.1234979 <https://doi.org/10.1080/00401706.2016.1234979>`__
 * Hameed, M.S.I., Núñez Ares, J. and Goos, P.: "Analysis of data from orthogonal minimally
   aliased response surface designs", *Journal of Quality Technology*, **55**, 366--384, 2023.
+  `doi:10.1080/00224065.2022.2151530 <https://doi.org/10.1080/00224065.2022.2151530>`__


### PR DESCRIPTION
## What changed

Two commits, both touching the design-comparison material in the
Design and Analysis of Experiments part.

### 1. Voice and clarity pass on the augmentation worked example (`judging-and-comparing-designs.rst`)

- "the three-run example above" now links back to the previous section,
  where that example actually lives (a separate HTML page).
- Added the X and M matrices for the centre-point design (row 3), so all
  four candidate designs now show their matrices. The closing observation
  now compares the two five-run designs (M3 versus M4) directly, which is the
  contrast the comparison rests on.
- Reworded phrasings flagged as not the author's voice: "can top them all"
  to "is best in every column"; "estimate the coefficients as a set" to
  "jointly"; "shore it up" to "strengthen it"; "resolves by purpose" to
  "resolves based on your intentions"; "it always flatters" to "favours".
- FDS axis description now reads "running fraction (percentiles)".
- Removed two forward references that named the comparison table before it
  appears, pointing the reader to the table "below" instead.
- Every bare "nine-run" / "thirteen-run" reference now carries its DSD or
  OMARS label so the reader need not scroll back to recall which is which.

### 2. DOIs on every journal article in both files' Readings

- Both files: the two OMARS journal papers carry verified DOIs.
- `optimal-and-omars-designs.rst` has five Readings blocks; the four other
  journal articles (St. John and Draper 1975; Meyer and Nachtsheim 1995;
  Jones and Nachtsheim 2011 and 2017; Hameed, Núñez Ares and Goos 2023) now
  each carry a trailing DOI link, with their existing free or stable links
  (JSTOR, the author's yint.org copy) kept.
- Every DOI was checked against the publisher record before adding.
  Textbooks and the daewr R package page have no DOI, so they stay as plain
  citations.

## Metadata

- `CITATION.cff` bumped to `2026.06.16` (the date rolled over from the
  staged `.15`), so the pending release is now `v2026.06.16`.

## Verification

- `make text`: zero warnings.
- `make html`: succeeds, `grep -r goatcounter _build/html/contents` zero hits.
- No em-dashes. Matrix determinants (4, 32, 12, 16) reproduce the table.

https://claude.ai/code/session_01MjTdW5BuKBy1b9iTZAPKC7

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjTdW5BuKBy1b9iTZAPKC7)_