### PR TITLE
Accuracy review: tighten OMARS and design-comparison subsections

### DIFF
--- a/design-analysis-experiments/judging-and-comparing-designs.rst
+++ b/design-analysis-experiments/judging-and-comparing-designs.rst
@@ -387,11 +387,13 @@ levels happen to be coded: flip the direction of one factor and the sign of ever
 containing it flips with it. The magnitude is the coding-invariant quantity, and it is what
 governs separability. A value of :math:`|r| = 0` means the two effects are orthogonal and can be
 estimated independently; :math:`|r| = 1` means they are the same column and cannot be told apart
-at all. Two summaries are useful: the **maximum** :math:`|r|` over all pairs is the single
-tightest confounding anywhere in the design (the worst case you would have to defend), while the
-**mean** :math:`|r|` is the overall level of entanglement. In the comparison table, the
-definitive screening design has a worst-pair value of :math:`0.707` (a structural hallmark of
-DSDs), which the thirteen-run OMARS design improves to :math:`0.570`; the mean values, :math:`0.322`
+at all. Two summaries are useful: the **maximum** :math:`|r|` over all pairs of second-order
+effects (the quadratics and two-factor interactions, which is where a screening design's
+entanglement lives) is the single tightest confounding anywhere in the design (the worst case you
+would have to defend), while the **mean** :math:`|r|` is the overall level of entanglement. In the
+comparison table, the definitive screening design has a worst-pair value of :math:`0.707` (a
+structural hallmark of DSDs, and a confounding between two of its second-order effects), which the
+thirteen-run OMARS design improves to :math:`0.570`; the mean values, :math:`0.322`
 against :math:`0.307`, are much closer, telling us the extra runs help most with the *worst* pair
 rather than with the average.
 
@@ -440,7 +442,10 @@ every other term, and is computed on whichever model you actually intend to fit.
 
 In the comparison table below, both summaries are reported for the main-effects-and-quadratic
 model. The definitive screening design shows :math:`\text{VIF} = 1.0` throughout: on that model its
-terms are mutually orthogonal. The thirteen-run OMARS design carries a maximum VIF of :math:`1.18`
+terms are mutually orthogonal. (This is not in tension with the worst-pair :math:`|r| = 0.707`
+quoted above: that correlation involves the two-factor interactions, which this model leaves out.
+Restricted to the main effects and quadratics, the DSD really is orthogonal.) The thirteen-run
+OMARS design carries a maximum VIF of :math:`1.18`
 and a mean of
 :math:`1.08`, which inflates the worst standard error by only :math:`\sqrt{1.18} \approx 1.09`,
 about nine percent. That is a mild and entirely acceptable price for the residual degrees of freedom

--- a/design-analysis-experiments/optimal-and-omars-designs.rst
+++ b/design-analysis-experiments/optimal-and-omars-designs.rst
@@ -439,7 +439,8 @@ introduced by Jones and Nachtsheim in 2011, collapses the two phases into one. I
 three-level design, economical (about :math:`2k + 1` runs for :math:`k` factors), that screens
 the main effects *and* lets you detect curvature, all from a single set of runs.
 
-The construction is a *foldover* of a conference matrix with a centre run added. A conference
+The construction is a *foldover* of a conference matrix with a centre run added, a route to the DSD
+due to Xiao, Lin, and Bai (2012). A conference
 matrix :math:`\mathbf{C}` of order :math:`m` is an :math:`m \times m` matrix with zeros on the
 diagonal and :math:`\pm 1` off it, whose columns are orthogonal:
 :math:`\mathbf{C}^T\mathbf{C} = (m-1)\mathbf{I}`. The design stacks :math:`\mathbf{C}`, its
