### PR TITLE
Make chapter-page TOC section entries read as links

### DIFF
--- a/_static/css/theme-extended-kgd.css
+++ b/_static/css/theme-extended-kgd.css
@@ -204,10 +204,20 @@ button.copybtn:focus,
     font-weight: 600;
     line-height: 1.25;
     margin-bottom: 0.35rem;
+}
+
+/* By default keep the toctree-l1 entries in the link colour so they read
+   as clickable. On a chapter index page the top level IS the chapter's
+   list of section links, and they must look like links. Only on the main
+   contents page (the captioned "Table of Contents") do we tone the top
+   level down to the heading colour, because there the top level is the
+   chapter titles and the clickable navigation is the section list nested
+   beneath each one. */
+.bd-article .toctree-wrapper:has(> .caption) li.toctree-l1 > a {
     color: var(--pst-color-text-base, #333);
 }
-.bd-article .toctree-wrapper li.toctree-l1 > a:hover,
-.bd-article .toctree-wrapper li.toctree-l1 > a:focus {
+.bd-article .toctree-wrapper:has(> .caption) li.toctree-l1 > a:hover,
+.bd-article .toctree-wrapper:has(> .caption) li.toctree-l1 > a:focus {
     color: var(--pst-color-primary, #0071bc);
 }
 


### PR DESCRIPTION
## What changed

On a chapter index page, the top-level entries of the body Table of Contents are the chapter's own section links (`1.1`, `1.2`, …). The previous styling rendered every `toctree-l1` entry in the heading colour, so on chapter pages those section links looked like plain, unclickable headings.

The fix keeps the **link colour as the default** for `toctree-l1` entries (so chapter-page section lists read as clickable) and tones them down to the heading colour **only on the main contents page**, which is identified by its `Table of Contents` caption via `:has(> .caption)`. Chapter index pages have no such caption, so their section entries now show in the link colour while keeping the larger, bold treatment.

## Why this scoping

The main contents page and chapter index pages both render a body toctree, but they differ by one thing: the main one carries a `:caption: Table of Contents` (rendered as `<p class="caption">`), and chapter ones do not. `:has(> .caption)` distinguishes them with no per-page markup. If a very old browser lacks `:has()` support, it degrades gracefully: the main page's chapter titles would simply appear in the link colour too (still correct and clickable, just not the heading look).

## Verification

- `make html` exits 0; `grep -r goatcounter _build/html/contents` returns zero hits.
- Confirmed in the generated markup that `_build/html/contents` contains the caption (so chapters stay heading-coloured) while `_build/html/data-visualization/index` has no caption (so its `1.x` section links now take the link colour).
- CSS-only change; LaTeX/PDF output is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011r1Y8ydHH4s1j2eZv6vXKy)_