### PR TITLE
Clarify the variance-of-slope derivation in linear regression

### DIFF
--- a/least-squares-modelling/least-squares-model-analysis.rst
+++ b/least-squares-modelling/least-squares-model-analysis.rst
@@ -302,6 +302,8 @@ quantity that is identically zero, so it has no effect on :math:`b_1`.
 
 That last form of expressing :math:`b_1` shows that every data point contributes a small amount to the coefficient :math:`b_1`. But notice how it is broken into 2 pieces: each term in the sum has a component due to :math:`m_i` and one due to :math:`y_i`. The :math:`m_i` term is a function of the x-data only, and since we assume the x's are measured without error, that term has no error. The :math:`y_i` component is the only part that has error.
 
+Up to this point :math:`b_1` is a single number, computed from the data in hand. To describe how precise that number is, we change how we read the :math:`y_i`. We now treat each :math:`y_i` as one realisation of a random variable, drawn from :math:`y_i \sim \mathcal{N}(\beta_0 + \beta_1 x_i, \sigma_\epsilon^2)` (assumptions 1 to 3). Imagine repeating the experiment: hold every :math:`x_i` at exactly the same setting, take a fresh measurement of each :math:`y_i`, and recompute :math:`b_1`. Each repeat gives a slightly different :math:`b_1`. The expectation :math:`\mathcal{E}\{b_1\}` and variance :math:`\mathcal{V}\{b_1\}` below describe the distribution of :math:`b_1` over those hypothetical repeats. Because the :math:`x_i` are held fixed, the weights :math:`m_i` are constants that carry no error, and the only randomness enters through the :math:`y_i`.
+
 So we can write:
 
 .. math::
@@ -313,6 +315,10 @@ So we can write:
         \mathcal{V}\{b_1\} &= \dfrac{\mathcal{V}\{y_i\}}{\sum_j{\left( x_j - \overline{\mathrm{x}} \right)^2}}
 
 where :math:`j` is an index for all data points used to build the least squares model.
+
+Two rules take us from the expectation line to the variance line. First, a constant multiplying a random variable comes out of the variance as its square, :math:`\mathcal{V}\{m_i y_i\} = m_i^2 \mathcal{V}\{y_i\}`, in the same way that :math:`\mathcal{E}\{m_i y_i\} = m_i \mathcal{E}\{y_i\}` for the expectation. Second, the variance of a sum equals the sum of the individual variances only when the terms are independent. That is assumption 6, that the :math:`y_i` are independent of one another; the cross-covariance terms are then zero, so no products between different :math:`y_i` appear. If the :math:`y_i` were correlated, for example data collected in time order, those cross terms would not vanish and this step would not hold.
+
+The last two lines use assumption 2, the constant error variance: every :math:`\mathcal{V}\{y_i\}` has the same value, so it factors out of the sum to leave :math:`\mathcal{V}\{b_1\} = \mathcal{V}\{y_i\} \sum_i m_i^2`. The remaining sum collapses because :math:`\sum_i m_i^2 = \dfrac{\sum_i (x_i - \overline{\mathrm{x}})^2}{\left(\sum_j (x_j - \overline{\mathrm{x}})^2\right)^2} = \dfrac{1}{\sum_j (x_j - \overline{\mathrm{x}})^2}`.
 
 **Questions**:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "pid-book"
-version = "0.2.5"
+version = "0.2.6"
 description = 'Process Improvement using Data. Repository for the book.'
 readme = "README.md"
 license = "CC-BY-SA-4.0"


### PR DESCRIPTION
## What changed

A reader got stuck at two points in the derivation of :math:`\mathcal{V}\{b_1\}` in `least-squares-modelling/least-squares-model-analysis.rst` (the "Confidence intervals for β₀ and β₁" section). This PR adds two short prose paragraphs to make the silent steps explicit, without changing any mathematics.

1. **The viewpoint switch (line 1 → line 2).** The symbol `y_i` quietly changes role: in `b_1 = m_1 y_1 + … + m_N y_N` the `y_i` are the observed numbers, but applying `ℰ{·}` and `𝒱{·}` re-reads each `y_i` as a random variable. A new paragraph names this: each `y_i` is one realisation drawn from `y_i ~ 𝒩(β₀+β₁x_i, σ²)`, and we imagine repeating the experiment at the same fixed `x_i` and recomputing `b_1`. The `m_i` are constants and carry no error.

2. **The algebra (line 2 → line 3 → line 5).** A new paragraph names the three rules and ties each to the assumptions already listed on the page:
   - a constant comes out of variance squared: `𝒱{m_i y_i} = m_i² 𝒱{y_i}`;
   - variance of a sum = sum of variances only under independence (assumption 6), so the cross-covariance terms vanish;
   - the constant error variance (assumption 2) factors out, and the remaining `∑ m_i² = 1 / ∑(x_j − x̄)²` collapse is shown explicitly (previously an invisible jump).

## What didn't change

No equations, numbers, or results were touched: this is purely explanatory prose. `CITATION.cff` was already at today's date (`2026.06.20` / `2026-06-20`), so no metadata bump was needed.

## Verification

- `make text` succeeds. The edited file (`least-squares-model-analysis.rst`) produces zero warnings. The 336 warnings in the run are all pre-existing "image file not readable" / "include file not found" warnings from the `figures/` symlink, which is not populated in this build environment, and are unrelated to this change.
- Rendered the edited section from `_build/text/...` and confirmed the new paragraphs read correctly in sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjbKvDmVEe5bJ2Gm4vBn8b

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjbKvDmVEe5bJ2Gm4vBn8b)_