### PR TITLE
DoE Ch.5 (1/4): classical factorial and fractional-factorial corrections

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.06.28"
-date-released: 2026-06-28
+version: "2026.07.02"
+date-released: 2026-07-02
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/design-analysis-experiments/blocking-and-confounding-for-disturbances.rst
+++ b/design-analysis-experiments/blocking-and-confounding-for-disturbances.rst
@@ -43,7 +43,7 @@ It is common for known, or controllable or measurable factors to have an effect 
 	:align: left
 	:scale: 50
 	:width: 900px
-	:alt: fake width
+	:alt: Cube showing a two-level, three-factor factorial split into two blocks on the ABC interaction
 
 In this section then we will deal with disturbances that are known, but their effect may or may not be measurable. We will also assume that we cannot control that disturbance, but we would like to minimize its effect.
 

--- a/design-analysis-experiments/changing-one-single-variable-at-a-time.rst
+++ b/design-analysis-experiments/changing-one-single-variable-at-a-time.rst
@@ -33,7 +33,7 @@ The base operating point is 346 K with a feed substrate concentration of 1.5 g/L
 	:align: center
 	:scale: 70
 	:width: 900px
-	:alt: fake width
+	:alt: Contour plot illustrating the one-factor-at-a-time search path
 
 .. FUTURE: use a curved surface like figure (c) on page 445 of BHH2
 

--- a/design-analysis-experiments/experiments-with-a-single-variable-at-two-levels.rst
+++ b/design-analysis-experiments/experiments-with-a-single-variable-at-two-levels.rst
@@ -3,7 +3,7 @@
 Experiments with a single variable at two levels
 ======================================================
 
-This is the simplest type of experiment. It involves an outcome variable, :math:`y`, and one input variable, :math:`x`. The :math:`x`-variable could be a continuous numeric one, such as temperature, or discrete on, such as yes/no, on/off, A/B. This type of experiment could be used to answer questions such as the following:
+This is the simplest type of experiment. It involves an outcome variable, :math:`y`, and one input variable, :math:`x`. The :math:`x`-variable could be a continuous numeric one, such as temperature, or discrete, such as yes/no, on/off, A/B. This type of experiment could be used to answer questions such as the following:
 
 	*	Has the reaction yield increased when using catalyst A or B?
 
@@ -11,7 +11,7 @@ This is the simplest type of experiment. It involves an outcome variable, :math:
 
 	*	Does the plastic's stretchability improve when extruded at various temperatures (a low or high temperature)?
 
