### PR TITLE
Reframe the OMARS disclosure as a verified catalogue member

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.06.21"
-date-released: 2026-06-21
+version: "2026.06.22"
+date-released: 2026-06-22
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/design-analysis-experiments/comparing-design-families.rst
+++ b/design-analysis-experiments/comparing-design-families.rst
@@ -75,13 +75,14 @@ panels that follow. ``process_improve`` builds the Box-Behnken design and the DS
 and builds the face-centred CCD on a resolution-V half-fraction cube with ``cube="fractional"``
 (the standard five-factor CCD; the library's default cube is the full factorial). The library
 also generates OMARS designs (``generate_omars``, with the DSD as the minimal member), but its
-foldover search does not reproduce this particular minimally-aliased 25-run member, so it is
-built here as two permuted conference-matrix foldovers and confirmed with the library's
-``is_omars`` verifier. That construction has the defining OMARS property, main effects
-orthogonal to every second-order term, but it is one constructed design and not a
-catalog-optimal member: a design
-selected from the :ref:`OMARS catalogue <DOE-omars-designs>` at this run size may score somewhat
-differently on the metrics below.
+foldover search does not enumerate this larger 25-run member, so it is built here as two permuted
+conference-matrix foldovers and confirmed with the library's ``is_omars`` verifier. Its 24
+distinct factor runs are the :ref:`OMARS catalogue <DOE-omars-designs>` basic design
+``bd-5-24-4-8-53`` (the construction reproduces that catalogue design exactly, up to a relabeling
+of the factors and a reordering of the runs), with one centre run added to make 25. It has the
+defining OMARS property, main effects orthogonal to every second-order term. The catalogue holds
+other 24-run members that place their runs differently and so score differently on the metrics
+below; this is one of them.
 
 Each design carries its textbook number of center runs rather than padding added to equalize the
 comparison: six for the Box-Behnken design (the canonical 46-run design is forty design runs plus
@@ -490,8 +491,9 @@ Read the whole comparison as an illustration of the process, not as a ranking of
 families. The table orders these particular designs on one model and one region; it is not a claim
 that a family is best. That is clearest for the OMARS row: the catalogue holds many OMARS designs
 for five factors, of different run sizes and aliasing trade-offs, and the twenty-five-run design
-here is one constructed instance, so its numbers describe that design rather than OMARS designs as a
-class. Change the member, the model, or the region and the rows shift. What carries from one study
+here is one of them (the basic design ``bd-5-24-4-8-53`` with a centre run), so its numbers describe
+that member rather than OMARS designs as a class. Change the member, the model, or the region and
+the rows shift. What carries from one study
 to the next is the method, building the information matrix and reading precision, separability,
 bias, and power from it.
 

--- a/docs/blog/judging-and-comparing-designs.md
+++ b/docs/blog/judging-and-comparing-designs.md
@@ -85,13 +85,34 @@ One disclosure about the OMARS design used here. OMARS is a catalogue, not a sin
 given factor count it offers many designs of different sizes, each selected to keep the aliasing
 among second-order terms minimal. The `process_improve` library does generate OMARS designs
 (`generate_omars`, with the definitive screening design as the minimal member), but its foldover
-search does not reproduce this particular minimally-aliased 25-run member, so it is built directly
-as two permuted conference-matrix foldovers and confirmed with the library's `is_omars` verifier.
-That gives it the defining OMARS property (main effects orthogonal to every second-order term) but
-makes it one constructed instance rather than a catalog-optimal member; a design pulled from the
-published OMARS catalogue at this run size may score somewhat differently. All four designs, and
+search does not enumerate this larger 25-run member, so it is built directly as two permuted
+conference-matrix foldovers and confirmed with the library's `is_omars` verifier. Its 24 distinct
+factor runs are the catalogue basic design `bd-5-24-4-8-53`: the construction reproduces that
+catalogue design exactly, up to a relabeling of the factors and a reordering of the runs, with one
+centre run added to make 25. That gives it the defining OMARS property (main effects orthogonal to
+every second-order term). The catalogue holds other 24-run members that place their runs
+differently and so score differently; this is one of them. All four designs, and
 every figure and number below, regenerate from the open Python scripts in the book (built with the
 process_improve library).
+
+To show where this member sits, three of the thirty 24-run catalogue designs, scored on the same
+eleven-term model and the same 25-run basis (each 24-run basic design plus one centre run), bracket
+the spread. `A` is the summed coefficient variance (smaller is more precise); the correlation column
+is the worst absolute correlation among all second-order terms, including the two-factor
+interactions the model leaves out (the fitted main-effect and quadratic terms stay uncorrelated at
+0.00 for every OMARS member).
+
+| Design | D-efficiency | A | Max \|r\| (2nd-order) |
+|---|---|---|---|
+| `bd-5-24-4-8-53` (used here) | 39.3% | 2.34 | 0.50 |
+| `bd-5-24-10-16-28` | 40.6% | 1.44 | 0.57 |
+| `bd-5-24-2-4-45` | 32.7% | 3.20 | 0.40 |
+
+Across all thirty 24-run members the per-run D-efficiency runs from 32.7% to 40.6%, the summed
+coefficient variance A from 1.44 to 3.20, and the worst second-order correlation from 0.40 to 0.57.
+The member used here sits between the extremes: more precise than the least-aliased design and less
+aliased than the most precise one. Which corner suits a study depends on whether precision or clean
+separation of the second-order terms matters more for its purpose.
 
 ## 1. Power
 
@@ -324,8 +345,8 @@ smaller designs to the extent that those interactions are negligible.
 And read the result as a demonstration of the comparison process, not as a verdict on the design
 families: the rows rank these particular designs on one model and region, not the families in
 general. That is sharpest for OMARS, where the catalogue holds many designs per factor count and the
-25-run instance here is just one of them, so the numbers describe that design and not OMARS designs
-as a class.
+25-run design here (the basic design `bd-5-24-4-8-53` with a centre run) is just one of them, so the
+numbers describe that member and not OMARS designs as a class.
 
 The fully worked comparison, with every design constructed and every number defined, is in the
 "Judging and comparing experimental designs" chapter of my free textbook. Every figure and number


### PR DESCRIPTION
## What this does

The 25-run OMARS design in the design-comparison subchapter is no longer described as "one constructed instance, not a catalogue-optimal member". Its 24 distinct factor runs reproduce the catalogue OMARS basic design `bd-5-24-4-8-53` exactly (up to factor relabeling and run order), with one centre run added to make 25; the construction is verified with the library's `is_omars`.

- `design-analysis-experiments/comparing-design-families.rst`: main disclosure rewritten to the verified-catalogue-member framing; the later "one constructed instance" mention now names the specific member.
- `docs/blog/judging-and-comparing-designs.md`: same disclosure rewrite, plus a **catalogue trade-off sidebar**: three of the thirty 24-run catalogue designs, scored on the same eleven-term model and 25-run basis, bracket the spread (D-efficiency 32.7-40.6%, summed coefficient variance A 1.44-3.20, worst second-order correlation 0.40-0.57), placing this member between the precision and low-aliasing extremes.

## What does not change

**No quoted quality metric changes.** The underlying design's eleven-term information matrix is identical (see companion figures PR), so the comparison table, the FDS and power figures, and every number in the prose are unchanged.

## Provenance note for review

The `bd-5-24-4-8-53` row of the sidebar (39.3% / 2.34 / 0.50) was reproduced locally from the design's own run matrix. The two comparison rows (`bd-5-24-10-16-28`, `bd-5-24-2-4-45`) and the across-catalogue ranges are the supplied catalogue figures; I did not have those designs' run matrices to recompute them, so please confirm before merge.

## Verification

- `make text`: build succeeded, **zero warnings**.
- `make html`: build succeeded; `grep -r goatcounter _build/html/contents` returns 0.
- `CITATION.cff` calendar version and release date bumped to 2026-06-22.

## Companion PR

- Figures: kgdunn/figures#28 (the permutation fix that makes the design a `bd-5-24-4-8-53` catalogue member; figure metrics unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7mKa66G9JcUGPaVUcYRm9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7mKa66G9JcUGPaVUcYRm9)_