### PR TITLE
Limit the contents-page Table of Contents to two levels

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.06.16"
-date-released: 2026-06-16
+version: "2026.06.17"
+date-released: 2026-06-17
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/contents.rst
+++ b/contents.rst
@@ -14,7 +14,7 @@ Process Improvement Using Data
 .. toctree::
 	:titlesonly:
 	:numbered:
-	:maxdepth: 3
+	:maxdepth: 2
 	:caption: Table of Contents
 
 	data-visualization/index


### PR DESCRIPTION
## What changed

The Table of Contents rendered in the body of the landing page (`contents`) expanded three levels deep, listing every `x.y.z` subsection (e.g. `6.5.17 Some properties of PCA models`, `6.7.1 Advantages of the projection to latent structures (PLS) method`). That made the page very long.

This PR changes the `:maxdepth:` of the "Table of Contents" toctree directive in `contents.rst` from `3` to `2`, so the body TOC stops at the `x.y` section level (e.g. `6.5`, `6.6`, `6.7`).

## What did NOT change

- **The left sidebar navigation is untouched.** The sidebar depth is driven by the theme's own `max_navbar_depth` option (default 4) in `conf.py`, which is a separate rendering path from the body toctree directive. No change was made to `conf.py`, so the sidebar continues to expand to its existing depth.

## Verification

- `make html` succeeds.
- Inspected the rendered `_build/html/contents`:
  - Body `<article>` toctree levels: `toctree-l1`, `toctree-l2` only (the desired `x.y` cap).
  - Sidebar `<nav>` toctree levels: `toctree-l1`, `toctree-l2`, `toctree-l3` (unchanged).
- `grep -r goatcounter _build/html/contents` returns zero hits (no telemetry in local build).
- `make text` builds successfully. The 334 warnings are all pre-existing and come from the `figures/` repo not being populated in the build sandbox; none relate to this change (a one-line toctree depth edit).

Per repository policy for substantive changes, `CITATION.cff` `version` and `date-released` are bumped to `2026.06.17`. The README attribution year range already ends in 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011r1Y8ydHH4s1j2eZv6vXKy)_