-We can perform several runs (experiments) at level A, and some runs at level B. These runs are randomized (i.e. do not perform all the A runs, and then the B runs). We strive to hold all other disturbance variables constant so we pick up only the A-to-B effect. Disturbances are any variables that might affect :math:`y` but, for whatever reason, we don't wish to quantify. If we cannot control the disturbance, then at least we can use :ref:`pairing <univariate_paired_tests>` and :ref:`blocking <DOE_blocking_section>`. Pairing is when there is one factor in our experiment; blocking is when we have more than one factor.
+We can perform several runs (experiments) at level A, and some runs at level B. These runs are randomized (i.e. do not perform all the A runs, and then the B runs). We strive to hold all other disturbance variables constant so we pick up only the A-to-B effect. Disturbances are any variables that might affect :math:`y` but, for whatever reason, we don't wish to quantify. If we cannot control the disturbance, then at least we can use :ref:`pairing <univariate_paired_tests>` and :ref:`blocking <DOE_blocking_section>`. Pairing is blocking with blocks of size two: the two runs of a pair are made under the same level of the disturbance, so its effect cancels in their difference. Blocking generalizes this to larger groups, and it is used even when there is only a single factor of interest.
 
 Recap of group-to-group differences
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -27,6 +27,8 @@ We have already seen in the :ref:`univariate statistics section <univariate-grou
 		-c_t &\leq& z &\leq & c_t\\
 		(\overline{x}_B - \overline{x}_A) - c_t \times \sqrt{s_P^2 \left(\frac{1}{n_A} + \frac{1}{n_B}\right)} &\leq& \mu_B - \mu_A &\leq & (\overline{x}_B - \overline{x}_A) + c_t  \times \sqrt{s_P^2 \left(\frac{1}{n_A} + \frac{1}{n_B}\right)}
 	\end{array}
+
+.. note:: We keep the symbol :math:`z` here to match the univariate section, but because the pooled variance :math:`s_P^2` is *estimated* from the data (rather than known), this statistic is strictly :math:`t`-distributed, not standard normal. That is why the critical value :math:`c_t` and the degrees of freedom :math:`n_A + n_B - 2` come from the :math:`t`-distribution.
 
 We consider the effect of changing from condition A to condition B to be a *statistically* significant effect when this confidence interval does not span zero. However, the width of this interval and how symmetrically it spans zero can cause us to come to a different, *practical* conclusion. In other words, we override the narrow statistical conclusion based on the richer information we can infer from the width of the confidence interval and the variance of the process.
 
@@ -106,7 +108,7 @@ Had we used a formal test of differences where we pooled the variances, we would
 	:align: center
 	:scale: 60
 	:width: 900px
-	:alt: fake width
+	:alt: Histogram of the average A-minus-B difference over all randomization permutations
 
 The figure shows the differences in the averages of A and B for the 24,310 realizations. The vertical line represents the difference in the average for the one particular set of numbers we measured in the experiment.
 

--- a/design-analysis-experiments/fractional-factorial-designs/generators-defining-relationships-blocking.rst
+++ b/design-analysis-experiments/fractional-factorial-designs/generators-defining-relationships-blocking.rst
@@ -103,7 +103,7 @@ Let's return to the table in the :ref:`previous section <DOE-half-fractions>` an
 
 After running these additional 4 experiments shown (in random order of course) we have a complete set of 8 runs. Analyzing the data together we can calculate the main effects and two-factor interactions without aliasing because we are back to the usual full factorial of :math:`2^3` runs. Confirm it for yourself visually in the plot alongside.
 
-So we see that we can always complete our half-fraction by creating a complementary fraction. This complimentary fraction is found by flipping the sign on the generating factor. For example, changing the sign from **C = AB** to **-C = AB**. In the illustration this is equivalent to running the 4 experiments at the closed circles.
+So we see that we can always complete our half-fraction by creating a complementary fraction. This complementary fraction is found by flipping the sign on the generating factor. For example, changing the sign from **C = AB** to **C = -AB**. In the illustration this is equivalent to running the 4 experiments at the closed circles.
 
 .. _DOE-Generators-for-blocking:
 

--- a/design-analysis-experiments/fractional-factorial-designs/half-fractions.rst
+++ b/design-analysis-experiments/fractional-factorial-designs/half-fractions.rst
@@ -28,7 +28,7 @@ So this is our half-factorial designed experiment in 3 factors, but it only requ
 	:align: center
 	:scale: 35
 	:width: 900px
-	:alt: fake width
+	:alt: Cube showing the four runs of a half-fraction in three factors
 
 What have we lost by running only half of the full factorial? Let's write out the full design and matrix of all interactions, then construct the :math:`\mathbf{X}` matrix for the least squares model.
 

--- a/design-analysis-experiments/fractional-factorial-designs/saturated-designs-for-screening.rst
+++ b/design-analysis-experiments/fractional-factorial-designs/saturated-designs-for-screening.rst
@@ -43,7 +43,7 @@ Use a least squares model to estimate the coefficients in the model:
 	\mathbf{y} &= \mathbf{Xb} \\
 	\mathbf{b} &= \left(\mathbf{X}^T\mathbf{X}\right)^{-1}\mathbf{X}^T\mathbf{y}
 
-where :math:`\mathbf{b} = [b_0, b_A, b_B, b_C, b_D, b_E, b_F, b_G]`. The matrix :math:`\mathbf{X}` is essentiall a copy of the above table, but with an added column of 1's for the intercept term. Notice that the :math:`\mathbf{X}^T\mathbf{X}` matrix will be diagonal. Make sure you can calculate :math:`\mathbf{X}^T\mathbf{X}` by hand, at least once. It is also straightforward to calculate the solution vector (by hand!), which you can confirm to be :math:`\mathbf{b} = [70.7, -2.3, 0.1, -2.8, -0.4, 0.5, -0.4, -1.7]`.
+where :math:`\mathbf{b} = [b_0, b_A, b_B, b_C, b_D, b_E, b_F, b_G]`. The matrix :math:`\mathbf{X}` is essentially a copy of the above table, but with an added column of 1's for the intercept term. Notice that the :math:`\mathbf{X}^T\mathbf{X}` matrix will be diagonal. Make sure you can calculate :math:`\mathbf{X}^T\mathbf{X}` by hand, at least once. It is also straightforward to calculate the solution vector (by hand!), which you can confirm to be :math:`\mathbf{b} = [70.7, -2.3, 0.1, -2.8, -0.4, 0.5, -0.4, -1.7]`.
 
 How do you assess which main effects are important?  There are eight data points and eight parameters, so there are no degrees of freedom and the residuals are all zero. In this case you have to use a :ref:`Pareto plot <DOE-Pareto-plot>`, which requires that your variables have been suitably scaled in order to judge importance of the main effects relative to each other. The Pareto plot would be given as shown below, and as usual, it does not show the intercept term.
 
@@ -57,13 +57,15 @@ How do you assess which main effects are important?  There are eight data points
 	pd.options.plotting.backend = "plotly"
 
 	# Create vectors for each factor in the experiment.
-	# itertools.product gives the full 2^3 design.
+	# itertools.product varies the last column fastest, so we label
+	# the columns C, B, A to obtain standard (Yates) order, where
+	# factor A alternates fastest. This matches the run table above.
 	design = pd.DataFrame(
 	    list(itertools.product([-1, +1],
 	                           [-1, +1],
 	                           [-1, +1])),
-	    columns=["A", "B", "C"],
-	)
+	    columns=["C", "B", "A"],
+	)[["A", "B", "C"]]
 	A = design["A"].to_numpy()
 	B = design["B"].to_numpy()
 	C = design["C"].to_numpy()
@@ -159,7 +161,7 @@ Significant effects would be **A**, **C** and **G**. The next largest effect, **
 
 The factor **B** is definitely not important to the response variable in this system and can be excluded in future experiments, as could **F** and **D** likely. Future experiments should focus on the **A**, **C** and **G** factors and their interactions. We show how to use these existing 8 experiments in the above table, but add a few new ones in the next section on design foldover and by understanding projectivity.
 
-A side note on screening designs is a mention of :index:`Plackett and Burman designs <pair: Plackett-Burman designs; experiments>`. These designs can sometimes be of greater use than a highly fractionated design. A fractional factorial must have :math:`2^{k-p}` runs, for integers :math:`k` and :math:`p`: i.e. either :math:`4, 8, 16, 32, 64, 128, \ldots` runs. Plackett-Burman designs are screening designs that can be run in any multiple of 4 greater or equal to 12:, i.e. :math:`12, 16, 20, 24, \ldots` runs. The Box, Hunter, and Hunter book has more information in Chapter 7, but another interesting paper on these topic is by Box and :index:`Bisgaard <single: Bisgaard, Søren>`: "What can you find out from 12 experimental runs?", which shows how to screen for 11 factors in 12 experiments.
+A side note on screening designs is a mention of :index:`Plackett and Burman designs <pair: Plackett-Burman designs; experiments>`. These designs can sometimes be of greater use than a highly fractionated design. A fractional factorial must have :math:`2^{k-p}` runs, for integers :math:`k` and :math:`p`: i.e. either :math:`4, 8, 16, 32, 64, 128, \ldots` runs. Plackett-Burman designs are screening designs that can be run in any multiple of 4, i.e. :math:`12, 16, 20, 24, \ldots` runs. The non-geometric cases (12, 20, 24, 28, ...), which are not powers of 2, are the ones that a fractional factorial cannot provide. The Box, Hunter, and Hunter book has more information in Chapter 7, but another interesting paper on these topic is by Box and :index:`Bisgaard <single: Bisgaard, Søren>`: "What can you find out from 12 experimental runs?", which shows how to screen for 11 factors in 12 experiments.
 
 .. youtube:: https://www.youtube.com/watch?v=zrZS-zovKSc&list=PLHUnYbefLmeOPRuT1sukKmRyOVd4WSxJE&index=50
 

--- a/design-analysis-experiments/full-factorial-designs/analysis-by-least-squares-modelling.rst
+++ b/design-analysis-experiments/full-factorial-designs/analysis-by-least-squares-modelling.rst
@@ -102,7 +102,7 @@ Some things to note are (1) the :index:`orthogonality` of :math:`\mathbf{X}^T\ma
 	The 61.5 term in the least squares model is the expected conversion at the baseline conditions. Notice from the least squares equations how it is just the average of the four experimental values, even though we did not actually perform an experiment at the center.
 
 Let's return to the :ref:`system with high interaction <DOE-two-level-factorials-interaction-effects>` where the four outcome values in standard order were
