### PR TITLE
Citation bump for republication, plus an FDS-sampling note

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.06.18"
-date-released: 2026-06-18
+version: "2026.06.19"
+date-released: 2026-06-19
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/design-analysis-experiments/judging-and-comparing-designs.rst
+++ b/design-analysis-experiments/judging-and-comparing-designs.rst
@@ -300,9 +300,13 @@ and no experiment required. The whole plot is a property of the design's geometr
 So we sample the region. Scatter a large number of locations, tens of thousands of them (the figure
 below uses 80,000), uniformly at random across the coded factor region: for :math:`k` factors that
 means drawing each coordinate independently and uniformly on :math:`[-1, +1]`, so the points fill
-the cube evenly. At every one of those locations we evaluate the SPV formula. We now hold tens of
-thousands of SPV values, one per sampled location, a dense picture of how precisely the fitted model
-would predict across the entire region.
+the cube evenly. One point is easy to miss: uniform random sampling almost never lands exactly on a
+corner of the cube, yet the prediction variance is usually largest at a vertex, where the G-optimal
+worst case sits. Add the :math:`2^k` extreme vertices back to the sampled set explicitly, so the
+worst-case (right-hand) tail of the curve is represented and the region is covered fairly. At every
+one of those locations we evaluate the SPV formula. We now hold tens of thousands of SPV values, one
+per sampled location, a dense picture of how precisely the fitted model would predict across the
+entire region.
 
 Finally we turn that cloud of numbers into a curve. Sort the SPV values from smallest to largest.
 The :math:`i`-th value in the sorted list is plotted at horizontal position


### PR DESCRIPTION
## What changed

Two changes for the next republish:

1. **`CITATION.cff`** bumped to `2026.06.19` (version and `date-released`).

2. **FDS sampling note** in `judging-and-comparing-designs.rst`. The paragraph
   that scatters tens of thousands of random locations to build the FDS curve
   now adds a sentence: uniform random sampling almost never lands on a cube
   vertex, but the prediction variance is usually largest at a vertex (the
   G-optimal worst case), so the reader must add the `2^k` extreme vertices
   back to the sampled set explicitly, otherwise the worst-case tail of the
   curve is understated and the region is not covered fairly. This matches how
   the omnibus evaluation script actually samples the space.

The updated omnibus figures (repositioned legend, bracketed run counts) are
already on the figures repo `main` (kgdunn/figures#17, merged), so this
republish will pick them up.

## Verification

- `make text`: zero warnings.
- `make html`: succeeds, `grep -r goatcounter _build/html/contents` zero hits.
- No em-dashes. README year range already ends in 2026.

https://claude.ai/code/session_01MjTdW5BuKBy1b9iTZAPKC7