### PR TITLE
Fix factual and typographical errors in Chapter 2 (univariate review)

### DIFF
--- a/univariate-review/binary-distribution-bernoulli-distribution.rst
+++ b/univariate-review/binary-distribution-bernoulli-distribution.rst
@@ -41,4 +41,4 @@ Another example: you work in a company that produces tablets. The machine create
 		:math:`n=100`
 		===================== ================== =================
 
-	-	Are you surprised by the large reduction in the number of defective tablets for only a small increase in :math:`p`? It is for this reason that a well-performing process producing accetable product does not need to have inspection of every product produced.
+	-	Are you surprised by the large reduction in the number of defective tablets for only a small increase in :math:`p`? It is for this reason that a well-performing process producing acceptable product does not need to have inspection of every product produced.

--- a/univariate-review/confidence-intervals.rst
+++ b/univariate-review/confidence-intervals.rst
@@ -59,7 +59,7 @@ Interpreting the confidence interval
 
 			90%, 17.6, 22.4
 			95%, 17.1, 22.9
-			99%, 15.7, 24.2
+			99%, 15.7, 24.3
 
 		As the confidence level is *increased*, our interval widens, indicating that we have a more reliable region, but it is less precise. With a wider interval we have greater confidence that the true parameter will be inside that region.
 

--- a/univariate-review/normal-distribution-and-checking-for-normality.rst
+++ b/univariate-review/normal-distribution-and-checking-for-normality.rst
@@ -20,7 +20,7 @@ The condition of finite variance is true for almost all systems of practical int
 	:alt:	../figures/univariate/CLT-derivation.svg
 	:align: center
 
-The critical requirement for the central limit theorem to be true is that the samples used to compute that average are independent of each together. The average produced from such samples will be more nearly normal though. Note: we **do not** require the original data to be normally distributed. This is a common misconception though.
+The critical requirement for the central limit theorem to be true is that the samples used to compute that average are independent of each other. The average produced from such samples will be more nearly normal though. Note: we **do not** require the original data to be normally distributed. This is a common misconception though.
 
 Imagine a case where we are throwing dice. The distributions, shown below, are obtained when we throw a die :math:`M` times and we plot the distribution of the *average* of these :math:`M` throws.
 
@@ -232,7 +232,7 @@ Some useful points:
 
 	-	The normal distribution only requires two parameters to describe it: :math:`\mu` and :math:`\sigma`
 
-	-	The area from :math:`x= -\sigma` to :math:`x = \sigma` is about 70% (68.3% exactly) of the distribution. So we have a probability of about 15% of seeing an :math:`x` value greater than :math:`x = \sigma`, and also 15% of :math:`x < -\sigma`
+	-	The area from :math:`x= -\sigma` to :math:`x = \sigma` is about 70% (68.3% exactly) of the distribution. So we have a probability of about 16% of seeing an :math:`x` value greater than :math:`x = \sigma`, and also 16% of :math:`x < -\sigma`
 
 	-	The :index:`tail <single: tail, in a histogram>` area outside :math:`\pm 2\sigma` is about 5% (2.275 outside each tail)
 

--- a/univariate-review/other-types-of-confidence-intervals.rst
+++ b/univariate-review/other-types-of-confidence-intervals.rst
@@ -12,14 +12,14 @@ Confidence interval for the variance
 	single: confidence interval; for variance
 	single: chi-squared distribution
 
-This confidence interval finds a region in which the normal distribution's variance parameter, :math:`\sigma`, lies. The range is obviously positive, since variance is a positive quantity. For reference, this range is:
+This confidence interval finds a region in which the normal distribution's variance parameter, :math:`\sigma^2`, lies. The range is positive, since variance is a positive quantity. For reference, this range is:
 
 .. math::
-	\left[\frac{(n-1)S^2}{\chi^2_{n-1, \alpha/2}} \quad\text{to}\quad \frac{(n-1)S^2}{\chi^2_{n-1, 1-\alpha/2}} \right]
+	\left[\frac{(n-1)S^2}{\chi^2_{n-1,\, 1-\alpha/2}} \quad\text{to}\quad \frac{(n-1)S^2}{\chi^2_{n-1,\, \alpha/2}} \right]
 
 -	:math:`n` is the number of samples
 -	:math:`S^2` is the sample variance
--	:math:`\chi^2_{n-1, \alpha/2}` are values from the :math:`\chi^2` distribution with :math:`n-1` and :math:`\alpha/2` degrees of freedom
+-	:math:`\chi^2_{n-1,\, \alpha/2}` and :math:`\chi^2_{n-1,\, 1-\alpha/2}` are the values from the :math:`\chi^2` distribution with :math:`n-1` degrees of freedom, having a cumulative area of :math:`\alpha/2` and :math:`1-\alpha/2` respectively to their left. The smaller critical value, :math:`\chi^2_{n-1,\, \alpha/2}`, appears in the denominator of the upper bound.
 -	:math:`1-\alpha`: is the level of confidence, usually 95%, so :math:`\alpha = 0.05` in that case.
 
 .. todo: give some R code still

