### PR TITLE
Process monitoring (Ch. 3): fix EWMA code/example mismatch and related errors

### DIFF
--- a/process-monitoring/ewma-charts.rst
+++ b/process-monitoring/ewma-charts.rst
@@ -21,13 +21,13 @@ The MA chart plots values of :math:`\overline{x}_t`, calculated from groups of s
 
 .. math::
 
-	\overline{x}_t = \frac{1}{n}x_{t-1} + \frac{1}{n}x_{t-2} + \ldots + \frac{1}{n}x_{t-n}
+	\overline{x}_t = \frac{1}{n}x_{t} + \frac{1}{n}x_{t-1} + \ldots + \frac{1}{n}x_{t-n+1}
 
 The EWMA chart is similar to the MA chart, but uses different weights; heavier weights for more recent observations, tailing off exponentially to very small weights further back in history. Let's take a look at a derivation.
 
 Define the process target as :math:`T` and define :math:`x_t` as a new data measurement arriving now. We then try to *create an estimate of that incoming value, giving some weight*, :math:`\lambda`, *to the actual measured value, and the rest of the weight*, :math:`1-\lambda`, *to the prior estimate*.
 
-Let us write the estimate of :math:`x_t` as :math:`\hat{x}_t`, with the :math:`\wedge` mark above the :math:`x_t` to indicate that it is a prediction of the actual measured :math:`x_t` value. The prior estimate is therefore written as :math:`\hat{x}_{t-1}`.
+Let us write this estimate as :math:`\hat{x}_t`, with the :math:`\wedge` mark above the :math:`x_t` to indicate that it is the EWMA estimate of the level at time :math:`t`: a smoothed value that blends the latest measurement with the running history. The prior estimate is therefore written as :math:`\hat{x}_{t-1}`. As shown below, this same smoothed value also serves as the one-step-ahead forecast of the next measurement.
 
 So putting into equation form that "an estimate of that incoming value, is given by some weight, :math:`\lambda` and the rest of the weight, :math:`1-\lambda`, to the prior estimate":
 
@@ -47,7 +47,7 @@ The last line in the equation group above shows that a 1-step-ahead prediction f
 
 The next plot shows visually what happens as the weight of :math:`\lambda` is changed. In this example a shift of :math:`\Delta = 1\sigma = 3` units occurs abruptly at :math:`t=150`. This is of course not known in practice, but the purpose here is to illustrate the effects of choosing :math:`\lambda`. Prior to that change the process mean is :math:`\mu=20` and the raw data has :math:`\sigma = 3`.
 
-The first chart is the raw data and also a Shewhart chart with subgroup size of 1; the control limits are at :math:`\pm 3` time the standard deviation, so at 11.0 and 19.0 units. This control chart barely picks up the shift, as was explained in a :ref:`prior section <monitoring_shewart_chart_slugishness>`.
+The first chart is the raw data and also a Shewhart chart with subgroup size of 1; the control limits are at :math:`\pm 3` times the standard deviation, so at 11.0 and 29.0 units. This control chart barely picks up the shift, as was explained in a :ref:`prior section <monitoring_shewart_chart_slugishness>`.
 
 The second, third and fourth charts are EWMA charts with different values of :math:`\lambda`; the line is the value on the left-hand side of equation :eq:`ewma-derivation-2`, in other words it is :math:`\hat{x}_{t+1}`, the EWMA value at time :math:`t`. We see that as :math:`\lambda` decreases, the charts are smoother, since the averaging effect is greater: more and more weight is given to the history, :math:`\hat{x}_{t}`, and less weight to the current data point, :math:`x_t`.  See equation :eq:`ewma-derivation-2` to understand that interpretation. Also note carefully how the control limits become narrower as the :math:`\lambda` decreases, as is explained shortly below.
 
@@ -102,13 +102,14 @@ The code here shows one way of calculating the EWMA values for a vector of data.
 	    if target is None:
 	        target = x[0]
 	    y = np.zeros(len(x))
-	    y[0] = target
-	    for k in range(1, len(x)):
-	        error = x[k - 1] - y[k - 1]
-	        y[k] = y[k - 1] + lam * error
+	    previous = target
+	    for k in range(len(x)):
+	        y[k] = lam * x[k] + (1 - lam) * previous
+	        previous = y[k]
 	    return y
 
-	# Try using this function now:
+	# Try using this function now. It reproduces the
+	# worked-example table below:
 	x = np.array([200, 210, 190, 190, 190, 190])
 	ewma(x, lam=0.3, target=200)
 