@@ -471,10 +472,14 @@ themselves identically. The consequences are:
         factor; and
 
     *   under effect sparsity (the common assumption that only a few of the many factors actually
-        drive the response), the design has a further useful property: restricted to any three of
-        the factors, its runs already form a design able to fit the full quadratic model in just
-        those three factors. So if only a handful of factors turn out to matter, the same single
-        set of runs supports a complete response-surface model in them.
+        drive the response), a sufficiently large design has a further useful property. Jones and
+        Nachtsheim show it for six factors or more, where the :math:`2k+1` runs comfortably exceed
+        the ten that a three-factor full quadratic needs: restricted to any three of the factors,
+        the runs already form a design able to fit the full quadratic model in just those three
+        factors. So if only a handful of factors turn out to matter, the same single set of runs
+        supports a complete response-surface model in them. (A small DSD cannot do this: the
+        nine-run, four-factor design used as the running example in the next section has fewer runs
+        than that ten-parameter model requires.)
 
 There is one limitation, and it comes from the very same mechanism. Folding cancels the
 cross-products between the main effects and the second-order terms, but it does nothing to
@@ -492,6 +497,9 @@ precisely what the next family of designs sets out to manage.
   the Presence of Second-Order Effects <https://yint.org/dsdesign>`_", *Journal of Quality
   Technology*, **43**, 1--15, 2011.
   `doi:10.1080/00224065.2011.11917841 <https://doi.org/10.1080/00224065.2011.11917841>`__
+* Xiao, L., Lin, D.K.J. and Bai, F.: "Constructing Definitive Screening Designs Using Conference
+  Matrices", *Journal of Quality Technology*, **44**, 2--8, 2012.
+  `doi:10.1080/00224065.2012.11917877 <https://doi.org/10.1080/00224065.2012.11917877>`__
 * John Lawson: "`DefScreen: Definitive Screening Designs, in package "daewr"
   <https://rdrr.io/cran/daewr/man/DefScreen.html>`_", *Design and Analysis of Experiments with
   R*.
@@ -522,11 +530,13 @@ centre runs are added to each. For a given number of factors there are many OMAR
 different run sizes, and they
 trade off against one another: a larger design estimates more of the second-order effects, with
 lower correlation among them and more power, at the cost of more runs. The definitive screening
-design turns out to be the smallest member of the family; the largest members rival a central
-composite design. Choosing among them is therefore a genuine multi-criteria decision, not a
-lookup, which is the subject of the next two subsections.
+design turns out to be the smallest member of the family; at the other extreme, the classical
+face-centred central composite and Box-Behnken designs are themselves OMARS designs, so the
+largest members coincide with the standard response surface designs. Choosing among them is
+therefore a genuine multi-criteria decision, not a lookup, which is the subject of the next two
+subsections.
 
-The original catalogue was produced by an enumeration (an integer-programming search) that is
+The original catalogue was produced by an enumeration based on integer programming that is
 complete for three to five factors at the smaller run sizes (up to 14 runs for three factors, and
 up to 24 runs for four and five factors), and partial for six and seven factors, where the
 seven-factor search was restricted to foldover designs. Many of these designs are foldover
@@ -535,8 +545,9 @@ orthogonality of the main effects, however, comes from the construction itself: 
 moments through order three are set to zero, so the non-foldover designs in the catalogue have
 equally clean main effects. The family has since been extended to mixed-level designs (three-level
 quantitative factors together with two-level categorical factors) and to orthogonally blocked
-designs, and the same line of work noted that two definitive screening designs, or more generally
-two OMARS designs, can be concatenated to build a larger design.
+designs. Larger OMARS designs can also be built by folding over and combining orthogonal building
+blocks such as conference, weighing, and Hadamard matrices, the same mechanism that turns a single
+conference matrix into a definitive screening design.
 
 **Readings**
 
@@ -557,7 +568,9 @@ more runs buy more estimable second-order effects, lower correlation among them,
 At the rich end sit the classical response surface designs, the :ref:`central composite
 <DOE_central_composite_designs>` and Box-Behnken designs: enough runs to estimate the full
 second-order model with little or no aliasing, often with the near-rotatable prediction
