### PR TITLE
Tidy run-count notation, capitalise a table, drop a version pin, note analyze_omars

### DIFF
--- a/design-analysis-experiments/judging-and-comparing-designs.rst
+++ b/design-analysis-experiments/judging-and-comparing-designs.rst
@@ -82,7 +82,7 @@ climbs steeply (already :math:`5.2\,\sigma^2` at :math:`x = 1.5`): a quantitativ
 against extrapolation.
 
 This and every figure in this subchapter is reproducible with `process_improve
-<https://github.com/kgdunn/process-improve>`_ (``pip install 'process-improve[expt]>=1.42'``).
+<https://github.com/kgdunn/process-improve>`_ (``pip install 'process-improve[expt]'``).
 Each block imports what it needs; the final figure also reuses the FDS helper and the designs
 built in the two blocks before it, so paste them in order. The prediction variance of the
 three-run quadratic design is a closed form:
@@ -153,35 +153,35 @@ the maximum and average of the prediction variance
     :header-rows: 1
     :widths: 34 8 12 16 14 8 8
 
-    *   - design
+    *   - Design
         - :math:`N`
         - :math:`\uparrow\ D=\det\mathbf{M}`
         - :math:`\downarrow\ A=\text{trace}\,\mathbf{M}^{-1}`
         - :math:`\uparrow\ E=\lambda_{\min}`
         - :math:`\downarrow\ G`
         - :math:`\downarrow\ I`
-    *   - base :math:`\{-1, 0, +1\}`
+    *   - Base :math:`\{-1, 0, +1\}`
         - 3
         - 4
         - 3.00
         - 0.44
         - 1.0
         - 0.80
-    *   - base, all three runs repeated
+    *   - Base, all three runs repeated
         - 6
         - 32
         - 1.50
         - 0.88
         - 0.5
         - 0.40
-    *   - base + two centre points
+    *   - Base + two centre points
         - 5
         - 12
         - 1.67
         - 1.00
         - 1.0
         - 0.44
-    *   - base + two points at :math:`\pm 1`
+    *   - Base + two points at :math:`\pm 1`
         - 5
         - 16
         - 2.50
@@ -400,7 +400,7 @@ omnibus comparison further down.
 	model4 = " + ".join(list("ABCD") + [f"I({c}**2)" for c in "ABCD"])
 
 	fig = go.Figure()
-	for design, label in [(dsd4, "DSD (9 runs)"), (omars4, "OMARS (13 runs)")]:
+	for design, label in [(dsd4, "DSD [n=9]"), (omars4, "OMARS [n=13]")]:
 	    curve = fds(design, model4, n_samples=80_000)["curve"]
 	    fig.add_trace(go.Scatter(x=curve["fraction"],
 	                             y=curve["scaled_prediction_variance"], name=label))
@@ -637,8 +637,8 @@ four-factor main-effects-and-quadratic model.
     :widths: 48 26 26
 
     *   - metric (arrow shows the preferred direction)
-        - DSD, 9 runs, 4 factors
-        - OMARS, 13 runs, 4 factors
+        - DSD [n=9], 4 factors
+        - OMARS [n=13], 4 factors
     *   - :math:`\uparrow` D-efficiency
         - 42.8 %
         - 39.0 %
@@ -866,10 +866,10 @@ a poor design.
     :widths: 40 15 15 15 15
 
     *   - Metric (arrow shows the preferred direction)
-        - BBD, 46 runs
-        - CCD, 32 runs
-        - OMARS, 25 runs
-        - DSD, 13 runs
+        - BBD [n=46]
+        - CCD [n=32]
+        - OMARS [n=25]
+        - DSD [n=13]
     *   - :math:`\uparrow` Power, main effect at :math:`\delta = \sigma`
         - 0.97
         - 0.98

--- a/design-analysis-experiments/optimal-and-omars-designs.rst
+++ b/design-analysis-experiments/optimal-and-omars-designs.rst
@@ -681,8 +681,12 @@ active, which is what lets us analyse them on their own. Step 4 is where the des
 since the second-order effects are correlated among themselves, only a limited number can be
 estimated together, and factor heredity (preferring the interaction whose parent main effects
 are active) is the principled way to choose among the candidates the data alone cannot fully
-separate. This staged procedure, and the code that carries it out, is developed alongside this
-book.
+separate. This staged procedure is available in ``process_improve`` as ``analyze_omars()``: it
+takes any coded two- or three-level design with its measured responses and carries out exactly the
+stages above, returning the clean main effects, the pooled error, the overall test for second-order
+activity, and the heredity-constrained selection among the second-order effects. See the top entry
+of the `process_improve changelog
+<https://github.com/kgdunn/process-improve/blob/main/CHANGELOG.md>`__.
 
 **Readings**
 

--- a/docs/blog/judging-and-comparing-designs.md
+++ b/docs/blog/judging-and-comparing-designs.md
@@ -240,7 +240,7 @@ One table holds the whole comparison. Designs run largest to smallest; the arrow
 each label says which direction is better. Power is quoted at delta = sigma, an effect of one noise
 standard deviation, as defined in lens 1.
 
-| Metric | BBD (46) | CCD (32) | OMARS (25) | DSD (13) |
+| Metric | BBD [n=46] | CCD [n=32] | OMARS [n=25] | DSD [n=13] |
 |---|---|---|---|---|
 | ↑ Residual degrees of freedom | 35 | 21 | 14 | 2 |
 | ↑ Power, main effect at delta = sigma | 0.97 | 0.98 | 0.99 | 0.42 |


### PR DESCRIPTION
## What this does

A set of small presentation and content fixes in the DoE chapters (and the blog companion). No numbers or analysis change.

1. **Run counts as `[n=NN]`.** In the comparison tables, the design columns now read `BBD [n=46]`, `CCD [n=32]`, `OMARS [n=25]`, `DSD [n=13]` (Table 4), and `DSD [n=9], 4 factors` / `OMARS [n=13], 4 factors` (Table 3), replacing the `46 runs` / `9 runs, 4 factors` style. The matching code-block legend labels and the blog table are updated to match. The figure legends are updated in the parallel [kgdunn/figures#24](https://github.com/kgdunn/figures/pull/24).
2. **Capitalised Table 1.** The first-column header (`Design`) and row labels (`Base …`) of "Four candidate designs for the single-factor quadratic model" are now capitalised.
3. **Dropped the version pin.** The install line is now `pip install 'process-improve[expt]'` (the `>=1.42` pin removed).
4. **`analyze_omars` note.** The "Analysing data from these designs" subsection now states that the staged OMARS analysis is available in `process_improve` as `analyze_omars()` (added in 1.45.0), with a link to the changelog.

## Note on one item you flagged

The DSD-vs-OMARS FDS figure samples **80,000** points, not 100,000: that value is consistent across the figure script (`N_EVAL = 80_000`), the prose, and the code block, so I left it unchanged. The separate six-design FDS figure uses 120,000. If you'd like the two FDS figures harmonised to one sample count, say which and I'll regenerate.

## Verification

- `make text`: 0 warnings. `make html`: succeeds; `grep -r goatcounter _build/html/contents` returns 0 hits.

## Dependency

The `[n=NN]` figure legends come from [kgdunn/figures#24](https://github.com/kgdunn/figures/pull/24); merging that first means this book deploy renders the updated figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7mKa66G9JcUGPaVUcYRm9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7mKa66G9JcUGPaVUcYRm9)_