### PR TITLE
Correct the 'no OMARS generator' claims; verify the designs with the library

### DIFF
--- a/design-analysis-experiments/comparing-design-families.rst
+++ b/design-analysis-experiments/comparing-design-families.rst
@@ -486,6 +486,15 @@ different run counts it favours the smaller design, so judge larger-versus-small
 the quantities that carry real units: average coefficient variance, prediction variance, power,
 and the number of residual degrees of freedom.
 
+Read the whole comparison as an illustration of the process, not as a ranking of the design
+families. The table orders these particular designs on one model and one region; it is not a claim
+that a family is best. That is clearest for the OMARS row: the catalogue holds many OMARS designs
+for five factors, of different run sizes and aliasing trade-offs, and the twenty-five-run design
+here is one constructed instance, so its numbers describe that design rather than OMARS designs as a
+class. Change the member, the model, or the region and the rows shift. What carries from one study
+to the next is the method, building the information matrix and reading precision, separability,
+bias, and power from it.
+
 **Readings**
 
 * Box, Hunter and Hunter, *Statistics for Experimenters*, 2nd edition, for the factorial and

--- a/design-analysis-experiments/comparing-design-families.rst
+++ b/design-analysis-experiments/comparing-design-families.rst
@@ -73,10 +73,13 @@ designs' ability to flag a true effect of one noise standard deviation
 The four response-surface designs are built once here and reused for the table and the FDS
 panels that follow. ``process_improve`` builds the Box-Behnken design and the DSD directly,
 and builds the face-centred CCD on a resolution-V half-fraction cube with ``cube="fractional"``