-77, 79, 81 and 89. Looking back, the baseline operation was :math:`T` = 395 K and :math:`S = \frac{1.25 - 0.5}{2}` = 0.875 g/L; you should prove to yourself that the least squares model is
+77, 79, 81 and 89. Looking back, the baseline operation was :math:`T` = 395 K and :math:`S = \frac{1.25 + 0.5}{2}` = 0.875 g/L; you should prove to yourself that the least squares model is
 
 	.. math::
 
@@ -114,7 +114,7 @@ The interaction term can now be readily interpreted: it is the additional increa
 		:align: right
 		:scale: 40
 		:width: 900px
-		:alt: fake width
+		:alt: Nonlinear response surface with the fitted least-squares plane below it
 
 Finally, out of interest, the nonlinear surface that was used to generate the experimental data for the interacting system is coloured in the illustration. In practice we never know what this surface looks like, but we estimate it with the least squares plane, which appears below the nonlinear surface as black and white grids. The corners of the box are outer levels at which we ran the factorial experiments.
 

--- a/design-analysis-experiments/full-factorial-designs/assessing-significance-of-main-effects-and-interactions.rst
+++ b/design-analysis-experiments/full-factorial-designs/assessing-significance-of-main-effects-and-interactions.rst
@@ -3,7 +3,7 @@
 Assessing significance of main effects and interactions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When there are no :index:`replicate points <pair: replicates; experiments>`, then the number of factors to estimate from a full factorial is :math:`2^k` from the :math:`2^k` observations. There are no degrees of freedom left to calculate the standard error or the confidence intervals for the main effects and interaction terms.
