### PR TITLE
Document the author's voice; republish to pick up reordered figures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,60 @@ comma, parentheses, or two separate sentences instead. En-dashes (`–`) in
 numeric ranges such as the `2010–2026` year range are correct and should
 stay.
 
+## Writing style: the author's voice
+
+When writing or editing prose for this book, match the author's voice.
+These rules are distilled from repeated corrections; follow them so the
+same edits do not have to be made again.
+
+**Tone**
+
+- Compare, do not advocate. When weighing designs, methods, or options,
+  lay out the trade-offs neutrally and let the reader (or the purpose of
+  the study) decide. Do not argue that one option is better or worse,
+  crown a winner, or tell the reader what they "should" do.
+- No dramatic or loaded framing. Avoid words like "trap", "flatters",
+  "lying", "the whole story". Say plainly what happens.
+- Do not moralize. Never label a quantity, reading, or comparison as
+  "honest" (it implies the alternatives are dishonest). Cut editorial or
+  sarcastic asides such as "as they should" or "a number nobody asked
+  for".
+- Do not overstate. Avoid "always", "never", "obviously", "the whole
+  story" unless the claim is literally true; prefer measured wording.
+- No cute or colourful adjectives standing in for precision (e.g.
+  "thrifty"). Use plain, exact language.
+
+**Technical rigour**
+
+- Define before you use. Introduce a term or metric in plain words
+  before leaning on it; never name-drop a concept (an optimality
+  criterion, for instance) that has not been set up. If you add a metric,
+  explain what it measures and why it belongs here.
+- Use terms correctly. Do not stretch a name to cover something it does
+  not mean (e.g. T-optimality is model discrimination, not total
+  information). Verify the definition; if unsure, flag it rather than
+  bluff.
+- Re-explain at the point of use. Briefly restate what a term means
+  where it appears again, rather than relying on the reader to scroll
+  back to an earlier definition.
+- State the scenario first. Make the assumptions explicit before drawing
+  a conclusion (for example: the model is already fixed, and we are
+  comparing where the runs are placed).
+
+**Formatting**
+
+- Numbers: keep a consistent number of significant figures (do not
+  blanket-round to a fixed number of decimals); attach units ("46 runs",
+  not "46"); no space before "%".
+- Tables: capitalise the first-column labels, and order the columns
+  meaningfully, keeping any related figure in the same order.
+- Keep paragraphs short; split a long one at its natural seam.
+
+**Process**
+
+- When a wording or style fix may recur elsewhere in the file, ask before
+  changing the other occurrences rather than assuming.
+
 ## Bump the version and citation date whenever you plan a PR
 
 This repository ships release metadata in three places that reusers and


### PR DESCRIPTION
## Summary

Two things in one PR, as requested.

**1. Document the author's voice.** A new `CLAUDE.md` section, "Writing style: the author's voice", distilled from corrections that have recurred this session and before, so future edits match the author's voice without re-litigating the same points. It covers:
- **Tone:** compare, don't advocate; no dramatic/loaded framing ("trap", "flatters", "lying"); don't moralize (no "honest", "as they should"); don't overstate; no cute adjectives standing in for precision.
- **Technical rigour:** define a term before using it; use names correctly (e.g. T-optimality is model discrimination, not total information); re-explain at the point of use; state the scenario/assumptions first.
- **Formatting:** consistent significant figures (no blanket rounding), units on numbers ("46 runs"), no space before "%", capitalised table labels, short paragraphs.
- **Process:** ask before applying a wording fix to other occurrences.

**2. Republish to pick up the reordered figures.** The build-and-deploy workflow checks out `kgdunn/figures` fresh (its default branch, no pinned ref or submodule) on every push to `main`. Merging this PR therefore re-runs the deploy and the live book picks up the reordered comparison figures from figures #16. This docs-only commit is just the carrier; it does not touch the build inputs.

## Notes

- `CLAUDE.md` is repo guidance, not book prose, so the build is unaffected; `make text` / `make html` are unchanged by this PR.
- The em-dashes already present in `CLAUDE.md` are pre-existing; the new section adds none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AveFGDuwLHBJ9SRD2aak3

---
_Generated by [Claude Code](https://claude.ai/code/session_012AveFGDuwLHBJ9SRD2aak3)_