### PR TITLE
Note why the second-order model is the default, and link Box-Behnken in the spectrum

### DIFF
--- a/design-analysis-experiments/optimal-and-omars-designs.rst
+++ b/design-analysis-experiments/optimal-and-omars-designs.rst
@@ -566,7 +566,8 @@ end sits the definitive screening design: the fewest runs, every main effect cle
 detectable, but the interactions tangled together. In the middle sit the larger OMARS designs:
 more runs buy more estimable second-order effects, lower correlation among them, and more power.
 At the rich end sit the classical response surface designs, the :ref:`central composite
-<DOE_central_composite_designs>` and Box-Behnken designs: enough runs to estimate the full
+<DOE_central_composite_designs>` and :ref:`Box-Behnken <DOE-box-behnken-designs>` designs: enough
+runs to estimate the full
 second-order model with little or no aliasing, often with the near-rotatable prediction
 behaviour those designs are prized for. In the face-centred case these classical designs are
 themselves OMARS designs, the strongest and largest members of the family, so the spectrum is
@@ -602,6 +603,21 @@ fraction-of-design-space plot, the correlations among the effects, and the power
 exactly the measures developed in :ref:`Judging and comparing designs
 <DOE-judging-and-comparing-designs>`, and they turn the choice along this spectrum from a matter
 of taste into a matter of arithmetic.
+
+This whole spectrum takes the second-order polynomial as the model to be estimated, which is worth
+stating. It is the lowest-order polynomial that can place a stationary point inside the region, a
+maximum, minimum, or saddle, so it is the simplest model able to describe an optimum; it stays
+linear in its coefficients, and it needs only three levels per factor. Higher-degree polynomials
+need more levels and tend to oscillate near the edges of the region, so when a quadratic does not
+fit it is more common to change the model class than to raise the degree. That choice matters here
+because the aliasing and the efficiency measures are properties of the design *together with* the
+model: they are read from the model matrix, so a different model gives a different alias structure
+and different efficiencies. Re-expressing the same quadratic in an orthogonal-polynomial basis (a
+re-parameterisation that leaves the fitted surface unchanged) lowers the correlations among the
+terms; a mechanistic model that is nonlinear in its parameters, or a flexible surrogate such as a
+Gaussian process or a spline fit, would call instead for a design optimal for that model, or a
+space-filling one. The spectrum here, and the measures that rank it, therefore describe the
+second-order case, and the model itself is one of the choices rather than a fixed backdrop.
 
 Analysing data from these designs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## What this does

Two small edits to `design-analysis-experiments/optimal-and-omars-designs.rst`, in the "A spectrum from screening to response surface" section.

1. **New paragraph: why the second-order model is the default, and that aliasing/efficiency are model-relative.** The section repeatedly targets "the full second-order model" without saying why. The added paragraph explains that the quadratic is the lowest-order polynomial that can place a stationary point (maximum, minimum, or saddle) inside the region, that it stays linear in its coefficients and needs only three levels, and that higher-degree polynomials need more levels and oscillate near the edges (so the model class is usually changed rather than the degree raised). It then makes explicit that the alias structure and the efficiency measures are properties of the design *together with* the chosen model: a re-parameterisation in an orthogonal-polynomial basis, a mechanistic (nonlinear-in-parameters) model, or a flexible surrogate (Gaussian process, splines) with a space-filling design would shift them. This answers a reader question the section previously left implicit.

2. **Box-Behnken back-reference.** In the sentence "At the rich end sit the classical response surface designs, the central composite and Box-Behnken designs", the bare "Box-Behnken designs" is now a `:ref:` link to the Box-Behnken section, matching the adjacent central-composite link.

## What did NOT change

No numbers, no figures, no other sections. Author voice and the no-em-dash rule followed.

## Verification

- `make text`: 0 warnings; the Box-Behnken `:ref:` resolves (no unknown-target warning).
- `make html`: succeeds; `grep -r goatcounter _build/html/contents` returns 0 hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7mKa66G9JcUGPaVUcYRm9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7mKa66G9JcUGPaVUcYRm9)_