+When there are no :index:`replicate points <pair: replicates; experiments>`, then the number of parameters to estimate from a full factorial is :math:`2^k` from the :math:`2^k` observations. There are no degrees of freedom left to calculate the standard error or the confidence intervals for the main effects and interaction terms.
 
 The standard error can be estimated if complete replicates are available. However, a complete replicate is onerous, because a complete replicate implies the entire experiment is repeated: system setup, running the experiment and measuring the result. Taking two samples from one actual experiment and measuring :math:`y` twice is not a true replicate. That is only an estimate of the measurement error and analytical error.
 
@@ -27,13 +27,48 @@ Pareto plot
 
 A full factorial with :math:`2^k` experiments has :math:`2^k` parameters to estimate. Once these parameters have been calculated, for example, by using a :ref:`least squares model <DOE-analysis-by-least-squares>`, then plot as shown the absolute value of the model coefficients in sorted order, from largest magnitude to smallest, ignoring the intercept term. Significant coefficients are established by visual judgement -- establishing a visual cutoff by contrasting the small coefficients to the larger ones.
 
+The example below is from a :math:`2^4` full factorial (four factors, sixteen runs) where the results for :math:`y` in standard order were :math:`y = \left[45,71,48,65,68,60,80,65,43,100,45,104,75,86,70,96 \right]`. The code fits the sixteen-parameter model by least squares and plots the sorted magnitudes of the fifteen effects.
+
+.. code-block:: python
+
+	import itertools
+	import numpy as np
+	import plotly.graph_objects as go
+
+	# Full 2^4 factorial in standard (Yates) order: factor A alternates fastest.
+	levels = [-1, 1]
+	design = np.array(list(itertools.product(levels, levels, levels, levels)))[:, ::-1]
+	y = np.array([45, 71, 48, 65, 68, 60, 80, 65,
+	              43, 100, 45, 104, 75, 86, 70, 96])
+
+	# Build every main effect and interaction column, then fit by least squares.
+	names = ["A", "B", "C", "D"]
+	factor = {name: design[:, i] for i, name in enumerate(names)}
+	terms = {}
+	for order in range(1, 5):
+	    for combo in itertools.combinations(names, order):
+	        column = np.ones(16)
+	        for f in combo:
+	            column = column * factor[f]
+	        terms["".join(combo)] = column
+
+	X = np.column_stack([np.ones(16)] + list(terms.values()))
+	b = np.linalg.solve(X.T @ X, X.T @ y)   # X is orthogonal, so this is exact
+	effects = dict(zip(terms.keys(), b[1:]))  # drop the intercept
+
+	# Pareto plot: absolute effects, largest bar at the top.
+	ordered = sorted(effects, key=lambda name: abs(effects[name]))
+	fig = go.Figure(go.Bar(x=[abs(effects[name]) for name in ordered],
+	                       y=ordered, orientation="h"))
+	fig.update_layout(xaxis_title_text="|effect|", yaxis_title_text="Term",
+	                  showlegend=False)
+	fig.show()
+
 .. image:: ../../figures/doe/pareto-plot-full-fraction.png
 	:align: left
 	:scale: 30
 	:width: 900px
-	:alt: fake width
-
-The example shown in the bar graph was from a full factorial experiment where the results for :math:`y` in standard order were :math:`y = \left[45,71,48,65,68,60,80,65,43,100,45,104,75,86,70,96 \right]`.
+	:alt: Pareto plot of effect magnitudes from a full factorial
 
 We would interpret that factors **A**, **C** and **D**, as well as the interactions of **AC** and **AD**, have a significant and causal effect on the response variable, :math:`y`. The main effect of **B** on the response :math:`y` is small, at least over the range that **B** was used in the experiment. Factor **B** can be omitted from future experimentation in this region, though it might be necessary to include it again if the system is operated at a very different point.
 
@@ -59,7 +94,7 @@ Standard error: from replicate runs or from an external dataset
 ..
 .. The standard error can be calculated in a similar manner if more than one duplicate run is performed. So rather run a :math:`2^4` factorial for 4 factors than a :math:`2^3`factorial twice; or as we will see later - one can screen five or more factors with :math:`2^4` runs.
 
