### PR TITLE
Harden the sparklines pipeline against silent log-path drift

### DIFF
--- a/docs/telemetry/server-runbook.md
+++ b/docs/telemetry/server-runbook.md
@@ -97,6 +97,7 @@ cp scripts/server/bots.txt.example           /etc/pid-book/bots.txt
 ln -s /opt/pid-book/scripts/server/run-goaccess.sh           /usr/local/bin/run-goaccess.sh
 ln -s /opt/pid-book/scripts/server/build-sparklines.py       /usr/local/bin/build-sparklines.py
 ln -s /opt/pid-book/scripts/server/caddy-json-to-combined.py /usr/local/bin/caddy-json-to-combined.py
+ln -s /opt/pid-book/scripts/server/check-stats-fresh.sh      /usr/local/bin/check-stats-fresh.sh
 chmod +x /opt/pid-book/scripts/server/*.sh
 chmod +x /opt/pid-book/scripts/server/*.py
 ```
@@ -274,8 +275,19 @@ No `<Location>` or `Alias` block needed.
 ```sh
 cat >/etc/cron.d/pid-book-stats <<'EOF'
 # Nightly readership pipeline for learnche.org/pid.
-# Order matters: GoAccess first (longer-running), sparklines second.
-17 4 * * *  root  /usr/local/bin/run-goaccess.sh && /usr/local/bin/build-sparklines.py >> /var/log/pid-book-stats.log 2>&1
+#
+# The two builders are decoupled with ';' (not '&&') on purpose: the
+# GoAccess HTML report and the sparklines JSON are independent outputs,
+# so a GoAccess failure must NOT stop build-sparklines.py from refreshing
+# the dashboard. (An '&&' here once let a GoAccess "no log files matched"
+# error silently freeze sparklines.json for ~10 days.)
+#
+# check-stats-fresh.sh runs last. Its stdout (the OK line) goes to the
+# log; its stderr (MISSING / STALE) is deliberately NOT redirected, so a
+# cron MAILTO mails the alert. Set MAILTO at the top of the file to
+# receive it.
+MAILTO=kgdunn@gmail.com
+17 4 * * *  root  { /usr/local/bin/run-goaccess.sh; /usr/local/bin/build-sparklines.py; } >> /var/log/pid-book-stats.log 2>&1; /usr/local/bin/check-stats-fresh.sh >> /var/log/pid-book-stats.log
 EOF
 chmod 644 /etc/cron.d/pid-book-stats
 ```
@@ -284,11 +296,24 @@ chmod 644 /etc/cron.d/pid-book-stats
 fall during low-traffic hours (Hetzner is in Germany, so this is the
 European pre-dawn).
 
+**Log path is configured once.** Both `build-sparklines.py` and
+`run-goaccess.sh` read the `logs =` line from
+`/etc/pid-book/sparklines.conf`; `run-goaccess.sh` falls back to it when
+`LOG_GLOBS` is unset in the environment. Do **not** hard-code a
+`LOG_GLOBS=` override in the cron line for a permanent path change: edit
+`sparklines.conf` instead, so the two halves cannot drift apart. The
+pre-migration Apache server logs the learnche.org vhost to
+`/var/www/logs/learnche.org/access.log*`; the post-migration Caddy box
+will use `/var/log/caddy/learnche.org.access.log*`. The shipped
+`sparklines.conf.example` lists both, so the same config works across the
+move.
+
 To run once immediately and verify:
 
 ```sh
 /usr/local/bin/run-goaccess.sh
 /usr/local/bin/build-sparklines.py --verbose
+/usr/local/bin/check-stats-fresh.sh        # expect: OK ... is 0h old
 ls -lh /var/www/learnche.org/_stats/
 curl -sf https://learnche.org/_stats/sparklines.json | python3 -m json.tool | head
 ```
@@ -445,6 +470,37 @@ modified producer.
 
 ## Manual operations
 
+### Dashboard frozen on an old date
+
+The `/pid/stats` page and the sidebar sparklines anchor their display
+window to the newest date in `sparklines.json`, so a dead pipeline does
+not show an error: it freezes on the last good day. If the dashboard is
+stuck:
+
+```sh
+ls -l /var/www/learnche.org/_stats/sparklines.json   # mtime stuck days back?
+/usr/local/bin/check-stats-fresh.sh                  # STALE / MISSING => pipeline dead
+tail -50 /var/log/pid-book-stats.log                 # what did the last run say?
+/usr/local/bin/run-goaccess.sh; echo "exit=$?"       # "no log files matched" => path drift
+```
+
+The usual cause is a **log-path drift**: the configured glob points at a
+path with no files (e.g. the Caddy path on a box still running Apache),
+so `run-goaccess.sh` exits non-zero and `build-sparklines.py` never
+refreshes the file. Confirm where the vhost actually logs and fix the
+single source of truth:
+
+```sh
+grep -rn -E 'ServerName|CustomLog' /etc/apache2/sites-enabled/   # Apache
+grep -rn 'output file' /etc/caddy/Caddyfile                      # Caddy
+# Then set the real path once, in /etc/pid-book/sparklines.conf:
+#   logs = /var/www/logs/learnche.org/access.log*
+```
+
+Both builders read that `logs =` line, so there is nothing else to
+change. Re-run the two builders and the dashboard repopulates within the
+hour (modulo the 1-hour browser cache).
+
 ### Smoke-test the JSON
 
 ```sh
@@ -506,6 +562,7 @@ E.g. reprocess a historical range:
 | Sparkline render | reader's browser | every page load with mount |
 | `run-goaccess.sh` | webserver | nightly, 04:17 UTC |
 | `build-sparklines.py` | webserver | nightly, 04:17 UTC, after GoAccess |
+| `check-stats-fresh.sh` | webserver | nightly, after the builders |
 | Log rotation | webserver | per logrotate config |
 
 Three different trust zones (CI, browser, server) collaborate; the

--- a/scripts/server/build-sparklines.py
+++ b/scripts/server/build-sparklines.py
@@ -96,8 +96,14 @@ LOG = logging.getLogger("build-sparklines")
 DEFAULT_CONFIG = "/etc/pid-book/sparklines.conf"
 
 DEFAULT_LOG_GLOBS = [
-    # Caddy's default per-host log path on Debian/Ubuntu installs.
+    # Caddy's default per-host log path on Debian/Ubuntu installs (the
+    # post-migration target server).
     "/var/log/caddy/learnche.org.access.log*",
+    # Current pre-migration server: Apache per-vhost CustomLog path. This
+    # is where learnche.org actually logs today; keep it in the default
+    # list so a config drift toward the Caddy path does not silently
+    # starve the builder of input.
+    "/var/www/logs/learnche.org/access.log*",
     # Archived pre-Hetzner Apache logs (combined format).
     "/var/log/learnche-archive/access.log*",
 ]

--- a/scripts/server/check-stats-fresh.sh
+++ b/scripts/server/check-stats-fresh.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Alert when the public stats artifact has gone stale.
+#
+# The /pid/stats dashboard and the sidebar sparklines render whatever is
+# in sparklines.json; they anchor their display window to the newest date
+# in that file. So when the nightly builder stops writing a fresh file,
+# the dashboard does not error: it silently freezes on the last good day.
+# That failure mode once went unnoticed for ~10 days.
+#
+# This guard makes the freeze loud. Run it from cron straight after the
+# nightly build. On a fresh file it prints one OK line to stdout; on a
+# missing or stale file it prints to *stderr* and exits non-zero, so a
+# cron MAILTO mails it (keep the check's stderr OUT of the >> log
+# redirect in the cron line, or cron sees no output and stays silent).
+#
+# Usage:
+#   check-stats-fresh.sh [TARGET]
+# Environment:
+#   MAX_AGE_HOURS  staleness threshold in hours (default 26 = nightly
+#                  cadence plus a few hours of slack).
+
+set -euo pipefail
+
+TARGET="${1:-/var/www/learnche.org/_stats/sparklines.json}"
+MAX_AGE_HOURS="${MAX_AGE_HOURS:-26}"
+
+if [[ ! -f "${TARGET}" ]]; then
+    echo "check-stats-fresh: MISSING ${TARGET}" >&2
+    exit 1
+fi
+
+now="$(date +%s)"
+mtime="$(stat -c %Y "${TARGET}")"
+age_h=$(( (now - mtime) / 3600 ))
+
+if (( age_h > MAX_AGE_HOURS )); then
+    echo "check-stats-fresh: STALE ${TARGET} is ${age_h}h old (> ${MAX_AGE_HOURS}h); the nightly builder is not writing it." >&2
+    exit 1
+fi
+
+echo "check-stats-fresh: OK ${TARGET} is ${age_h}h old"

--- a/scripts/server/run-goaccess.sh
+++ b/scripts/server/run-goaccess.sh
@@ -35,13 +35,34 @@ set -euo pipefail
 
 LOG_GLOBS_DEFAULT=(
     # Try common Caddy / Apache / Nginx default per-host log locations.
-    # If your server is elsewhere, set LOG_GLOBS in the cron file.
+    # If your server is elsewhere, set LOG_GLOBS in the cron file or the
+    # `logs =` line of sparklines.conf (read below).
     "/var/log/caddy/learnche.org.access.log*"
     "/var/www/logs/learnche.org/access.log*"
     "/var/log/apache2/learnche.org-access.log*"
     "/var/log/nginx/learnche.org.access.log*"
     "/var/log/learnche-archive/access.log*"
 )
+
+# Single source of truth for the log path. Precedence:
+#   1. LOG_GLOBS in the environment (highest; set by cron for one-offs).
+#   2. The `logs =` line in sparklines.conf, so this script and
+#      build-sparklines.py read the *same* paths and cannot drift apart.
+#      (Drift is exactly what silently froze the dashboard once: the
+#      builder config pointed at the live Apache log while this script's
+#      cron override still pointed at the not-yet-existent Caddy path.)
+#   3. The built-in default list above.
+SPARKLINES_CONF="${SPARKLINES_CONF:-/etc/pid-book/sparklines.conf}"
+if [[ -z "${LOG_GLOBS:-}" && -f "${SPARKLINES_CONF}" ]] && command -v python3 >/dev/null 2>&1; then
+    conf_logs="$(python3 - "${SPARKLINES_CONF}" <<'PY'
+import configparser, sys
+cfg = configparser.ConfigParser()
+cfg.read(sys.argv[1])
+print(cfg.get("paths", "logs", fallback="").strip())
+PY
+)"
+    [[ -n "${conf_logs}" ]] && LOG_GLOBS="${conf_logs}"
+fi
 
 LOG_GLOBS=("${LOG_GLOBS:-${LOG_GLOBS_DEFAULT[*]}}")
 GOACCESS_CONF="${GOACCESS_CONF:-/etc/pid-book/goaccessrc}"

--- a/scripts/server/sparklines.conf.example
+++ b/scripts/server/sparklines.conf.example
@@ -14,8 +14,18 @@
 # Whitespace-separated list of glob patterns. Both .log and .log.gz are
 # supported automatically. Both Caddy JSON and Apache combined-format
 # files are parsed (the script auto-detects per line). Order does not
-# matter — the script deduplicates.
-logs = /var/log/caddy/learnche.org.access.log* /var/log/learnche-archive/access.log*
+# matter; the script deduplicates.
+#
+# This is the single source of truth for the log path: run-goaccess.sh
+# reads the same `logs =` value when LOG_GLOBS is not set in the
+# environment, so both halves of the nightly pipeline stay in step.
+#
+# The current pre-migration server is Apache, logging the learnche.org
+# vhost to /var/www/logs/learnche.org/access.log*. The /var/log/caddy/
+# entry is the post-migration target. Listing both means the same config
+# works before and after the move. The archive glob is the immutable
+# pre-Hetzner history.
+logs = /var/www/logs/learnche.org/access.log* /var/log/caddy/learnche.org.access.log* /var/log/learnche-archive/access.log*
 
 # Public path. Must be served as-is by Caddy under the same origin as
 # the book (learnche.org/_stats/) so the sidebar `fetch()` does not need


### PR DESCRIPTION
## Why

The `/pid/stats` dashboard sat frozen for ~10 days (last data point ~Jun 9). Root cause, found by walking the live server:

- The dashboard and sidebar sparklines render `/_stats/sparklines.json` and **anchor their display window to the newest date in that file**. So when the nightly pipeline dies, nothing errors: the page silently freezes on the last good day.
- The pipeline's log glob had drifted to the *future* Caddy path (`/var/log/caddy/...`), but the live box still runs **Apache**, logging the learnche.org vhost to `/var/www/logs/learnche.org/access.log*`. So `run-goaccess.sh` exited `no log files matched`, the cron `&&` short-circuited `build-sparklines.py`, and the JSON was never refreshed.

The operational fix (point the config at the real Apache log) is already applied on the server. This PR makes the failure impossible to miss next time and removes the drift that caused it.

## What changed

- **Single source of truth for the log path.** `run-goaccess.sh` now falls back to the `logs =` line of `sparklines.conf` when `LOG_GLOBS` is unset, so it and `build-sparklines.py` can no longer point at different paths. Shipped defaults and `sparklines.conf.example` list **both** the Apache and Caddy paths, so one config works before and after the migration.
- **Decoupled cron jobs.** `;` instead of `&&` between `run-goaccess.sh` and `build-sparklines.py`, so a GoAccess failure can no longer block the sparkline refresh.
- **New `check-stats-fresh.sh` staleness guard**, run last in cron. Exits non-zero and prints to stderr (which a cron `MAILTO` mails) when `sparklines.json` is missing or older than `MAX_AGE_HOURS` (default 26).
- **Runbook updates**: documents the current-Apache vs future-Caddy reality, the single-config rule, and a "dashboard frozen on an old date" troubleshooting recipe.

## What did not change

No book content, no build, no client-side telemetry behaviour. The display logic in `telemetry.js` is untouched; only the server-side pipeline scripts and the runbook. `CITATION.cff` is already at today's date (`2026.06.20`).

## Verification

- `bash -n` on both shell scripts and `ast.parse` on `build-sparklines.py`: clean.
- `check-stats-fresh.sh`: `MISSING` -> exit 1, fresh file -> `OK ... 0h old` exit 0.
- The `sparklines.conf` INI-extraction snippet used by `run-goaccess.sh` returns the expected glob list.
- No em-dashes introduced (repo style rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7n5vozgRP2fza5jdRGHXm)_