### PR TITLE
Document size-based vhost-log retention in the server runbook

### DIFF
--- a/docs/telemetry/server-runbook.md
+++ b/docs/telemetry/server-runbook.md
@@ -258,6 +258,29 @@ vhosts may go weeks or months between rotations (their files just
 grow until they cross 10 MB) — not a problem for sparklines, just a
 quirk to know.
 
+Two consequences of this size-based behaviour are worth spelling out,
+because "how many days do I keep?" is the question that usually prompts
+a `rotate` change:
+
+* **`rotate N` counts files, not days.** With size-based rotation,
+  `rotate 1825` keeps the last 1825 rotated files. For the busy
+  `access.log` that crosses 10 MB about once a day, that is roughly
+  1825 days; for a quieter log it spans much longer. To guarantee at
+  least N days of `access.log` history, any `rotate` value comfortably
+  above N suffices (the live server uses `rotate 1825`, so 40+ days is
+  met for any realistic traffic level). Newly raised counts fill in one
+  file at a time: a recent bump shows only as many days as have elapsed
+  since the bump, plus whatever older files survived the previous
+  setting.
+* **Day-granularity survives multi-day files.** When a low-traffic day
+  does not push the log past 10 MB, one rotated file can span two or
+  more calendar days. That does not blur the sparklines:
+  `build-sparklines.py` buckets every hit by its own timestamp,
+  independent of file boundaries, so per-day counts are still exact.
+  This is why there is no need to force `daily` rotation (which would
+  drop `size 10M` and rotate every apache and vhost log, producing many
+  near-empty files) just to get clean daily numbers.
+
 **`_stats/` directory.** Apache serves it automatically since
 `DocumentRoot` covers it; you only need to create the directory and
 make sure `www-data` can write to it:


### PR DESCRIPTION
## Why

Follow-up to the stats-outage work (#168). The obvious next question, "how do I keep at least N days of Apache logs?", runs into a non-obvious detail: the vhost logrotate stanza uses **size-based** rotation (`size 10M` overrides `daily`), so `rotate N` is a count of *files*, not days. Investigating the live server showed `rotate 1825` is already set and already covers `/var/www/logs/*/*.log`, so the 40-day target is met, but the reasoning was worth recording so it isn't re-derived later.

## What changed

Doc-only. Expands the existing `size`-vs-`daily` note in the Apache section of `docs/telemetry/server-runbook.md` with two points:

- **`rotate N` counts files, not days.** Any `rotate` comfortably above N guarantees ≥N days of `access.log` for realistic traffic; a freshly raised count fills in one file per day from the bump onward.
- **Day-granularity survives multi-day files.** When a quiet day doesn't cross 10 MB and a rotated file spans two calendar days, the sparklines stay exact because `build-sparklines.py` buckets hits by their own timestamp, independent of file boundaries. So there's no need to force `daily` rotation just to get clean per-day numbers.

## What did not change

No code, no build, no other docs. Markdown prose only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7n5vozgRP2fza5jdRGHXm)_