-If there are more experiments than parameters to be estimated, then we have extra degrees of freedom. Having degrees of freedom implies we can calculate the standard error, :math:`S_E`. Once :math:`S_E` has been found, we can also calculate the standard error for each model coefficient, and then confidence intervals can be constructed for each main effect and interaction. And because the model matrix is orthogonal, the confidence interval for each effect is independent of the other. This is because the general confidence interval is :math:`\mathcal{V}\left(\mathbf{b}\right) = \left(\mathbf{X}^T\mathbf{X}\right)^{-1}S_E^2`, and the off-diagonal elements in :math:`\mathbf{X}^T\mathbf{X}` are zero.
+If there are more experiments than parameters to be estimated, then we have extra degrees of freedom. Having degrees of freedom implies we can calculate the standard error, :math:`S_E`. Once :math:`S_E` has been found, we can also calculate the standard error for each model coefficient, and then confidence intervals can be constructed for each main effect and interaction. And because the model matrix is orthogonal, the confidence interval for each effect is independent of the other. This is because the variance-covariance matrix of the estimates is :math:`\mathcal{V}\left(\mathbf{b}\right) = \left(\mathbf{X}^T\mathbf{X}\right)^{-1}S_E^2`, and the off-diagonal elements in :math:`\mathbf{X}^T\mathbf{X}` are zero, so the estimates are uncorrelated. The confidence interval for each coefficient is then :math:`b_i \pm c_t \sqrt{\mathcal{V}(b_i)}`.
 
 For an experiment with :math:`n` runs, and where we have coded our :math:`\mathbf{X}` matrix to contain :math:`-1` and :math:`+1` elements, and when the :math:`\mathbf{X}` matrix is orthogonal, the standard error for coefficient :math:`b_i` is :math:`S_E(b_i) = \sqrt{\mathcal{V}\left(b_i\right)} = \sqrt{\dfrac{S_E^2}{\sum{x_i^2}}}`. Some examples:
 
@@ -167,7 +202,7 @@ After having established which effects are significant, we can exclude the nonsi
 
 .. AU: I modified the last sentence of the following paragraph because it seemed redundant. Please confirm.
 
-Continuing the above example, where a :math:`2^4` factorial was run, the response values in standard order were :math:`y = [71, 61, 90, 82, 68, 61, 87, 80, 61, 50, 89, 83, 59, 51, 85, 78]`. The significant effects were from **A**, **B**, **D** and **BD**. Now, omitting the nonsignificant effects, there are only five parameters to estimate, including the intercept, so the standard error is :math:`S_E^2 = \dfrac{39}{16-5} = 3.54`, with 11 degrees of freedom. The :math:`S_E(b_i)` value for all coefficients, except the intercept, is :math:`\sqrt{\dfrac{S_E^2}{16}} = 0.471`, and the critical :math:`t`-value at the 95% level is ``qt(0.975, df=11)`` = 2.2. So the confidence intervals can be calculated to confirm that these are indeed significant effects.
+As an example, consider a :math:`2^4` factorial (16 runs) where the response values in standard order were :math:`y = [71, 61, 90, 82, 68, 61, 87, 80, 61, 50, 89, 83, 59, 51, 85, 78]`. Assessing the 15 effects with a Pareto plot, or against the standard error, identifies **A**, **B**, **D** and **BD** as the significant ones. Now, omitting the nonsignificant effects, there are only five parameters to estimate, including the intercept, so the standard error is :math:`S_E^2 = \dfrac{39}{16-5} = 3.54`, with 11 degrees of freedom. The :math:`S_E(b_i)` value for all coefficients, except the intercept, is :math:`\sqrt{\dfrac{S_E^2}{16}} = 0.471`, and the critical :math:`t`-value at the 95% level is ``qt(0.975, df=11)`` = 2.2. So the confidence intervals can be calculated to confirm that these are indeed significant effects.
 
 There is some circular reasoning here: postulate that one or more effects are zero and increase the degrees of freedom by removing those parameters in order to confirm the remaining effects are significant. Some general advice is to first exclude effects that are definitely small, and then retain medium-size effects in the model until you can confirm they are not significant.
 
@@ -180,14 +215,14 @@ Variance of estimates from the COST approach versus the factorial approach
 	:align: center
 	:scale: 50
 	:width: 900px
-	:alt: fake width
+	:alt: Comparison of effect-estimate variance for the COST and factorial approaches
 
 Finally, we end this section on factorials by illustrating their efficiency. Contrast the two cases: COST and the full factorial approach. For this analysis we define the main effect simply as the difference between the high and low values (normally we divide through by 2, but the results still hold). Define the variance of the measured :math:`y` value as :math:`\sigma_y^2`.
 
 	.. tabularcolumns:: |l|l|
 
 +--------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------+
