### PR TITLE
Add Previous/Next navigation row to the top of each page

### DIFF
--- a/_static/css/theme-extended-kgd.css
+++ b/_static/css/theme-extended-kgd.css
@@ -242,3 +242,15 @@ button.copybtn:focus,
         break-inside: avoid;
     }
 }
+
+/* Top Previous / Next navigation row (see _templates/sections/header-article.html).
+   It reuses the theme's .prev-next-footer styling for the links, but sits at the
+   top of the article, so flip the divider to a bottom border and add a little
+   breathing room beneath it before the article content begins. */
+.bd-article-container .prev-next-top {
+    margin-top: 0.5rem;
+    margin-bottom: 1rem;
+    padding-bottom: 0.75rem;
+    border-top: none;
+    border-bottom: 1px solid var(--pst-color-border, #e5e5e5);
+}

--- a/_templates/sections/header-article.html
+++ b/_templates/sections/header-article.html
@@ -1,0 +1,28 @@
+{# Overrides sphinx_book_theme/sections/header-article.html.
+   Adds a Previous / Next navigation row at the top of every article, mirroring
+   the buttons in the footer, so readers can move between pages without first
+   scrolling to the bottom. The header-items row above is kept identical to the
+   theme's default. #}
+{% if theme_article_header_start or theme_article_header_end %}
+<div class="header-article-items header-article__inner">
+  {% if theme_article_header_start %}
+    <div class="header-article-items__start">
+      {% for item in theme_article_header_start %}
+        <div class="header-article-item">{% include item %}</div>
+      {% endfor %}
+    </div>
+  {% endif %}
+  {% if theme_article_header_end %}
+    <div class="header-article-items__end">
+      {% for item in theme_article_header_end %}
+        <div class="header-article-item">{% include item %}</div>
+      {% endfor %}
+    </div>
+  {% endif %}
+</div>
+{% endif %}
+{% if theme_show_prev_next and (prev or next) %}
+<nav class="prev-next-footer prev-next-top d-print-none" aria-label="Page navigation (top)">
+  {% include "components/prev-next.html" %}
+</nav>
+{% endif %}


### PR DESCRIPTION
## What

The **Previous / Next** links previously appeared only at the bottom of each page, so readers had to scroll all the way down before moving to the next section. This adds the same Previous / Next row at the **top** of every article as well, for quicker navigation.

## How

- **`_templates/sections/header-article.html`** (new): overrides the sphinx-book-theme section of the same name. It keeps the theme's default header-items row (sidebar toggle + header buttons) unchanged, then renders the theme's existing `components/prev-next.html` immediately below it. The block is guarded by `theme_show_prev_next and (prev or next)`, so the contents page (no previous) and any page without neighbours degrade gracefully. The override is picked up because `templates_path = ["_templates"]` is searched ahead of the theme.
- **`_static/css/theme-extended-kgd.css`**: a small rule styling the top row (`.prev-next-top`) with a bottom divider instead of the footer's top border, plus spacing before the article content. It reuses the theme's existing `.prev-next-footer` link styling so the top and bottom rows look identical.

No prose or content changed; the footer Previous / Next row is untouched.

## Verification

- `sphinx-build -b html` succeeds. Built pages now contain both a `prev-next-footer prev-next-top` row in the header and the original footer row; links resolve to the correct neighbouring pages.
- `grep -r goatcounter _build/html/contents` returns zero hits (no telemetry leaked in a local build).
- `CITATION.cff` version/date already read today's date (`2026.06.20`); README year range (`2010–2026`) already current, so no metadata bump was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqaQ5R7DPtMEhmw5xSTLUu

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqaQ5R7DPtMEhmw5xSTLUu)_