--- a/univariate-review/paired-tests.rst
+++ b/univariate-review/paired-tests.rst
@@ -32,7 +32,7 @@ The disadvantage of the paired test is that we lose degrees of freedom. Let's se
 
 	#.	Calculate the mean, :math:`\overline{w}` and the standard deviation, :math:`s_w`, of these :math:`n` difference values.
 
-	#.	What do we need to assume about the population from which :math:`w` comes?  Nothing. We are not interested in the :math:`w` values, we are interested in :math:`\overline{w}`. OK, so what distribution would values of :math:`\overline{w}` come from?  By the central limit theorem, the :math:`\overline{w}` values should be normally distributed as :math:`\overline{w} \sim \mathcal{N}\left(\mu_w, \sigma_w^2/n \right)`, where :math:`\mu_w = \mu_{A-B}`.
+	#.	What do we need to assume about the population from which :math:`w` comes?  Nothing. We are not interested in the :math:`w` values, we are interested in :math:`\overline{w}`. OK, so what distribution would values of :math:`\overline{w}` come from?  By the central limit theorem, the :math:`\overline{w}` values should be normally distributed as :math:`\overline{w} \sim \mathcal{N}\left(\mu_w, \sigma_w^2/n \right)`, where :math:`\mu_w = \mu_{B-A} = \mu_B - \mu_A`.
 
 	#.	Now calculate the :math:`z`-value, but use the sample standard deviation, instead of the population standard deviation.
 
@@ -48,7 +48,7 @@ The disadvantage of the paired test is that we lose degrees of freedom. Let's se
 
 		The value of :math:`c_t` is taken from the :math:`t`-distribution with :math:`n-1` degrees of freedom at the level of confidence required: use the ``qt(...)`` function in R to obtain the values of :math:`c_t`.
 
-The :index:`loss of degrees of freedom <single: degrees of freedom; loss of>` can be seen when we use exactly the same data and treat the problem as one where we have :math:`n_A` and :math:`n_B` samples in groups A and B and want to test for a difference between :math:`\mu_A` and :math:`\mu_B`. You are encouraged to try this out. There are more degrees of freedom, :math:`n_A + n_B - 2` in fact when we use the :math:`t`-distribution with the :ref:`pooled variance shown here <univariate_eqn_pooled_variance>`. Compare this to the case just described above where there are only :math:`n` degrees of freedom.
+The :index:`loss of degrees of freedom <single: degrees of freedom; loss of>` can be seen when we use exactly the same data and treat the problem as one where we have :math:`n_A` and :math:`n_B` samples in groups A and B and want to test for a difference between :math:`\mu_A` and :math:`\mu_B`. You are encouraged to try this out. There are more degrees of freedom, :math:`n_A + n_B - 2` in fact when we use the :math:`t`-distribution with the :ref:`pooled variance shown here <univariate_eqn_pooled_variance>`. Compare this to the paired-test case just described above, where there are only :math:`n-1` degrees of freedom.
 
 .. This example illustrates:
 .. todo:: example showing loss of DOF (boys shoes example in BHH2). particularly, show the plots (p98 on BHH2- edition 1)

