### PR TITLE
Default Claude Code sessions to Opus

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "model": "opus"
+}


### PR DESCRIPTION
## What changed

Adds `.claude/settings.json` setting the default Claude Code model for this repository to Opus:

```json
{
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "model": "opus"
}
```

Web sessions are rebuilt from the repository each time, so a committed `.claude/settings.json` is the only place a model default persists across sessions (a gitignored `settings.local.json` would not survive the ephemeral container). This makes sessions start on Opus without having to run `/model` each time. The `opus` family alias tracks the latest Opus release; it can be pinned to a specific version (e.g. `claude-opus-4-8`) if you prefer.

## Caveat worth knowing

If the Claude Code on the web *environment* pins the model via managed settings, that managed value takes precedence over this repo-level setting, so this file alone may not flip the active model. In that case the durable fix is to set the default model in the web environment/session configuration. This file is still the correct repo-level lever and is what applies for local CLI sessions and any session not overridden by managed settings.

This is a tooling-config change only: no book content, build, or site output is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011r1Y8ydHH4s1j2eZv6vXKy)_