### PR TITLE
Clarify two reader questions in the least-squares CI derivation

### DIFF
--- a/least-squares-modelling/least-squares-model-analysis.rst
+++ b/least-squares-modelling/least-squares-model-analysis.rst
@@ -294,6 +294,12 @@ Start from the equations that define |b0| and |b1| :ref:`in the prior section <L
     	b_1 &=& \sum{m_iy_i} &\text{where} \qquad m_i &=& \dfrac{x_i - \overline{\mathrm{x}}}{\sum_j{\left( x_j - \overline{\mathrm{x}} \right)^2}}
 	\end{array}
 
+In going from the second line to the third, the :math:`\overline{\mathrm{y}}` term drops out. Expand the
+numerator: :math:`\sum_i \left(x_i - \overline{\mathrm{x}}\right)\left(y_i - \overline{\mathrm{y}}\right) = \sum_i \left(x_i - \overline{\mathrm{x}}\right)y_i - \overline{\mathrm{y}} \sum_i \left(x_i - \overline{\mathrm{x}}\right)`,
+and the last sum is zero, since :math:`\sum_i \left(x_i - \overline{\mathrm{x}}\right) = 0` by the definition of
+the mean. So :math:`\overline{\mathrm{y}}` is the average of all the :math:`y_i`, but here it multiplies a
+quantity that is identically zero, so it has no effect on :math:`b_1`.
+
 That last form of expressing :math:`b_1` shows that every data point contributes a small amount to the coefficient :math:`b_1`. But notice how it is broken into 2 pieces: each term in the sum has a component due to :math:`m_i` and one due to :math:`y_i`. The :math:`m_i` term is a function of the x-data only, and since we assume the x's are measured without error, that term has no error. The :math:`y_i` component is the only part that has error.
 
 So we can write:
@@ -318,7 +324,7 @@ where :math:`j` is an index for all data points used to build the least squares 
 
 #.	What do we use for the numerator term :math:`\mathcal{V}\{y_i\}`?
 
-	-	This term represents the variance of the :math:`y_i` values at a given point :math:`x_i`. If (a) there is no evidence of :index:`lack-of-fit`, and (b) if |y| has the same error at all levels of |x|, then we can write that :math:`\mathcal{V}\{y_i\}` = :math:`\mathcal{V}\{e_i\}  = \dfrac{\sum{e_i^2}}{n-k}`, where :math:`n` is the number of data points used, and :math:`k` is the number of coefficients estimated (2 in this case). The :math:`n-k` quantity is the degrees of freedom.
+	-	This term represents the variance of the :math:`y_i` values at a given point :math:`x_i`. It is the variance of :math:`y_i` about its true value on the line (the error variance), not the spread of the :math:`y_i` about their overall average :math:`\overline{\mathrm{y}}`. If you took repeated measurements at a fixed :math:`x_i`, it is the variance you would see around the average of those repeats; with no replicates we estimate it by pooling the residuals about the fitted line. If (a) there is no evidence of :index:`lack-of-fit`, and (b) if |y| has the same error at all levels of |x|, then we can write that :math:`\mathcal{V}\{y_i\}` = :math:`\mathcal{V}\{e_i\}  = \dfrac{\sum{e_i^2}}{n-k}`, where :math:`n` is the number of data points used, and :math:`k` is the number of coefficients estimated (2 in this case). The :math:`n-k` quantity is the degrees of freedom.
 
 Now for the variance of :math:`b_0 = \overline{\mathrm{y}} - b_1 \overline{\mathrm{x}}`. The only terms with error are :math:`b_1`, and :math:`\overline{\mathrm{y}}`. So we can derive that:
 


### PR DESCRIPTION
## What changed

A reader annotated section 6.7 ("Confidence intervals for the model coefficients") with two questions that the prose did not answer. This PR adds the two missing explanations.

1. **Where did the `ybar` go?** When `b1` is rewritten from `sum(x_i - xbar)(y_i - ybar) / sum(x_i - xbar)^2` to `sum(m_i y_i)`, the `ybar` term vanishes. Added a short paragraph showing why: expanding the numerator leaves `ybar * sum(x_i - xbar)`, and that sum is identically zero by the definition of the mean. So `ybar` is the average of all the `y_i`, but it multiplies zero and cannot affect `b1`.

2. **What is `V{y_i}` the variance of?** The reader asked whether it is the spread about the fitted line, about the overall average `ybar`, or about replicate readings at a fixed `x_i`. Added a sentence clarifying it is the error variance of `y_i` about its true value on the line (equal to the pure-error variance you would get from replicates at a fixed `x_i` when there is no lack-of-fit), not the spread of the `y_i` about `ybar`.

## What did not change

The underlying analysis and all equations are unchanged; these are purely explanatory additions. No figures touched.

## Verification

- `make text` succeeds. The edited file produces no new warnings (the 336 warnings are all pre-existing "image file not readable" entries from the `figures/` symlink not being present in the build container, unrelated to this change).
- Both new passages render correctly in `_build/text`.

`CITATION.cff` `version:`/`date-released:` were already at today's date (2026.06.19) and the README year range already ends in 2026, so no metadata bump was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvDaHMNyNo82DRaLdai7mp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvDaHMNyNo82DRaLdai7mp)_