-behaviour those designs are prized for.
+behaviour those designs are prized for. In the face-centred case these classical designs are
+themselves OMARS designs, the strongest and largest members of the family, so the spectrum is
+really one continuous family rather than three separate boxes.
 
 The axis along which they are arranged is the trade-off between three things: how many runs you
 spend, how much of the second-order model you can estimate, and how cleanly (how free of


### PR DESCRIPTION
## What this is

An accuracy review of the two recently added subsections, checked line by line against the
primary literature:

- `design-analysis-experiments/optimal-and-omars-designs.rst`
- `design-analysis-experiments/judging-and-comparing-designs.rst`

Sources consulted: Núñez Ares & Goos (2020, *Technometrics*, the OMARS enumeration paper),
Goos (2025, *WIREs Comp. Stat.* review), Núñez Ares, Schoen & Goos (2023, *Statistica Sinica*,
mixed-level OMARS), Jones & Nachtsheim (2011, 2013) and Xiao, Lin & Bai (2012) on definitive
screening designs, and Smucker, Krzywinski & Altman (2018) on optimal design.

## What was already correct (no change needed)

The bulk of both sections holds up. All of the mathematics was re-derived by hand and reproduces
exactly (information matrix, its inverse, the D/A/E criteria, the prediction-variance polynomial,
the four-design dilemma table, the SPV scaling, and the run-count / degrees-of-freedom arithmetic).
The core OMARS facts are verbatim-correct against the 2020 paper: the naming and orthogonality
definition, **7,933 basic designs / 55,531 total via 0–6 added centre runs**, the completeness
ranges (3 factors up to 14 runs; 4 and 5 factors up to 24 runs; partial for 6 and 7; 7-factor
restricted to foldover), "all odd design moments through order three equal zero", and the acronym.
The mixed-level and orthogonally blocked extensions, and the staged design-based analysis, are also
supported.

## What changed

- **Construction of larger designs.** Replaced the unsupported statement that "two DSDs / two OMARS
  designs can be concatenated" with the documented construction: larger OMARS designs are built by
  folding over and combining orthogonal building blocks (conference, weighing, Hadamard matrices),
  the same mechanism behind a DSD.
- **Largest members vs central composite designs.** Face-centred central composite and Box-Behnken
  designs are themselves (strong) OMARS designs, so the largest members *coincide with* the
  classical response surface designs rather than merely "rivalling" a central composite design.
  The design-spectrum paragraph now notes the spectrum is one continuous family.
- **DSD projection property.** Qualified to six or more factors, following Jones & Nachtsheim:
  a full quadratic in three factors needs ten runs, so the nine-run four-factor DSD used as the
  running example cannot support it. The text now says so explicitly.
- **Attribution.** Credited Xiao, Lin & Bai (2012) for the conference-matrix construction of DSDs
  and added the reference.
- **Enumeration wording.** "an integer-programming search" → "an enumeration based on integer
  programming".
- **|r| vs VIF clarity.** Stated that the maximum |r| summary ranges over the second-order effects
  (including two-factor interactions), so it does not contradict the VIF = 1.0 reported for the DSD
  on the main-effects-and-quadratic model.

## Not changed (flagged for a manual check)

The computed values in the DSD-vs-OMARS comparison table (D-efficiency, A, I, G, the correlation
and VIF summaries, power) are the book's own computations rather than figures from the papers. They
are internally consistent and the VIF = 1.0 result was reproduced here, but the continuous values
are worth re-confirming with the accompanying `process_improve` code.

## Build

`make text` succeeds; the only warnings are the pre-existing "image file not readable" notices from
the un-checked-out `figures/` submodule. No new RST warnings were introduced by these edits, and
the changes are prose-only (no build files touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGHih2rP9CkYAxcZcZiA9e

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGHih2rP9CkYAxcZcZiA9e)_