@@ -117,15 +118,16 @@ The code here shows one way of calculating the EWMA values for a vector of data.
 	ewma <- function(x, lambda, target=x[1]){
 	    N <- length(x)
 	    y <- numeric(N)
-	    y[1] = target
-	    for (k in 2:N){
-	        error = x[k - 1] - y[k - 1]
-	        y[k] = y[k - 1] + lambda*error
+	    previous <- target
+	    for (k in 1:N){
+	        y[k] = lambda*x[k] + (1 - lambda)*previous
+	        previous = y[k]
 	    }
 	return(y)
 	}
 
-	# Try using this function now:
+	# Try using this function now. It reproduces the
+	# worked-example table below:
 	x <- c(200, 210, 190, 190, 190, 190)
 	ewma(x, lambda = 0.3, target = 200)
 
@@ -133,7 +135,7 @@ The code here shows one way of calculating the EWMA values for a vector of data.
 .. EWMA can detect both changes in level and changes in variance
 .. TODO: After introducing concept, show why Shewhart fails with heavy autocorr. Have to increase Shewhart N, or widen the limits.
 
-Here is a worked example, starting with the assumption the process is at the target value of :math:`T = 200` units, and :math:`\lambda=0.3`. We intentionally show what happens if the new value stays fixed at 190: you see the value plotted gets only a weight of 0.3, while the 0.7 weight is for the prior historical value. Slowly the value plotted catches up, but there is always a lag. The value plotted on the chart is from the last equation in the set of :eq:`ewma-derivation-2`.
+Here is a worked example, starting with the assumption the process is at the target value of :math:`T = 200` units, and :math:`\lambda=0.3`. We intentionally show what happens if the new value stays fixed at 190: you see the value plotted gets only a weight of 0.3, while the 0.7 weight is for the prior historical value. Slowly the value plotted catches up, but there is always a lag. The value plotted on the chart is from the first equation in the set of :eq:`ewma-derivation-2`, namely :math:`\hat{x}_t = \lambda x_t + (1-\lambda)\hat{x}_{t-1}`.
 
 ============= ==================== ==================================================
 Sample number Raw data :math:`x_t` Value plotted on chart: :math:`\hat{x}_t`

--- a/process-monitoring/process-monitoring.rst
+++ b/process-monitoring/process-monitoring.rst
@@ -25,7 +25,7 @@
 Process monitoring in context
 ==============================
 
-In the first section we learned about :ref:`visualizing data <SECTION-data-visualization>`, then we moved on to reviewing :ref:`univariate statistics <SECTION-univariate-review>`. This section now combines both topics, showing how to create a system that monitors a single, univariate, value from any process. These monitoring systems are easily implemented online, and generate great value for companies that use them in day-to-day production. This is one of their greatest advantages: almost no training is required to interpret the visualization and secondly the human eye can quickly pick up any patters or trends in the plots; both expected and unexpected patterns.
+In the first section we learned about :ref:`visualizing data <SECTION-data-visualization>`, then we moved on to reviewing :ref:`univariate statistics <SECTION-univariate-review>`. This section now combines both topics, showing how to create a system that monitors a single, univariate, value from any process. These monitoring systems are easily implemented online, and generate great value for companies that use them in day-to-day production. This is one of their greatest advantages: almost no training is required to interpret the visualization and secondly the human eye can quickly pick up any patterns or trends in the plots; both expected and unexpected patterns.
 
 Monitoring charts are a graphical tool, enabling anyone to rapidly detect a problem by visual analysis. The next logical step after detection of a problem is to diagnose it, but we will cover diagnosis in the section on :ref:`latent variable models <SECTION_latent_variable_modelling>`.
 

--- a/process-monitoring/shewhart-charts.rst
+++ b/process-monitoring/shewhart-charts.rst
@@ -44,6 +44,8 @@ Assuming we know :math:`\sigma_{\overline{X}}`, which we usually do not in pract
 
 The reason for :math:`c_n = \pm 3` is that the total area between that lower and upper bound spans 99.73% of the area (in R: ``pnorm(+3) - pnorm(-3)`` gives 0.9973). So it is highly unlikely, a chance of 1 in 370, that a data point, :math:`\overline{x}`, calculated from a subgroup of :math:`n` raw :math:`x`-values, will lie outside these bounds.
 
+The algebra above is written as an interval that brackets :math:`\mu`, but in operation the centre line is held fixed (at the target, or at |xdb| once it is estimated) and these same limits are used to bracket each newly plotted :math:`\overline{x}`. The two views give the identical LCL and UCL because the interval is symmetric about the centre.
+
 The following illustration should help connect the concepts: the raw data's distribution happens to have a mean of 6 and standard deviation of 2, while it is clear the distribution of the subgroups of 5 samples (thicker line) is much narrower.
 
 .. image:: ../figures/monitoring/explain-shewhart.png
@@ -56,7 +58,7 @@ The following illustration should help connect the concepts: the raw data's dist
 Using estimated parameters instead
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The derivation in equation :eq:`shewhart-theoretical` requires knowing the population variance, :math:`\sigma`, and assuming that our target for :math:`x` is :math:`\mu`. The latter assumption is reasonable, but we will estimate a value for :math:`\sigma` instead, using the data.
+The derivation in equation :eq:`shewhart-theoretical` requires knowing the population standard deviation, :math:`\sigma`, and assuming that our target for :math:`x` is :math:`\mu`. The latter assumption is reasonable, but we will estimate a value for :math:`\sigma` instead, using the data.
 
 .. index:: ! phase 1 (monitoring charts)
 
@@ -253,7 +255,7 @@ You make a **type I error** when your sample is typical of normal operation, yet
 
 *Synonyms* for a **type I error**: false alarm, false positive (used mainly for testing of diseases), producer's risk (used for acceptance sampling, because here as the producer you will be rejecting an acceptable sample), false rejection rate, or alpha.
 
-You make a **type II error** when your sample really is abnormal, but falls within the the UCL and LCL limits and is therefore not detected. This error rate is denoted by :math:`\beta`, and it is a function of the degree of abnormality, which we derive next.
+You make a **type II error** when your sample really is abnormal, but falls within the UCL and LCL limits and is therefore not detected. This error rate is denoted by :math:`\beta`, and it is a function of the degree of abnormality, which we derive next.
 
 *Synonyms* for a **type II error**: false negative (used mainly for testing of diseases), consumer's risk (used for acceptance sampling, because your consumer will be receiving available product which is defective), false acceptance rate, or beta.
 
@@ -365,6 +367,6 @@ Mistakes to avoid
 
 #.	Imagine you are monitoring an aspect of the final product's quality, e.g. viscosity, and you have a product specification that requires that viscosity to be within, say 40 to 60 cP. It is a mistake to place those **specification limits** on the monitoring chart as a guide when to take action. It is also a mistake to use the required specification limits instead of the LCL and UCL. The monitoring chart is to detect abnormal variation in the process and gives a signal on when to take action, not to inspect for quality specifications. You can certainly have another chart for that, but the process monitoring chart's limits are intended to monitor process stability, and these Shewhart stability limits are calculated differently. Ideally the specification limits lie beyond the LCL and UCL action limits.
 
-#.	Shewhart chart limits were calculated with the assumption of **independent subgroups** (e.g. subgroup :math:`i` has no effect on subgroup :math:`i+1`). For a process with mild autocorrelation, the act of creating subgroups, with :math:`n` samples in each group, removes most, if not all, of the relationship between subgroups. However processes with heavy autocorrelation (slow moving processes sampled at a high rate, for example), will have LCL and UCL calculated from equation :eq:`shewhart-limits` that will raise false alarms too frequently. In these cases you can widen the limits, or remove the autocorrelation from the signal. More on this in the later section on :ref:`exponentially weighted moving average (EWMA) charts <monitoring_EWMA>`.
+#.	Shewhart chart limits were calculated with the assumption of **independent subgroups** (e.g. subgroup :math:`i` has no effect on subgroup :math:`i+1`). For a process with mild autocorrelation, averaging :math:`n` samples into each subgroup reduces, though does not remove, the relationship between successive subgroup means. However processes with heavy autocorrelation (slow moving processes sampled at a high rate, for example), will have LCL and UCL calculated from equation :eq:`shewhart-limits` that will raise false alarms too frequently. In these cases you can widen the limits, or remove the autocorrelation from the signal. More on this in the later section on :ref:`exponentially weighted moving average (EWMA) charts <monitoring_EWMA>`.
 
 #.	Using Shewhart charts on two or more **highly correlated quality variables**, usually on your final product measurement, can increase your type II (consumer's risk) dramatically. We will come back to this very important topic in the section on :ref:`latent variable models <LVM_monitoring>`, where we will counterintuitively prove that even having individual charts each within their respective limits can result where it is outside the joint limits.

--- a/process-monitoring/what-is-process-monitoring-about.rst
+++ b/process-monitoring/what-is-process-monitoring-about.rst
@@ -65,7 +65,7 @@ What should we monitor?
 
 Any variable can be monitored. However, the purpose of process monitoring is so that you can **react early** to bad, or unusual operation. This implies we should monitor variables as soon as they become available, preferably in real-time. They are more suitable than variables that take a long time to acquire (e.g. laboratory measurements). We should not have to wait to the end of the production line to find our process was out of statistical control.
 
-Data/measurements available at the start of your process, suc as raw material data from your supplier should also be monitored as soon as it is available, e.g. when received by your company, or even earlier - before the supplier ships it to you.
+Data/measurements available at the start of your process, such as raw material data from your supplier should also be monitored as soon as it is available, e.g. when received by your company, or even earlier - before the supplier ships it to you.
 
 Intermediate variables measured from sensors at all points along the production process are (a) available much more frequently and without delay, (b) are more precise, (c) are usually more meaningful to the operating staff than final quality variables from the lab, and (d) contain the "fingerprint" of the fault, helping the engineers with diagnosis of what the problem is and point to which part(s) of the process need adjustment (see `MacGregor (1997) <https://literature.learnche.org/item/75/using-on-line-process-data-to-improve-quality-challenges-for-statisticians>`_).
 


### PR DESCRIPTION
A critique-and-repair pass over the Process Monitoring chapter (one of the most-visited parts of the site), from two angles: teaching clarity for a first-time reader, and technical scrutiny of the kind an SPC researcher or vendor statistician would apply. This PR repairs the clear errors; the full critique (including teaching/technical items left for you to decide) is below.

## Errors repaired

1. **EWMA worked example did not match its own code.** The table plots the standard EWMA statistic (filter form, `x̂_t = λ·x_t + (1-λ)·x̂_{t-1}`, using the current measurement), but the Python/R code computed the one-step-ahead forecast (`error = x[k-1] - y[k-1]`, using the previous measurement). Running the supplied code therefore returned the table shifted by one sample and **silently dropped the final data point**. Rewrote both code blocks to the filter form so they now reproduce the table exactly (`[200, 203, 199.1, 196.37, 194.46, 193.12]`) and match the section's `√(λ/(2-λ))` limit formula and standard SPC software.

2. **Wrong numeric limit in the EWMA example:** the upper individuals limit for μ=20, σ=3 is 20+3×3 = **29.0**, not 19.0 (the figure source `explain-EWMA.R` confirms 29). Also "±3 time" → "±3 times".

3. **Self-contradictory "prediction of x_t" wording:** `x̂_t` contains `x_t`, so it cannot be a prediction *of* `x_t`. Reworded as the smoothed level estimate that also serves as the one-step-ahead forecast; pinned the worked example to the equation it actually uses.

4. **Moving-average formula** now includes the current sample, matching its "n most recent" description.

5. **Shewhart:** "population variance, σ" → "standard deviation, σ"; added one sentence clarifying the limits bracket the plotted `x̄` (not the mean); softened the overstated claim that subgrouping removes autocorrelation.

6. **Typos:** "suc as", "patters", doubled "the".

## What did NOT change
No figures were touched: the only figure-relevant fix was a prose number, and the committed PNG already shows the correct 11/29 limits, so no parallel `kgdunn/figures` PR is needed. The underlying analysis is unchanged.

## Verification
- `make text` succeeds with **zero warnings**.
- `make html` succeeds; `grep -r goatcounter _build/html/contents` returns **0** hits.
- Re-verified all quoted numbers: Shewhart rubber-bale (x̿=238.8, a₅=0.9400, LCL 225.6 / UCL 252.0; after exclusion ≈224/252), the c₄ table for n=2…15, the β table, PCR/Cpk arithmetic (13.4% out-of-spec at PCR 0.5; 1.5σ shift → Cpk 1.5, 3.4 dpm), and that the corrected EWMA code reproduces the worked table.

## Larger items flagged for follow-up (not in this PR)
- The chapter has **no inline reproducible figure code blocks**, against the chapter-rework playbook. This is the biggest remaining gap and warrants a dedicated PR.
- Phase 1 vs phase 2 is named but never walked through concretely (your open TODO in `shewhart-charts.rst`).
- CUSUM is shown only as a V-mask; the tabular (k, h) form used by modern software is not introduced.
- Single-sample β is framed as "the chart is slow" without linking to ARL (compounding over samples), which can mislead.
- "No assumption is made regarding the distribution of x" oversells distribution-freeness given the normality the α/β/ARL results rely on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1hx9U3TydSonCDWXL2Q2D

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1hx9U3TydSonCDWXL2Q2D)_