-| COST approach                                                            | Fractional factorial approach                                                                                  |
+| COST approach                                                            | Factorial approach                                                                                             |
 +==========================================================================+================================================================================================================+
 | The main effect of :math:`T` is :math:`b_T = y_2 - y_1`.                 | The main effect is :math:`b_T = 0.5(y_2 - y_1) + 0.5(y_4 - y_3)`.                                              |
 +--------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------+
@@ -196,6 +231,6 @@ Finally, we end this section on factorials by illustrating their efficiency. Con
 | So :math:`\mathcal{V}(b_T) = 2\sigma_y^2`.                               | And :math:`\mathcal{V}(b_T) = \sigma_y^2`.                                                                     |
 +--------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------+
 
-Not only does the factorial experiment estimate the effects with much greater precision (lower variance), but the COST approach cannot estimate the effect of interactions, which is incredibly important, especially as systems approach optima that are on ridges (see the contour plots earlier in this section for an example).
+The factorial uses all four runs to estimate :math:`b_T`, whereas the COST comparison uses only two, so part of the variance reduction is simply the extra runs. The point is that those same four runs *also* estimate :math:`b_S` and the interaction :math:`b_{TS}` at no additional cost, whereas the COST approach cannot estimate the effect of interactions at all. Interactions are important, especially as systems approach optima that lie on ridges (see the contour plots earlier in this section for an example).
 
 Factorial designs make each experimental observation work twice.

--- a/design-analysis-experiments/full-factorial-designs/example-design-and-analysis-of-a-three-factor-experiment.rst
+++ b/design-analysis-experiments/full-factorial-designs/example-design-and-analysis-of-a-three-factor-experiment.rst
@@ -121,6 +121,8 @@ The data are from a plastics molding factory that must treat its waste before di
 
 		y = 11.25 + 6.25x_C + 0.75x_T -7.25x_S + 0.25 x_C x_T -6.75 x_C x_S -0.25 x_T x_S - 0.25 x_C x_T x_S
 
+	Notice that each least-squares coefficient is exactly half the corresponding by-hand effect above: the :math:`C` effect of :math:`12.5` appears as :math:`b_C = 6.25`, and the :math:`CS` effect of :math:`-13.5` appears as :math:`b_{CS} = -6.75`. The reason is that the coefficient measures the change over *half* the range of the coded factor, from :math:`0` to :math:`+1`, whereas the effect measures the change over the *full* range, from :math:`-1` to :math:`+1`. This convention is discussed in the note below.
+
 Learning notes:
 
 	*	The chemical compound could be coded either as (chemical P = :math:`-1`, chemical Q = :math:`+1`) or (chemical P = :math:`+1`, chemical Q = :math:`-1`). The interpretation of the :math:`x_C` coefficient is the same, regardless of the coding.
@@ -131,7 +133,7 @@ Learning notes:
 
 In this text we quantify the effect as the change in response over *half the range* of the factor. For example, if the center point is 400 K, the lower level is 375 K and the upper level is 425 K, then an effect of ``"-5"`` represents a reduction in :math:`y` of 5 units for every increase of 25 K in :math:`x`.
 
-We use this representation because it corresponds with the results calculated from least-squares software. Putting the matrix of :math:`-1` and :math:`+1` entries into the software as :math:`\mathbf{X}`, along with the corresponding vector of responses, :math:`y`, you can calculate these effects as :math:`\mathbf{b} = \left(\mathbf{X}^T\mathbf{X}\right)^{-1}\mathbf{X}\mathbf{y}`.
+We use this representation because it corresponds with the results calculated from least-squares software. Putting the matrix of :math:`-1` and :math:`+1` entries into the software as :math:`\mathbf{X}`, along with the corresponding vector of responses, :math:`y`, you can calculate these effects as :math:`\mathbf{b} = \left(\mathbf{X}^T\mathbf{X}\right)^{-1}\mathbf{X}^T\mathbf{y}`.
 
 Other textbooks, specifically Box, Hunter and Hunter, will report effects that are double ours. This is because they consider the effect to be the change from the lower level to the upper level (double the distance). The advantage of their representation is that binary factors (catalyst A or B; agitator on or off) can be readily interpreted, whereas in our notation, the effect is a little harder to describe (simply double it!).
 

--- a/design-analysis-experiments/full-factorial-designs/using-two-levels-for-two-or-more-factors.rst
+++ b/design-analysis-experiments/full-factorial-designs/using-two-levels-for-two-or-more-factors.rst
@@ -64,7 +64,7 @@ The range over which they will be varied is given in the table. This range was i
 		:align: center
 		:scale: 40
 		:width: 900px
