### PR TITLE
Make each chapter code block self-contained in its imports

### DIFF
--- a/design-analysis-experiments/judging-and-comparing-designs.rst
+++ b/design-analysis-experiments/judging-and-comparing-designs.rst
@@ -82,18 +82,15 @@ climbs steeply (already :math:`5.2\,\sigma^2` at :math:`x = 1.5`): a quantitativ
 against extrapolation.
 
 This and every figure in this subchapter is reproducible with `process_improve
-<https://github.com/kgdunn/process-improve>`_ (``pip install 'process-improve[expt]>=1.42'``);
-the code blocks build on one another, so paste them in order. The prediction variance of the
+<https://github.com/kgdunn/process-improve>`_ (``pip install 'process-improve[expt]>=1.42'``).
+Each block imports what it needs; the final figure also reuses the FDS helper and the designs
+built in the two blocks before it, so paste them in order. The prediction variance of the
 three-run quadratic design is a closed form:
 
 .. code-block:: python
 
-	import itertools
 	import numpy as np
-	import pandas as pd
 	import plotly.graph_objects as go
-	from plotly.subplots import make_subplots
-	from process_improve.experiments import Factor, generate_design, evaluate_design
 
 	# Single-factor quadratic design {-1, 0, +1}: the prediction variance is a closed form.
 	x = np.linspace(-1.6, 1.6, 321)
@@ -376,6 +373,11 @@ model expansion, the prediction variance and the FDS curve, are reused for the o
 comparison further down.
 
 .. code-block:: python
+
+	import itertools
+	import numpy as np
+	import plotly.graph_objects as go
+	from process_improve.experiments import Factor, generate_design
 
 	def model_matrix(design):
 	    """Main-effects-plus-pure-quadratics expansion [1 | x_i | x_i^2]."""
@@ -774,6 +776,11 @@ the library scores exactly this model and not the full second-order one:
 
 .. code-block:: python
 
+	import numpy as np
+	import pandas as pd
+	import plotly.graph_objects as go
+	from process_improve.experiments import Factor, evaluate_design, generate_design
+
 	def conference_matrix_order6():
 	    """Order-6 conference matrix (C C' = 5 I) from the quadratic residues of GF(5):
 	    the backbone of definitive screening and OMARS designs."""
@@ -977,6 +984,12 @@ on the two scales:
 
 .. code-block:: python
 
+	import itertools
+	import numpy as np
+	import plotly.graph_objects as go
+	from plotly.subplots import make_subplots
+
+	# Reuses fds_curve (from the DSD-vs-OMARS block) and the designs dict (previous block).
 	region5 = np.vstack([np.random.default_rng(1).uniform(-1, 1, size=(120_000, 5)),
 	                     np.array(list(itertools.product([-1, 1], repeat=5)), float)])
 	fracs = np.linspace(0, 1, 200)

--- a/design-analysis-experiments/judging-and-comparing-designs.rst
+++ b/design-analysis-experiments/judging-and-comparing-designs.rst
@@ -392,12 +392,12 @@ comparison further down.
 	    P = model_matrix(points)
 	    return np.einsum("ij,jk,ik->i", P, xtx_inv, P)
 
-	def fds_curve(design, points, fracs, scaled=False):
+	def fds_curve(design, points, fractions, scaled=False):
 	    """Sorted prediction variance as a fraction-of-design-space curve."""
 	    pv = np.sort(prediction_variance(design, points))
 	    if scaled:
 	        pv = pv * len(np.asarray(design))