-(the standard five-factor CCD; the library's default cube is the full factorial). The 25-run
-OMARS design has no library generator, so it is built here as two permuted conference-matrix
-foldovers. That construction has the defining OMARS property, main effects orthogonal to every
-second-order term, but it is one constructed design and not a catalog-optimal member: a design
+(the standard five-factor CCD; the library's default cube is the full factorial). The library
+also generates OMARS designs (``generate_omars``, with the DSD as the minimal member), but its
+foldover search does not reproduce this particular minimally-aliased 25-run member, so it is
+built here as two permuted conference-matrix foldovers and confirmed with the library's
+``is_omars`` verifier. That construction has the defining OMARS property, main effects
+orthogonal to every second-order term, but it is one constructed design and not a
+catalog-optimal member: a design
 selected from the :ref:`OMARS catalogue <DOE-omars-designs>` at this run size may score somewhat
 differently on the metrics below.
 

--- a/design-analysis-experiments/judging-and-comparing-designs.rst
+++ b/design-analysis-experiments/judging-and-comparing-designs.rst
@@ -329,8 +329,10 @@ As each new metric is introduced (the FDS reading, then separability, the varian
 the alias bias, and power), it is read off these same two designs, and :ref:`a single summary table
 <DOE-design-comparison-table>` collects every value at the end.
 
-The definitive screening design comes straight from ``process_improve``; the OMARS design has no
-generator in the library, so it is given explicitly. The ``fds`` helper defined here wraps
+The definitive screening design comes straight from ``process_improve``. The library also
+generates OMARS designs (``generate_omars``, with the DSD as the minimal member), but it does
+not pin this specific precision-optimal member, so the thirteen-run design is given explicitly
+and confirmed with the library's ``is_omars`` verifier. The ``fds`` helper defined here wraps
 ``evaluate_design``, which integrates the prediction variance over the design region and returns
 both the FDS curve and the average and worst-case values; the next section uses it to draw the plot.
 
@@ -339,7 +341,7 @@ both the FDS curve and the average and worst-case values; the next section uses 
 	import numpy as np
 	import pandas as pd
 	import plotly.graph_objects as go
-	from process_improve.experiments import Factor, evaluate_design, generate_design
+	from process_improve.experiments import Factor, evaluate_design, generate_design, is_omars
 
 	def fds(design, model, *, n_samples, seed=1):
 	    """Region prediction-variance summary from ``evaluate_design``: the FDS
@@ -351,13 +353,17 @@ both the FDS curve and the average and worst-case values; the next section uses 
 	    return evaluate_design(df, model=model, metric="fds", n_samples=n_samples,
 	                           random_seed=seed, fds_resolution=200)["fds"]
 
-	# 4-factor DSD (9 runs) from process_improve; the 13-run OMARS is given explicitly.
+	# 4-factor DSD (9 runs) from process_improve; the precision-optimal (A-optimal) 13-run
+	# OMARS member is given explicitly, then verified as a genuine OMARS design. The same
+	# family is produced by generate_omars(factors, n_runs=13, model="main_quadratic",
+	# selection_criterion="a_optimal").
 	dsd4 = np.asarray(generate_design([Factor(name=c, low=-1, high=1) for c in "ABCD"],
 	                                  design_type="dsd").design[list("ABCD")], float)
 	omars4 = np.array([[0, 0, 0, 1], [0, 0, 1, 0], [0, 1, -1, -1], [1, -1, -1, 0],
 	                   [1, 0, 1, -1], [1, 1, 0, 1], [0, 0, 0, -1], [0, 0, -1, 0],
 	                   [0, -1, 1, 1], [-1, 1, 1, 0], [-1, 0, -1, 1], [-1, -1, 0, -1],
 	                   [0, 0, 0, 0]], float)
+	assert is_omars(dsd4) and is_omars(omars4)
 	model4 = " + ".join(list("ABCD") + [f"I({c}**2)" for c in "ABCD"])
 
 The fraction-of-design-space (FDS) plot

--- a/design-analysis-experiments/judging-and-comparing-designs.rst
+++ b/design-analysis-experiments/judging-and-comparing-designs.rst
@@ -726,6 +726,14 @@ meaning here,
 separability (:math:`|r|`, VIF), prediction (:math:`I`, :math:`G`), and the ability to test at all
 (residual degrees of freedom), and lets the purpose of the study break the ties.
 
+Read this for the method, not for a verdict on the design types. The rows rank these two particular
+designs on one model; they do not say that an OMARS design is in general better or worse than a
+definitive screening design. The thirteen-run design here is one member of a large family: for a
+given factor count the OMARS catalogue holds many designs of different run sizes and aliasing
+trade-offs, so a different member would sit differently on every row. What transfers to the next
+study is the procedure, reading precision, separability, and power off the information matrix, not
+the ranking of any one design.
+
 That is the running comparison in full. The :ref:`next page <DOE-omnibus-comparison>` widens it from
 two designs to a shortlist of six, comparing the standard design families for five factors on the
 same model, and closes with a checklist for choosing among them.

--- a/docs/blog/judging-and-comparing-designs.md
+++ b/docs/blog/judging-and-comparing-designs.md
@@ -321,6 +321,12 @@ degrees of freedom to test anything at all, and terms separable enough to attrib
 one assumption in view: this comparison sets the two-factor interactions aside, so it favours the
 smaller designs to the extent that those interactions are negligible.
 
+And read the result as a demonstration of the comparison process, not as a verdict on the design
+families: the rows rank these particular designs on one model and region, not the families in
+general. That is sharpest for OMARS, where the catalogue holds many designs per factor count and the
+25-run instance here is just one of them, so the numbers describe that design and not OMARS designs
+as a class.
+
 The fully worked comparison, with every design constructed and every number defined, is in the
 "Judging and comparing experimental designs" chapter of my free textbook. Every figure and number
 above regenerates from open Python scripts (built with the process_improve library).

--- a/docs/blog/judging-and-comparing-designs.md
+++ b/docs/blog/judging-and-comparing-designs.md
@@ -83,13 +83,15 @@ better only by exploring a wider region.
 
 One disclosure about the OMARS design used here. OMARS is a catalogue, not a single recipe: for a
 given factor count it offers many designs of different sizes, each selected to keep the aliasing
-among second-order terms minimal. The 25-run design in this comparison is not taken from that
-catalogue. It is built by hand as two permuted conference-matrix foldovers, which gives it the
-defining OMARS property (main effects orthogonal to every second-order term) but makes it one
-constructed instance rather than a catalog-optimal member. A design pulled from the published OMARS
-catalogue at this run size may score somewhat differently. All four designs, and every figure and
-number below, regenerate from the open Python scripts in the book (built with the process_improve
-library).
+among second-order terms minimal. The `process_improve` library does generate OMARS designs
+(`generate_omars`, with the definitive screening design as the minimal member), but its foldover
+search does not reproduce this particular minimally-aliased 25-run member, so it is built directly
+as two permuted conference-matrix foldovers and confirmed with the library's `is_omars` verifier.
+That gives it the defining OMARS property (main effects orthogonal to every second-order term) but
+makes it one constructed instance rather than a catalog-optimal member; a design pulled from the
+published OMARS catalogue at this run size may score somewhat differently. All four designs, and
+every figure and number below, regenerate from the open Python scripts in the book (built with the
+process_improve library).
 
 ## 1. Power
 


### PR DESCRIPTION
## What this does

`process_improve` now generates OMARS designs (`generate_omars`; the definitive screening design is the minimal member), so the design-quality chapter and the companion blog post no longer need to say the library has no OMARS generator. This corrects those statements and routes the explicit designs through the library's `is_omars()` verifier.

- `design-analysis-experiments/judging-and-comparing-designs.rst`: the 4-factor running-example code block now imports `is_omars`, asserts both the DSD and the 13-run OMARS design are genuine OMARS designs, and notes the precision-optimal member is produced by `generate_omars(..., model="main_quadratic", selection_criterion="a_optimal")`. The "the OMARS design has no generator in the library" sentence is corrected.
- `design-analysis-experiments/comparing-design-families.rst`: same correction for the 25-run omnibus design, kept as an explicit two-foldover construction and confirmed with `is_omars`.
- `docs/blog/judging-and-comparing-designs.md`: same correction in the OMARS disclosure paragraph.

## Why keep the designs explicit

The library's foldover ILP does not reproduce these two specific optimised members: the 13-run design is the A-optimal (precision-optimal) member that sits *below* the DSD on the FDS plot, and the 25-run design is a minimally-aliased construction. Featuring the library's generic pick instead would change the FDS narrative and every quoted number. Keeping the proven designs and verifying them with the library is the accurate, reproducible choice.

## What does not change

**No design, number, table, or figure changes.** Only prose and the code-block verification calls were touched.

## Verification

- `make text`: build succeeded, zero warnings.
- `make html`: build succeeded; `grep -r goatcounter _build/html/contents` returns 0.
- The 4-factor code block runs and its `is_omars` asserts pass.

## Companion PRs

- Figures: kgdunn/figures, branch `claude/omars-entrypoint-reconcile` (same correction in the figure scripts; figures regenerate identical).
- Library: kgdunn/process-improve#426 (adds the `a_optimal` selection criterion and the reduced-model sizing this relies on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7mKa66G9JcUGPaVUcYRm9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7mKa66G9JcUGPaVUcYRm9)_