-		:alt: fake width
+		:alt: Cube plot of a two-factor, two-level factorial design
 
 .. _DOE-two-level-factorials-main-effects:
 
@@ -97,7 +97,7 @@ The following surface plot illustrates the true, but unknown, surface from which
 	.. image:: ../../figures/doe/factorial-two-level-surface-example-cropped.png
 		:align: left
 		:scale: 50
-		:alt: fake width
+		:alt: True response surface with slight curvature over the factorial region
 		:width: 900px
 
 An :index:`interaction plot` is an :ref:`alternative way to visualize these main effects <DOE-fig-Interaction-plot-example>`. Use this method when you don't have computer software to draw the surfaces. [We saw this earlier in the :ref:`visualization section <SECTION-data-visualization>`]. We will discuss interaction plots more in the next section. Here is an illustration of one such plot for a system with little interaction.
@@ -127,7 +127,7 @@ Consider the case when washing your hands with cold water. If you use soap with 
 
 Now consider the case when washing your hands with hot water. The time taken to clean your hands with hot water when you use soap is greatly reduced, far faster than any other combination. We say there is an interaction between using soap and the temperature of the water. This is an example of an interaction that works to help us reach the objective faster.
 
-The effect of warm water enhances the effect of soap. Conversely, the effect is soap is enhanced by using warm water. So symmetry means that if soap interacts with water temperature, then we also know that water temperature interacts with soap.
+The effect of warm water enhances the effect of soap. Conversely, the effect of soap is enhanced by using warm water. So symmetry means that if soap interacts with water temperature, then we also know that water temperature interacts with soap.
 
 In summary, interaction means the effect of one factor depends on the level of the other factor. In this example, that implies the effect of soap is different, depending on if we use cold water or hot water. Interactions are also symmetrical. The soap’s effect is enhanced by warm water, and the warm water’s effect is enhanced by soap.
 
@@ -138,7 +138,7 @@ Let's use a :ref:`different system here to illustrate <DOE-fig-interaction-examp
 		:align: center
 		:scale: 40
 		:width: 900px
-		:alt: fake width
+		:alt: Contour plot of a two-factor system that shows interaction
 
 	.. tabularcolumns:: |l|c|c||c|
 
@@ -166,7 +166,7 @@ Notice how different the main effect is at the low and high levels of :math:`S`.
 Similarly, the main effect of substrate concentration is
 
 		-	:math:`\Delta S_{T-} = 81 - 77 = 4\%` per 0.75 g/L
-		-	:math:`\Delta S_{T-} = 89 - 79 = 10\%` per 0.75 g/L
+		-	:math:`\Delta S_{T+} = 89 - 79 = 10\%` per 0.75 g/L
 
 which gives the average substrate concentration main effect as 7% per 0.75 g/L.
 

--- a/design-analysis-experiments/why-learning-about-systems-is-important.rst
+++ b/design-analysis-experiments/why-learning-about-systems-is-important.rst
@@ -44,12 +44,12 @@ Another engineering example
 
 Here's a great example from the book by Box, Hunter and Hunter. Consider the negative-slope :ref:`relationship between pressure and yield <DOE-yield-pressure-impurity-correlation>`: as pressure increases, the yield drops. A line could be drawn through the points from the happenstance measurements, taken from the process at different times in the past. That line could be from a :ref:`least squares model <SECTION-least-squares-modelling>`. It is true that the observed pressure and yield are correlated, as that is exactly what a least squares model is intended for: to quantify correlation.
 
-The true mechanism in this system is that pressure is increased to remove the frothing that occurs in the reactor. Higher frothing occurs when there is an impurity in the raw material, so operators increase reactor pressure when they see frothing (i.e. high impurity). However, it is the high impurity that actually causes the lower yield, not the pressure itself. These relationships between yield, pressure and impurity levels are illustrated below, based an adaption from the book by Box, Hunter and Hunter, Chapter 14 (1st edition) or Chapter 10 (2nd edition).
+The true mechanism in this system is that pressure is increased to remove the frothing that occurs in the reactor. Higher frothing occurs when there is an impurity in the raw material, so operators increase reactor pressure when they see frothing (i.e. high impurity). However, it is the high impurity that actually causes the lower yield, not the pressure itself. These relationships between yield, pressure and impurity levels are illustrated below, based on an adaptation from the book by Box, Hunter and Hunter, Chapter 14 (1st edition) or Chapter 10 (2nd edition).
 
 .. _DOE-yield-pressure-impurity-correlation:
 
 .. image:: ../figures/doe/yield-pressure-impurity-correlation.png