-	    return np.quantile(pv, fracs)
+	    return np.quantile(pv, fractions)
 
 	# 4-factor DSD (9 runs) from process_improve; the 13-run OMARS is given explicitly.
 	dsd4 = np.asarray(generate_design([Factor(name=c, low=-1, high=1) for c in "ABCD"],
@@ -411,12 +411,14 @@ comparison further down.
 	rng = np.random.default_rng(1)
 	region4 = np.vstack([rng.uniform(-1, 1, size=(80_000, 4)),
 	                     np.array(list(itertools.product([-1, 1], repeat=4)), float)])
-	fracs = np.linspace(0, 1, 200)
+	fraction_grid = np.linspace(0, 1, 200)
 
 	fig = go.Figure()
-	fig.add_trace(go.Scatter(x=fracs, y=fds_curve(dsd4, region4, fracs, scaled=True),
+	fig.add_trace(go.Scatter(x=fraction_grid,
+	                         y=fds_curve(dsd4, region4, fraction_grid, scaled=True),
 	                         name="DSD (9 runs)"))
-	fig.add_trace(go.Scatter(x=fracs, y=fds_curve(omars4, region4, fracs, scaled=True),
+	fig.add_trace(go.Scatter(x=fraction_grid,
+	                         y=fds_curve(omars4, region4, fraction_grid, scaled=True),
 	                         name="OMARS (13 runs)"))
 	fig.update_layout(xaxis_title="Fraction of design space",
 	                  yaxis_title="Scaled prediction variance, SPV")
@@ -992,14 +994,14 @@ on the two scales:
 	# Reuses fds_curve (from the DSD-vs-OMARS block) and the designs dict (previous block).
 	region5 = np.vstack([np.random.default_rng(1).uniform(-1, 1, size=(120_000, 5)),
 	                     np.array(list(itertools.product([-1, 1], repeat=5)), float)])
-	fracs = np.linspace(0, 1, 200)
+	fds_fraction = np.linspace(0, 1, 200)
 
 	fig = make_subplots(rows=1, cols=2,
 	                    subplot_titles=("Scaled (per run)", "Unscaled (sigma^2 units)"))
 	for label, d in designs.items():
-	    fig.add_trace(go.Scatter(x=fracs, y=fds_curve(d, region5, fracs, scaled=True),
+	    fig.add_trace(go.Scatter(x=fds_fraction, y=fds_curve(d, region5, fds_fraction, scaled=True),
 	                             name=label), row=1, col=1)
-	    fig.add_trace(go.Scatter(x=fracs, y=fds_curve(d, region5, fracs, scaled=False),
+	    fig.add_trace(go.Scatter(x=fds_fraction, y=fds_curve(d, region5, fds_fraction, scaled=False),
 	                             name=label, showlegend=False), row=1, col=2)
 	fig.update_yaxes(title_text="Scaled prediction variance", row=1, col=1)
 	fig.update_yaxes(title_text="Prediction variance / sigma^2", row=1, col=2)


### PR DESCRIPTION
Makes each of the four reproducible code blocks in "Judging and comparing experimental designs" self-contained in its imports, so a reader running any single block does not have to scroll back for the import line.

## What changed

Each block now imports exactly what it uses, even where that repeats an earlier block:

| Block (before its figure) | Imports it now carries |
|---|---|
| Prediction-variance extrapolation | `numpy`, `plotly.graph_objects` |
| FDS, DSD vs OMARS | `itertools`, `numpy`, `plotly.graph_objects`, `Factor`, `generate_design` |
| Power comparison | `numpy`, `pandas`, `plotly.graph_objects`, `Factor`, `evaluate_design`, `generate_design` |
| FDS, four designs (scaled vs unscaled) | `itertools`, `numpy`, `plotly.graph_objects`, `make_subplots` |

The lead-in now says each block imports what it needs, and flags the one remaining cross-block dependency.

## Variable carry-over (the question behind this)

After this change, the only variables that carry across blocks are into the **final** block, which reuses:
- `fds_curve` (defined in the DSD-vs-OMARS block), and
- the `designs` dict (built in the power block).

Blocks 1 to 3 are otherwise self-contained. I added a one-line comment in the final block naming those two reuses. I did **not** duplicate the helper and the full design construction into the final block, because that ~25-line copy would have to be kept in sync with the originals; happy to do that if you'd rather every block be runnable in complete isolation.

## Verification

- The four blocks were extracted directly from the RST and executed end to end: they still reproduce (designs 46/32/25/13, power 0.97/0.98/0.99/0.42). No logic or numbers changed.
- `make text`: chapter warning-free.
- `make html`: succeeds; `grep -r goatcounter _build/html/contents` returns zero hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxeyNbB9psERdPZz5FSPhP

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxeyNbB9psERdPZz5FSPhP)_