### PR TITLE
Build the chapter CCD with process_improve cube="fractional"

### DIFF
--- a/design-analysis-experiments/judging-and-comparing-designs.rst
+++ b/design-analysis-experiments/judging-and-comparing-designs.rst
@@ -82,7 +82,7 @@ climbs steeply (already :math:`5.2\,\sigma^2` at :math:`x = 1.5`): a quantitativ
 against extrapolation.
 
 This and every figure in this subchapter is reproducible with `process_improve
-<https://github.com/kgdunn/process-improve>`_ (``pip install 'process-improve[expt]'``);
+<https://github.com/kgdunn/process-improve>`_ (``pip install 'process-improve[expt]>=1.42'``);
 the code blocks build on one another, so paste them in order. The prediction variance of the
 three-run quadratic design is a closed form:
 
@@ -764,10 +764,10 @@ designs' ability to flag a true effect of one noise standard deviation
 (:math:`\delta = \sigma`) at :math:`\alpha = 0.05`.
 
 The four response-surface designs are built once here and reused for the table and the FDS
-panels that follow. ``process_improve`` builds the Box-Behnken design and the DSD directly;
-its central composite design uses a full-factorial cube (48 runs for five factors), so the
-face-centred CCD is built on the standard resolution-V half-fraction cube instead, and the
-25-run OMARS design (no library generator) is two permuted conference-matrix foldovers. The
+panels that follow. ``process_improve`` builds the Box-Behnken design and the DSD directly,
+and builds the face-centred CCD on a resolution-V half-fraction cube with ``cube="fractional"``
+(the standard five-factor CCD; the library's default cube is the full factorial). The 25-run
+OMARS design has no library generator, so it is two permuted conference-matrix foldovers. The
 power comes from ``evaluate_design``, given the eleven-term model as an explicit formula so
 the library scores exactly this model and not the full second-order one:
 
@@ -797,11 +797,8 @@ the library scores exactly this model and not the full second-order one:
 
 	bbd = coded(generate_design(factors, "box_behnken", center_points=6))
 	dsd = coded(generate_design(factors, "dsd"))
-	cube = coded(generate_design(factors, "fractional_factorial",
-	                             generators=["E=ABCD"], center_points=0))
-	faces = np.array([[s if i == m else 0 for i in range(5)]
-	                  for m in range(5) for s in (-1, 1)], float)
-	ccd = np.vstack([cube, faces, np.zeros((6, 5))])
+	ccd = coded(generate_design(factors, "ccd", cube="fractional",
+	                            alpha="face_centered", center_points=6))
 	cm = conference_matrix_order6()[:, :5]
 	cm2 = cm[:, [2, 4, 1, 3, 0]]
 	omars = np.vstack([cm, -cm, cm2, -cm2, np.zeros((1, 5))])


### PR DESCRIPTION
Switches the chapter's CCD code block to the `cube="fractional"` option that shipped in process-improve v1.42.0, removing the hand-assembled cube workaround.

## ✅ Reproducibility confirmed

process-improve **1.42.0 is now on PyPI**: `pip install 'process-improve[expt]>=1.42'` installs cleanly and `cube="fractional"` works (32 runs, resolution V, generators `['E=ABCD']`). The earlier merge blocker is cleared; this PR is ready to merge.

## What changed

The CCD block previously hand-built the cube, faces and centre runs:

```python
cube = coded(generate_design(factors, "fractional_factorial",
                             generators=["E=ABCD"], center_points=0))
faces = np.array([[s if i == m else 0 for i in range(5)]
                  for m in range(5) for s in (-1, 1)], float)
ccd = np.vstack([cube, faces, np.zeros((6, 5))])
```

It now uses one call, and the lead-in prose drops the "library's CCD uses a full cube" caveat:

```python
ccd = coded(generate_design(factors, "ccd", cube="fractional",
                            alpha="face_centered", center_points=6))
```

The reproducibility install line is bumped to `pip install 'process-improve[expt]>=1.42'`.

## What did not change

Every quoted number is identical: the CCD is still the 32-run resolution-V half-fraction design (D-efficiency 28.0%, VIF 3.20, power 0.98 / 0.32, residual df 21), and all other designs are untouched. The library reproduces the same fraction (generators `E=ABCD`, resolution 5).

## Verification

- Updated code blocks run against process-improve 1.42.0 (from PyPI): run counts 46 / 32 / 25 / 13, powers 0.97/0.98/0.99/0.42 and 0.82/0.32/0.46/0.15, average prediction variance 0.18/0.31/0.51/0.71, all unchanged.
- `make text`: chapter warning-free.
- `make html`: succeeds; `grep -r goatcounter _build/html/contents` returns zero hits.

Parallel figures PR (same change in `omnibus_designs.py`): kgdunn/figures#20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxeyNbB9psERdPZz5FSPhP