-	:alt:	../figures/doe/yield-pregon.svg
+	:alt: Projections showing how yield, pressure and impurity are related
 	:scale: 50
 	:align: center
 	:width: 900px
@@ -60,7 +60,7 @@ Another problem with using happenstance data is that they are not taken in rando
 
 .. Other factors are always affecting the system. The operator mistakenly adjusts the temperature set point to 480K instead of 470K. The conversion value at the end of the shift is 3% higher. This "experiment" of sorts enters the collection of anecdotes that operators and engineers like to tell each other, and soon it becomes "accepted" that temperature can be used to improve conversion. However, it might have been a lower impurity in the raw materials, the new pump that was installed the previous day, improved controller tuning by another team of engineers, or any other event(s).
 
-Designed experiments are the only way we can be sure that these correlated events are causal. You often hear people repeat the (incomplete) phrase that "correlation does not imply causality". That is only half-true: the other half of the phrase is "correlation is a necessary, but not sufficient, condition for causality".
+Designed experiments are the only way we can be sure that these correlated events are causal. You often hear people repeat the phrase that "correlation does not imply causality". That is true, but it is worth adding the other half: some observable association is usually present when there is a causal link, but the association on its own is not sufficient evidence of it. (The association need not be a linear correlation; a genuine causal effect can show near-zero linear correlation when the relationship is curved or when competing mechanisms offset each other.)
 
 In summary, do not rely on anecdotal "evidence" from colleagues. Always question the system, and always try to perturb the system intentionally. In practice you won't always be allowed to move the system too drastically, so at the end of this chapter we will discuss :ref:`response surface methods <DOE-RSM>` and :ref:`evolutionary operation <DOE-EVOP>`, which can be implemented on-line in production processes.
 


### PR DESCRIPTION
This is the first of four PRs from a critique-and-repair sweep of Chapter 5 (Design and Analysis of Experiments). It covers the classical full-factorial, fractional-factorial, single-variable, and blocking sections. The RSM, new-design (optimal / DSD / OMARS / comparison), and exercises sections follow in separate PRs.

## What changed

**Technical corrections (verified numerically)**
- **Saturated-design code was not reproducible.** The Python block built the design with `itertools.product` (factor A varying *slowest*) but paired it with the standard-order `y` vector (A varying *fastest*), so running the shipped code returned coefficients with A and C swapped versus the prose, and interaction columns D/E/F/G that disagreed with the printed table and with the adjacent R block. Now built in Yates order; it reproduces `b = [70.7, -2.3, 0.1, -2.8, -0.4, 0.5, -0.4, -1.7]` exactly.
- `(X'X)^-1 S_E^2` was called "the general confidence interval"; it is the variance-covariance matrix. Renamed, and the coefficient CI is now given explicitly.
- The COST-vs-factorial variance table column headed "Fractional factorial approach" is actually a full `2^2` factorial. Renamed to "Factorial approach", with a note on the run-count trade-off.
- `S = (1.25 - 0.5)/2 = 0.875` was arithmetically wrong; corrected to `(1.25 + 0.5)/2`.
- Pairing redefined as blocking with blocks of size two (the previous "one factor vs more than one factor" split is nonstandard).
- Added a note that the group-difference statistic labelled `z` is really t-distributed (estimated variance).
- Softened the "correlation is a necessary condition for causality" claim.

**Clarity and typos**
- The `2^4` refit example ("Continuing the above example...") referenced a commented-out normal-probability example; rewritten to stand alone.
- Flag the factor-of-two between by-hand effects and least-squares coefficients at first use in the three-factor example.
- Fixed a mislabeled `ΔS` term, a missing transpose in `b = (X'X)^-1 X'y`, and several typos ("essentiall", "effect is soap", "discrete on", "complimentary").
- Replaced placeholder `fake width` alt text with real image descriptions.

**Reproducibility**
- Added a plotly Pareto code block before the full-factorial Pareto figure (reproduces the significant effects A, C, D, AC, AD).

## What did not change
The underlying worked examples and their headline numbers are unchanged (two-factor and three-factor factorial models, half-fraction confounding, `2^{7-4}` alias table, blocking derivation): all were re-derived and confirmed correct.

## Verification
- Every quoted number re-derived in Python (Pareto effects, saturated-design `b`, refit `S_E`).
- `make text` succeeds; no new warnings in the edited files (the pre-existing image-not-readable warnings come from the figures symlink being absent in the build sandbox, and are present on `main` too).

## Follow-up (later PRs / figures repo)
Some dated R/matplotlib figures in these sections (Pareto plots, line/surface plots, the COST/factorial variance chart) remain regeneration candidates; those will be handled with parallel figures-repo PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_012frH3Zp8ED142St9Xcff3B)_