--- a/univariate-review/poisson-distribution.rst
+++ b/univariate-review/poisson-distribution.rst
@@ -33,7 +33,7 @@ Formally, the Poisson distribution can be written as :math:`\displaystyle \frac{
 
 		0, 0.25% chance
 		1, 1.5%
-		3, 8.9
+		3, 8.9%
 		6, 16%
 		10, 4.1%
 		15, 0.1%

--- a/univariate-review/some-terminology.rst
+++ b/univariate-review/some-terminology.rst
@@ -29,7 +29,7 @@ We review a couple of concepts that you should have seen in a prior statistical 
 
 **Distribution**
 
-	Distributions are used to summarize, in a compact way, a much larger collection of a much larger collection of data points. Histograms, just discussed above, are one way of visualizing a distribution. We can also express distributions by a few numerical parameters. See below.
+	Distributions are used to summarize, in a compact way, a much larger collection of data points. Histograms, just discussed above, are one way of visualizing a distribution. We can also express distributions by a few numerical parameters. See below.
 
 **Probability**
 
@@ -186,7 +186,7 @@ We review a couple of concepts that you should have seen in a prior statistical 
 		print('These two should agree mostly')
 
 		# Run it several times to verify that the
-		# two are similar, when they are not
+		# two are similar, when there are no
 		# outliers
 
 		# Now add a huge outlier:

--- a/univariate-review/t-distribution.rst
+++ b/univariate-review/t-distribution.rst
@@ -46,7 +46,7 @@ Compare this to the previous case where our :math:`n` samples are independent, a
 
 	\frac{\overline{x} - \mu}{\sigma/\sqrt{n}} \sim \mathcal{N} \left(0, 1\right)
 
-So the more practical and useful case where :math:`z  = \frac{\overline{x} - \mu}{s/\sqrt{n}} \sim t_{n-1}` can now be used to construct an interval for :math:`\mu`. We say that :math:`z` follows the :math:`t`-distribution with :math:`n-1` degrees of freedom, where the degrees of freedom refer to those from the calculating the *estimated* standard deviation, :math:`s`.
+So the more practical and useful case where :math:`z  = \frac{\overline{x} - \mu}{s/\sqrt{n}} \sim t_{n-1}` can now be used to construct an interval for :math:`\mu`. We say that :math:`z` follows the :math:`t`-distribution with :math:`n-1` degrees of freedom, where the degrees of freedom refer to those from calculating the *estimated* standard deviation, :math:`s`.
 
 Note that the new variable :math:`z` only requires we know the population mean (:math:`\mu`), not the population standard deviation; rather we use our estimate of the standard deviation :math:`s/\sqrt{n}` in place of the population standard deviation.
 

--- a/univariate-review/testing-for-differences-and-similarity.rst
+++ b/univariate-review/testing-for-differences-and-similarity.rst
@@ -522,7 +522,7 @@ Summary and comparison of methods
 
 Let's compare the 3 estimates. Recall our aim is to convince ourself/someone that system B will have better long-term performance than the current system A.
 
-If we play devil's advocate, our :index:`null hypothesis` is that system B has no effect. Then it is up to us to prove, convincingly, that the change from A to B has a systematic, permanent effect. That is what the calculated probabilities represent :, the probability of us being wrong.
+If we play devil's advocate, our :index:`null hypothesis` is that system B has no effect. Then it is up to us to prove, convincingly, that the change from A to B has a systematic, permanent effect. That is what the calculated probabilities represent, the probability of us being wrong.
 
 	#.	Using only reference data: 11% (about 1 in 10)
 


### PR DESCRIPTION
## What this does

A technical and editorial review of Chapter 2 (Univariate Data Analysis) turned up a number of errors. This PR repairs the ones that are clearly wrong; the larger pedagogical observations are summarised in the session chat for the author to decide on.

### Technical corrections

- **Variance confidence interval** (`other-types-of-confidence-intervals.rst`): the two chi-squared critical values in the interval were transposed. Under the cumulative-area subscript convention used elsewhere in the chapter (and consistent with the F-ratio interval just below it), the *smaller* critical value, `chi^2_{n-1, alpha/2}`, must sit in the denominator of the *upper* bound. The bounds are now `(n-1)S^2 / chi^2_{n-1, 1-alpha/2}` to `(n-1)S^2 / chi^2_{n-1, alpha/2}`. Also: the parameter is the variance `sigma^2` (not `sigma`), and the bullet that described `alpha/2` as a "degrees of freedom" argument now correctly calls it a tail area.
- **Paired tests** (`paired-tests.rst`): the paired t-test uses **n-1** degrees of freedom, not `n` (the text earlier states n-1, so this was internally inconsistent). The mean of the differences `w = x_B - x_A` is `mu_{B-A} = mu_B - mu_A`, not `mu_{A-B}`.
- **Confidence-interval table** (`confidence-intervals.rst`): the 99% upper bound rounds to **24.3** (was 24.2); the other rows already round consistently.
- **Normal distribution** (`normal-distribution-...rst`): the area beyond one standard deviation in one tail is about **16%** ((1 - 0.683)/2 = 15.9%), not 15%; and "independent of each other" (was "each together").

### Editorial / typo fixes

- Duplicated phrase "a much larger collection of a much larger collection" (`some-terminology.rst`).
- "accetable" -> "acceptable" (`binary-distribution-bernoulli-distribution.rst`).
- Missing percent sign in the Poisson table (`poisson-distribution.rst`).
- Stray " :," punctuation (`testing-for-differences-and-similarity.rst`).
- "from the calculating" -> "from calculating" (`t-distribution.rst`).
- Grammar in an R code comment (`some-terminology.rst`).

### What was not changed

The underlying worked examples, datasets, and headline numbers are unchanged; these are corrections to text, one table value, and one formula ordering. Some broader structural and pedagogical points (e.g. the reuse of the symbol `z` for a t-distributed quantity, and the CLT-vs-normality framing in the t-distribution example) are deliberate authorial choices and are left for the author to weigh; they are written up in chat.

### Verification

`make text` succeeds. The only warnings are the pre-existing "image file not readable" / missing-include warnings caused by the unpopulated `figures/` symlink in the build sandbox; none originate from the edited files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V355srmetZkajcjbk9mdcP

---
_Generated by [Claude Code](https://claude.ai/code/session_01V355srmetZkajcjbk9mdcP)_