### PR TITLE
Retarget omnibus back-link and capitalise the model-fit table headers

### DIFF
--- a/design-analysis-experiments/comparing-design-families.rst
+++ b/design-analysis-experiments/comparing-design-families.rst
@@ -3,7 +3,7 @@
 An omnibus comparison across design families
 ============================================
 
-The :ref:`two-design comparison <DOE-design-comparison-table>` made its point on a narrow contest. Widen it now to the six families a
+The :ref:`two-design comparison <DOE-dsd-omars-comparison>` made its point on a narrow contest. Widen it now to the six families a
 practitioner would actually shortlist for **five** factors on the same
 main-effects-and-quadratic model (eleven terms: an intercept, five linear, and five pure
 quadratic, with no two-factor interactions): a full :math:`2^5` factorial, a resolution-V
@@ -27,15 +27,15 @@ fit the model?
     :header-rows: 1
     :widths: 34 12 22 32
 
-    *   - design (5 factors)
-        - runs
-        - fits the 11-term model?
-        - residual degrees of freedom
-    *   - full factorial, :math:`2^5` + 2 centre
+    *   - Design (5 factors)
+        - Runs
+        - Fits the 11-term model?
+        - Residual degrees of freedom
+    *   - Full factorial, :math:`2^5` + 2 centre
         - 34
         - no (rank 7)
         - 27, reduced model only
-    *   - fractional, :math:`2^{5-1}` + 2 centre
+    *   - Fractional, :math:`2^{5-1}` + 2 centre
         - 18
         - no (rank 7)
         - 11, reduced model only

--- a/design-analysis-experiments/judging-and-comparing-designs.rst
+++ b/design-analysis-experiments/judging-and-comparing-designs.rst
@@ -311,6 +311,8 @@ criteria, and the per-run (SPV) scaling that stops sheer replication from masque
 The rest of this subchapter puts that vocabulary to work on a single running comparison of two
 realistic multi-factor designs, introduced in the next section.
 
+.. _DOE-dsd-omars-comparison:
+
 A running comparison: a DSD and an OMARS design
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## What changed

Three small fixes to the design-comparison chapters, from reader feedback:

1. **Omnibus back-link retargeted.** The omnibus page (`comparing-design-families.rst`) opens with `The :ref:`two-design comparison``, which previously jumped to the *closing summary table* of the judging page. It now points at the start of the running comparison: a new label `DOE-dsd-omars-comparison` on the "A running comparison: a DSD and an OMARS design" subsection. The reader now lands where the two-design comparison begins rather than at its final table.

2. **Table headers capitalised.** In the "Which designs can fit the five-factor main-effects-and-quadratic model" table, the column headers (`Design (5 factors)`, `Runs`, `Fits the 11-term model?`, `Residual degrees of freedom`) and the lower-case first-column row labels (`Full factorial`, `Fractional`) are now capitalised, matching the table-styling convention. The other first-column labels were already capitalised.

3. **Alias-panel annotation** (in the companion figures PR): the `max |A|` annotation moves to the top-right corner of each alias panel, matching the correlation panels.

No prose content or numbers changed. The analysis is untouched.

## Companion PR

Figure change: kgdunn/figures#25.

## Verification

- `make text` succeeds with zero warnings; the new `:ref:` label resolves cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7mKa66G9JcUGPaVUcYRm9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7mKa66G9JcUGPaVUcYRm9)_