### PR TITLE
Bump version to 0.2.7 to redeploy with the updated correlation-map figure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "pid-book"
-version = "0.2.6"
+version = "0.2.7"
 description = 'Process Improvement using Data. Repository for the book.'
 readme = "README.md"
 license = "CC-BY-SA-4.0"


### PR DESCRIPTION
## What this does

Bumps the book version `0.2.6` → `0.2.7` so a merge to `main` redeploys the book and **pulls in the updated correlation-map figure** from `kgdunn/figures`.

The book's CI (`build-deploy.yml`) checks out `kgdunn/figures` at build time (no pinned ref), so once [kgdunn/figures#23](https://github.com/kgdunn/figures/pull/23) is merged (it is), the next book deploy picks up the regenerated `correlation-colormap-four-designs.png` automatically. This version bump provides that deploy trigger.

## Scope

- `pyproject.toml`: `version` 0.2.6 → 0.2.7. Nothing else changes.
- No book content / RST / figure-path changes.
- `conf.py` derives the Sphinx `version`/`release` from the git short SHA, so this `pyproject` version is metadata only and does not affect the rendered HTML/PDF.
- `CITATION.cff` is already at today's calendar version (2026.06.20) and date, and the README year range is current, so those need no change.

## Verification

- `make text`: 0 warnings. `make html`: succeeds; `grep -r goatcounter _build/html/contents` returns 0 hits.

## Companion PR

- [kgdunn/figures#23](https://github.com/kgdunn/figures/pull/23) (merged): moved the `max |r|` annotation to the top-right of each correlation-map panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7mKa66G9JcUGPaVUcYRm9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7mKa66G9JcUGPaVUcYRm9)_