### PR TITLE
DOE chapter: build OMARS designs with generate_omars; alias via evaluate_design

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.06.22"
-date-released: 2026-06-22
+version: "2026.06.23"
+date-released: 2026-06-23
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/design-analysis-experiments/comparing-design-families.rst
+++ b/design-analysis-experiments/comparing-design-families.rst
@@ -72,17 +72,16 @@ designs' ability to flag a true effect of one noise standard deviation
 
 The four response-surface designs are built once here and reused for the table and the FDS
 panels that follow. ``process_improve`` builds the Box-Behnken design and the DSD directly,
-and builds the face-centred CCD on a resolution-V half-fraction cube with ``cube="fractional"``
-(the standard five-factor CCD; the library's default cube is the full factorial). The library
-also generates OMARS designs (``generate_omars``, with the DSD as the minimal member), but its
-foldover search does not enumerate this larger 25-run member, so it is built here as two permuted
-conference-matrix foldovers and confirmed with the library's ``is_omars`` verifier. Its 24
-distinct factor runs are the :ref:`OMARS catalogue <DOE-omars-designs>` basic design
-``bd-5-24-4-8-53`` (the construction reproduces that catalogue design exactly, up to a relabeling
-of the factors and a reordering of the runs), with one centre run added to make 25. It has the
-defining OMARS property, main effects orthogonal to every second-order term. The catalogue holds
-other 24-run members that place their runs differently and so score differently on the metrics
-below; this is one of them.
+builds the face-centred CCD on a resolution-V half-fraction cube with ``cube="fractional"``
+(the standard five-factor CCD; the library's default cube is the full factorial), and builds the
+OMARS design with ``generate_omars``. We ask it for a twenty-five-run, five-factor member on the
+main-effects-and-quadratic model, selected for precision (A-optimality); the definitive screening
+design is the minimal member of the same foldover family, and the twenty-four design runs are
+folded around one centre run. It has the defining OMARS property, main effects orthogonal to every
+second-order term, which the library's ``is_omars`` verifier confirms. This is one member of a
+large family: the :ref:`OMARS catalogue <DOE-omars-designs>` holds many twenty-five-run members
+that place their runs differently and so score differently on the metrics below, and the generator
+returns the one its A-optimality search settles on.
 
 Each design carries its textbook number of center runs rather than padding added to equalize the
 comparison: six for the Box-Behnken design (the canonical 46-run design is forty design runs plus
@@ -103,22 +102,7 @@ the library scores exactly this model and not the full second-order one:
 	import numpy as np
 	import pandas as pd
 	import plotly.graph_objects as go
-	from process_improve.experiments import Factor, evaluate_design, generate_design
-
-	def conference_matrix_order6():
-	    """Order-6 conference matrix (C C' = 5 I) from the quadratic residues of GF(5):
-	    the backbone of definitive screening and OMARS designs."""
-	    q = 5
-	    residues = {(a * a) % q for a in range(1, q)}
-	    chi = [0] + [1 if a in residues else -1 for a in range(1, q)]
-	    c = np.zeros((6, 6))
-	    for i in range(1, 6):
-	        c[0, i] = c[i, 0] = 1
-	    for i in range(q):
-	        for j in range(q):
-	            if i != j:
-	                c[1 + i, 1 + j] = chi[(j - i) % q]
-	    return c
+	from process_improve.experiments import Factor, evaluate_design, generate_design, generate_omars
 
 	names = list("ABCDE")
 	factors = [Factor(name=c, low=-1, high=1) for c in names]
@@ -131,9 +115,8 @@ the library scores exactly this model and not the full second-order one:
 	dsd = coded(generate_design(factors, "dsd"))
 	ccd = coded(generate_design(factors, "ccd", cube="fractional",
 	                            alpha="face_centered", center_points=6))
-	cm = conference_matrix_order6()[:, :5]
-	cm2 = cm[:, [2, 4, 1, 3, 0]]
-	omars = np.vstack([cm, -cm, cm2, -cm2, np.zeros((1, 5))])
+	omars = coded(generate_omars(factors, n_runs=25, model="main_quadratic",
+	                             selection_criterion="a_optimal"))
 	designs = {"Box-Behnken": bbd, "CCD": ccd, "OMARS": omars, "DSD": dsd}
 
 	def power(design):
@@ -160,11 +143,11 @@ the library scores exactly this model and not the full second-order one:
     the harder target.
 
 The thirteen-run DSD is visibly underpowered: a :math:`0.42` chance on a one-sigma main effect and
-only :math:`0.15` on a quadratic of the same size. The run-richer designs all clear :math:`0.97`
-on main effects, and the Box-Behnken design, the largest at forty-six runs, is the only one with a
-strong :math:`0.82` chance on curvature. Power rewards the larger designs, which is the practical
-reading and exactly what an efficiency score that normalizes out the number of runs would have
-hidden.
+only :math:`0.15` on a quadratic of the same size. The run-richer designs all clear :math:`0.96`
+on main effects, and the Box-Behnken design, the largest at forty-six runs, has the strongest
+chance on curvature at :math:`0.82`, with the twenty-five-run OMARS design next at :math:`0.53`.
+Power rewards the larger designs, which is the practical reading and exactly what an efficiency
+score that normalizes out the number of runs would have hidden.
 
 One caveat in the definitive screening design's favour, since its numbers look stark. A DSD is
 built on an assumption of effect sparsity, not for this saturated eleven-term fit: its design
@@ -186,62 +169,62 @@ a poor design.
     *   - :math:`\uparrow` Power, main effect at :math:`\delta = \sigma`
         - 0.97
         - 0.98
-        - 0.99
+        - 0.96
         - 0.42
     *   - :math:`\uparrow` Power, quadratic at :math:`\delta = \sigma`
         - 0.82
         - 0.32
-        - 0.46
+        - 0.53
         - 0.15
     *   - :math:`\downarrow` Average prediction variance, :math:`\sigma^2` units
         - 0.18
         - 0.31
-        - 0.51
+        - 0.29
         - 0.71
     *   - :math:`\downarrow` Maximum prediction variance, :math:`\sigma^2` units
         - 0.84
         - 0.77
-        - 0.84
+        - 0.51
         - 1.05
     *   - :math:`\downarrow` Maximum scaled prediction variance :math:`G`
         - 38.8
         - 24.6
-        - 20.9
+        - 12.7
         - 13.6
     *   - :math:`\downarrow` Summed coefficient variance :math:`A`
         - 1.05
         - 2.39
-        - 2.34
+        - 1.61
         - 3.70
     *   - :math:`\uparrow\ E`, smallest eigenvalue of :math:`\mathbf{X}^T\mathbf{X}`
         - 2.54
         - 2.00
-        - 0.93
+        - 2.64
         - 0.85
     *   - :math:`\downarrow` Maximum :math:`|r|` among model terms
         - 0.15
         - 0.75
-        - 0.00
+        - 0.31
         - 0.13
     *   - :math:`\downarrow` Maximum VIF
         - 1.20
         - 3.20
-        - 1.00
+        - 1.21
         - 1.05
     *   - :math:`\downarrow` Maximum alias :math:`|\mathbf{A}|`, omitted interactions
         - 0.00
         - 0.00
-        - 1.00
+        - 0.77
         - 1.09
     *   - :math:`\uparrow` D-optimal information :math:`|\mathbf{X}^T\mathbf{X}|^{1/p}`
         - 14.0
         - 8.97
-        - 9.82
+        - 10.0
         - 5.19
     *   - :math:`\uparrow` D-efficiency, per run (see note)
         - 30.5%
         - 28.0%
-        - 39.3%
+        - 40.1%
         - 39.9%
 
 Let's focus on the last row first. Recall what D-efficiency measures: it takes the determinant of
@@ -256,30 +239,32 @@ strongest designs here sit near 30 to 40%. (A separate *relative* D-efficiency c
 takes the D-optimal design as 100%, so it is worth checking which one a given package reports.)
 
 The two D rows make this concrete. The **unscaled** D-optimal information
-:math:`|\mathbf{X}^T\mathbf{X}|^{1/p}` ranks the designs as every other row does, the
-Box-Behnken design highest at :math:`14.0` and the thirteen-run DSD lowest at :math:`5.19`. Divide
-that same determinant through by the run count and the order reverses in the row directly beneath
-it: per-run D-efficiency ranks the small DSD and OMARS designs *highest*, at :math:`39.9\,\%` and
-:math:`39.3\,\%`, above the Box-Behnken and composite designs that predict better, test better, and
-detect curvature far better. The number is not wrong; it is answering a different question. Dividing
-by the run count rewards a design for spending few experiments, so a small design comes out ahead
-even when it tests and predicts worse. Scaled prediction variance carries the same concern, and for
-the same reason it has been questioned in the design literature (Anderson-Cook, Borror and
-Montgomery, 2009, and its published discussion; Goos and Núñez Ares, 2025).
+:math:`|\mathbf{X}^T\mathbf{X}|^{1/p}` puts the Box-Behnken design highest at :math:`14.0` and the
+thirteen-run DSD lowest at :math:`5.19`, the ranking the real-unit rows broadly agree on. Divide
+that same determinant through by the run count and the row directly beneath it tells a different
+story: per-run D-efficiency puts the twenty-five-run OMARS and the thirteen-run DSD highest, at
+:math:`40.1\,\%` and :math:`39.9\,\%`, ahead of the forty-six-run Box-Behnken at :math:`30.5\,\%`.
+The number is not wrong; it is answering a different question. Dividing by the run count measures
+information per experiment, so a design that spends few experiments scores well on this row even
+when, like the DSD, it carries the least total information and the weakest power. Scaled prediction
+variance carries the same concern, and for the same reason it has been questioned in the design
+literature (Anderson-Cook, Borror and Montgomery, 2009, and its published discussion; Goos and
+Núñez Ares, 2025).
 
 The quantities in real units, the **unscaled prediction variance** in :math:`\sigma^2`, the summed
 coefficient variance :math:`A`, and the power, all reward the larger Box-Behnken design, which is
 the reading that matches what the experiments can actually deliver.
 
-The two maximum-variance rows report the worst case under each scaling, and the two do not agree. In
-real :math:`\sigma^2` units the face-centred CCD has the lowest maximum (:math:`0.77`), just below
-the Box-Behnken and OMARS designs, because the face-centred cube carries runs at the corners where
-the unscaled variance peaks while the Box-Behnken design does not. The scaled maximum :math:`G`, the
-worst-case scaled prediction variance, reverses the order: the thirteen-run DSD is lowest at
-:math:`13.6` and the forty-six-run Box-Behnken highest at :math:`38.8`. This is the same per-run
-normalisation seen in the two D rows; dividing the worst-case variance through by the run count
-rewards the design that spends fewer experiments. Read the unscaled maximum for the variance
-obtained at the bench, and the scaled :math:`G` to compare worst cases per experiment.
+The two maximum-variance rows report the worst case under each scaling, and they disagree most for
+the designs at the extremes of run count. In real :math:`\sigma^2` units the thirteen-run DSD has
+the highest maximum (:math:`1.05`), the worst single-point prediction at the bench, while the OMARS
+design has the lowest (:math:`0.51`). The scaled maximum :math:`G`, which divides the worst-case
+variance through by the run count, moves the DSD from worst to nearly best: it sits at :math:`13.6`,
+just above the OMARS design's :math:`12.7`, while the forty-six-run Box-Behnken, with a moderate
+unscaled maximum of :math:`0.84`, has the highest :math:`G` at :math:`38.8`. The reversal for the
+DSD and the Box-Behnken is the same per-run normalisation seen in the two D rows; dividing by the
+run count rewards the design that spends fewer experiments. Read the unscaled maximum for the
+variance obtained at the bench, and the scaled :math:`G` to compare worst cases per experiment.
 
 The alias row makes the cost of the reduced model explicit. The model fits no two-factor
 interactions, so any that are present bias the coefficients we keep, by the
@@ -287,10 +272,11 @@ interactions, so any that are present bias the coefficients we keep, by the
 at zero on this model (:math:`|\mathbf{A}| = 0`): their quadratics are balanced against the
 omitted interactions, so a present interaction leaves the fitted coefficients untouched. The
 definitive screening and OMARS designs instead protect the main effects, whose alias is
-zero, but let a present interaction shift a quadratic by as much as a full unit. Whether that
-matters is a question about the system rather than the design: it is the price of setting the
-interactions aside, and it is why a follow-up design is run once a screening study has
-flagged the active factors.
+zero, but let a present interaction shift a quadratic by a large fraction of a unit, up to
+:math:`0.77` here for the OMARS design and :math:`1.09` for the definitive screening design.
+Whether that matters is a question about the system rather than the design: it is the price of
+setting the interactions aside, and it is why a follow-up design is run once a screening study
+has flagged the active factors.
 
 The pattern is easier to see than to tabulate. The figure below shows the absolute alias matrix
 for each design as a heatmap, the eleven fitted terms down the rows and the ten omitted two-factor
@@ -302,17 +288,17 @@ interactions across the columns:
 	import plotly.graph_objects as go
 	from plotly.subplots import make_subplots
 
-	# Reuses the designs dict (from the power block). A = (X1'X1)^-1 X1'X2 maps the ten omitted
-	# two-factor interactions (columns) onto the eleven fitted terms (rows).
+	# Reuses the designs dict, names and model (from the power block). evaluate_design
+	# returns the alias matrix A = (X1'X1)^-1 X1'X2 directly: its rows are the eleven fitted
+	# terms (intercept, main effects, quadratics) and its columns the ten omitted two-factor
+	# interactions.
 	fitted = ["1", "A", "B", "C", "D", "E", "A^2", "B^2", "C^2", "D^2", "E^2"]
 	pairs = [a + b for i, a in enumerate("ABCDE") for b in "ABCDE"[i + 1:]]
 
 	def alias_abs(d):
-	    d = np.asarray(d, float); n = len(d)
-	    X1 = np.column_stack([np.ones(n)] + [d[:, i] for i in range(5)]
-	                         + [d[:, i] ** 2 for i in range(5)])
-	    X2 = np.column_stack([d[:, i] * d[:, j] for i in range(5) for j in range(i + 1, 5)])
-	    return np.abs(np.linalg.solve(X1.T @ X1, X1.T @ X2))
+	    df = pd.DataFrame(np.asarray(d, float), columns=names)
+	    a = evaluate_design(df, model=model, metric="alias_matrix")["alias_matrix"]["matrix"]
+	    return np.abs(np.asarray(a, float))
 
 	fig = make_subplots(rows=2, cols=2, subplot_titles=list(designs))
 	for k, d in enumerate(designs.values()):
@@ -330,7 +316,7 @@ interactions across the columns:
     Absolute alias matrix :math:`|\mathbf{A}|` for the four designs (rows: the eleven fitted terms;
     columns: the ten omitted two-factor interactions). The Box-Behnken and composite designs hold
     every entry at zero on this model; the OMARS and definitive screening designs keep the
-    main-effect rows at zero and carry the bias on the quadratic rows, up to :math:`1.00` and
+    main-effect rows at zero and carry the bias on the quadratic rows, up to :math:`0.77` and
     :math:`1.09` respectively.
 
 The same entanglement is a correlation rather than a directed bias. The figure below shows the
@@ -377,9 +363,9 @@ values:
     the quadratics, and the two-factor interactions the model omits), separated by lines. The
     main-effect block is orthogonal to everything for every design. The main-effect and quadratic
     blocks are the fitted terms, so their worst off-diagonal is the table's maximum :math:`|r|` row
-    (:math:`0.15`, :math:`0.75`, :math:`0.00`, :math:`0.13`); the :math:`0.50` for the OMARS and
-    definitive screening designs sits only in the blocks that involve the omitted interactions,
-    the same aliasing the matrix above measures.
+    (:math:`0.15`, :math:`0.75`, :math:`0.31`, :math:`0.13`); the stronger correlations,
+    :math:`0.83` for the OMARS design and :math:`0.50` for the definitive screening design, sit in
+    the blocks that involve the omitted interactions, the same aliasing the matrix above measures.
 
 It is worth being clear about what the table compares. The model is already settled: we have
 committed to the eleven-term main-effects-plus-quadratics model and are comparing point-placement
@@ -388,8 +374,9 @@ along exactly that line. For *estimation*, the determinant criterion :math:`D` (
 run) and the summed coefficient variance :math:`A` summarise the whole parameter set, and
 :math:`E`-optimality adds the worst single coefficient direction, the smallest eigenvalue of
 :math:`\mathbf{X}^T\mathbf{X}`. It is the coefficient-space counterpart to the maximum prediction
-variance, and it agrees with :math:`A` and the prediction rows: the Box-Behnken design first, the
-DSD last. For *prediction*, the average and maximum prediction variance are the working analogues of
+variance; like :math:`A` and the prediction rows it places the DSD clearly last (:math:`E = 0.85`),
+though at the top it ranks the OMARS design marginally above the Box-Behnken (:math:`2.64` versus
+:math:`2.54`). For *prediction*, the average and maximum prediction variance are the working analogues of
 :math:`I`- and :math:`G`-optimality. A model-discrimination criterion such as :math:`T`-optimality
 has no place here: it is defined only against a second, rival model, measuring the lack of fit of
 one against the other, so once a single model is settled there is no rival curve to be far from.
@@ -454,8 +441,9 @@ Within either panel the rule from before still holds: a low and flat curve is wh
 right tail (anchored at the cube vertices, where the maximum prediction variance usually lives) shows
 the worst case. The two panels differ only in how they put the designs on a common footing. The left
 panel is scaled, normalized by the number of runs, so it compares the designs per experiment; on
-that footing the thirteen-run DSD curve sits among the rest, and its right-tail value, the scaled
-maximum :math:`G` reported in the table, is in fact the lowest of the four. The right panel is
+that footing the thirteen-run DSD curve sits among the rest rather than far above them, and the
+lowest right-tail value, the scaled maximum :math:`G` reported in the table, belongs to the OMARS
+design at :math:`12.7`, with the DSD just behind at :math:`13.6`. The right panel is
 unscaled, in real
 :math:`\sigma^2` units, so it compares the variance actually obtained at the bench; there the DSD
 curve is the highest and the forty-six-run Box-Behnken the lowest. The two views answer different
@@ -491,8 +479,8 @@ Read the whole comparison as an illustration of the process, not as a ranking of
 families. The table orders these particular designs on one model and one region; it is not a claim
 that a family is best. That is clearest for the OMARS row: the catalogue holds many OMARS designs
 for five factors, of different run sizes and aliasing trade-offs, and the twenty-five-run design
-here is one of them (the basic design ``bd-5-24-4-8-53`` with a centre run), so its numbers describe
-that member rather than OMARS designs as a class. Change the member, the model, or the region and
+here is just the one the generator's A-optimality search returns, so its numbers describe that
+member rather than OMARS designs as a class. Change the member, the model, or the region and
 the rows shift. What carries from one study
 to the next is the method, building the information matrix and reading precision, separability,
 bias, and power from it.

--- a/design-analysis-experiments/judging-and-comparing-designs.rst
+++ b/design-analysis-experiments/judging-and-comparing-designs.rst
@@ -329,19 +329,19 @@ As each new metric is introduced (the FDS reading, then separability, the varian
 the alias bias, and power), it is read off these same two designs, and :ref:`a single summary table
 <DOE-design-comparison-table>` collects every value at the end.
 
-The definitive screening design comes straight from ``process_improve``. The library also
-generates OMARS designs (``generate_omars``, with the DSD as the minimal member), but it does
-not pin this specific precision-optimal member, so the thirteen-run design is given explicitly
-and confirmed with the library's ``is_omars`` verifier. The ``fds`` helper defined here wraps
-``evaluate_design``, which integrates the prediction variance over the design region and returns
-both the FDS curve and the average and worst-case values; the next section uses it to draw the plot.
+Both designs come straight from ``process_improve``: ``generate_design`` builds the nine-run
+definitive screening design, and ``generate_omars`` builds the thirteen-run OMARS member directly
+(the DSD is the minimal member of the same foldover family), each confirmed with the library's
+``is_omars`` verifier. The ``fds`` helper defined here wraps ``evaluate_design``, which integrates
+the prediction variance over the design region and returns both the FDS curve and the average and
+worst-case values; the next section uses it to draw the plot.
 
 .. code-block:: python
 
 	import numpy as np
 	import pandas as pd
 	import plotly.graph_objects as go
-	from process_improve.experiments import Factor, evaluate_design, generate_design, is_omars
+	from process_improve.experiments import Factor, evaluate_design, generate_design, generate_omars, is_omars
 
 	def fds(design, model, *, n_samples, seed=1):
 	    """Region prediction-variance summary from ``evaluate_design``: the FDS
@@ -353,16 +353,13 @@ both the FDS curve and the average and worst-case values; the next section uses 
 	    return evaluate_design(df, model=model, metric="fds", n_samples=n_samples,
 	                           random_seed=seed, fds_resolution=200)["fds"]
 
-	# 4-factor DSD (9 runs) from process_improve; the precision-optimal (A-optimal) 13-run
-	# OMARS member is given explicitly, then verified as a genuine OMARS design. The same
-	# family is produced by generate_omars(factors, n_runs=13, model="main_quadratic",
-	# selection_criterion="a_optimal").
-	dsd4 = np.asarray(generate_design([Factor(name=c, low=-1, high=1) for c in "ABCD"],
-	                                  design_type="dsd").design[list("ABCD")], float)
-	omars4 = np.array([[0, 0, 0, 1], [0, 0, 1, 0], [0, 1, -1, -1], [1, -1, -1, 0],
-	                   [1, 0, 1, -1], [1, 1, 0, 1], [0, 0, 0, -1], [0, 0, -1, 0],
-	                   [0, -1, 1, 1], [-1, 1, 1, 0], [-1, 0, -1, 1], [-1, -1, 0, -1],
-	                   [0, 0, 0, 0]], float)
+	# Both four-factor designs come from process_improve: the 9-run DSD and the
+	# precision-optimal (A-optimal) 13-run OMARS member of the same foldover family,
+	# the latter carrying two estimable two-factor interactions. is_omars confirms each.
+	factors4 = [Factor(name=c, low=-1, high=1) for c in "ABCD"]
+	dsd4 = np.asarray(generate_design(factors4, design_type="dsd").design[list("ABCD")], float)
+	omars4 = np.asarray(generate_omars(factors4, n_runs=13, model="main_quadratic",
+	                                   selection_criterion="a_optimal").design[list("ABCD")], float)
 	assert is_omars(dsd4) and is_omars(omars4)
 	model4 = " + ".join(list("ABCD") + [f"I({c}**2)" for c in "ABCD"])
 
@@ -441,12 +438,12 @@ helper from the previous section:
 
     FDS plot for a nine-run definitive screening design and a thirteen-run OMARS design,
     both in four factors on the main-effects-plus-quadratic model. The curves cross near a
-    fraction of 0.75: the larger design predicts better on average but worse at the extreme
+    fraction of 0.73: the larger design predicts better on average but worse at the extreme
     corners.
 
 The thirteen-run OMARS curve sits *below* the nine-run DSD curve for roughly the first three
 quarters of the region: it has lower best-case, median, and average prediction variance.
-But the two curves **cross** near :math:`f \approx 0.75`, and the thirteen-run OMARS curve then
+But the two curves **cross** near :math:`f \approx 0.73`, and the thirteen-run OMARS curve then
 rises well above: its worst-case prediction variance is noticeably higher. This crossing is the
 practical tension between V- (average) and G- (worst-case) optimality, and it has a physical cause:
 the larger design here places fewer runs out near the edge of the region, so prediction there
@@ -460,7 +457,7 @@ corner (a vertex of the :math:`[-1, 1]` cube), where random interior sampling ra
 ``evaluate_design`` therefore adds the cube vertices to its interior sample by default (its
 ``include_vertices`` argument). Including them lifts the nine-run DSD's :math:`G` from :math:`8.98`
 to :math:`9.00`, a maximum that turns out to sit precisely at a corner, and leaves the thirteen-run
-OMARS value at :math:`12.50` because its worst case lies in the interior. The shift is tiny, so it
+OMARS value at :math:`12.70` because its worst case lies in the interior. The shift is tiny, so it
 changes no conclusion here, but including the extreme points is the correct procedure, and the
 :ref:`omnibus comparison <DOE-omnibus-comparison>` relies on it.
 
@@ -687,7 +684,7 @@ four-factor main-effects-and-quadratic model.
         - 6.19
     *   - :math:`\downarrow\ G`, maximum SPV
         - 9.00
-        - 12.50
+        - 12.70
     *   - :math:`\downarrow` maximum :math:`|r|`
         - 0.707
         - 0.570


### PR DESCRIPTION
## What changed

A final sanity pass on the last three DOE-chapter sections so the code reflects the library's current ability to **create** OMARS designs (`generate_omars`) and **evaluate** them (`evaluate_design`).

**`judging-and-comparing-designs.rst`**
- The 13-run OMARS design is now built live with `generate_omars(factors, n_runs=13, model="main_quadratic", selection_criterion="a_optimal")` instead of a pasted literal matrix.
- That member reproduces the whole comparison table except the worst-case `G` (12.50 -> 12.70); the FDS-crossing fraction shifts 0.75 -> 0.73. Updated the table, the figure caption, and the two prose mentions.

**`comparing-design-families.rst`**
- The 25-run OMARS design is now built with `generate_omars(..., n_runs=25, ...)` instead of a hand-built conference-matrix foldover; the `conference_matrix_order6` helper is gone.
- The alias-matrix heatmap now reads its values from `evaluate_design(metric="alias_matrix")`.
- The library returns its own A-optimal member rather than the previously hand-picked catalogue design `bd-5-24-4-8-53`, so the OMARS column of the quality table and the surrounding discussion are re-derived for that member. It improves A (2.34 -> 1.61), E (0.93 -> 2.64), and worst-case prediction variance, but no longer holds its fitted-term correlation at exactly zero (max |r| 0.00 -> 0.31, VIF 1.00 -> 1.21, alias 1.00 -> 0.77). Corrected the stale claim that the library "does not enumerate this larger 25-run member".

**`optimal-and-omars-designs.rst`**: no change needed; its `analyze_omars()` reference is accurate.

`CITATION.cff` `version` / `date-released` bumped to 2026-06-23.

## Headline numbers verified

Every quoted table value and prose number reproduces against the installed library (`generate_omars` is deterministic at the default seed). The defining OMARS property (main effects orthogonal to every second-order term) holds exactly for both generated members, confirmed with `is_omars`.

## Build

`make text` succeeds with zero warnings. `make html` succeeds; `grep -c goatcounter _build/html/contents` returns 0.

## Companion PR (figures)

The five regenerated PNGs and the figure scripts live in kgdunn/figures#30. The two PRs should merge together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PFeF7TyDH8ZehKebyefPxj)_