### PR TITLE
DoE Ch.5 (3/4): optimal/DSD/OMARS/comparison fixes and section reorder

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.06.28"
-date-released: 2026-06-28
+version: "2026.07.02"
+date-released: 2026-07-02
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/design-analysis-experiments/comparing-design-families.rst
+++ b/design-analysis-experiments/comparing-design-families.rst
@@ -323,7 +323,7 @@ interactions across the columns:
 .. figure:: ../figures/doe/alias-matrix-heatmaps-four-designs.png
     :align: center
     :width: 750px
-    :alt: heatmaps-four-designs.py
+    :alt: Absolute alias-matrix heatmaps for the four candidate designs
 
     Absolute alias matrix :math:`|\mathbf{A}|` for the four designs (rows: the eleven fitted terms;
     columns: the ten omitted two-factor interactions). The Box-Behnken and composite designs hold
@@ -369,7 +369,7 @@ values:
 .. figure:: ../figures/doe/correlation-colormap-four-designs.png
     :align: center
     :width: 750px
-    :alt: heatmaps-four-designs.py
+    :alt: Absolute correlation colour maps among model-effect columns for the four designs
 
     Absolute correlation among the twenty model-effect columns, in three blocks (the main effects,
     the quadratics, and the two-factor interactions the model omits), separated by lines. The

--- a/design-analysis-experiments/definitive-screening-designs.rst
+++ b/design-analysis-experiments/definitive-screening-designs.rst
@@ -60,11 +60,12 @@ themselves identically. The consequences are:
         factor; and
 
     *   under effect sparsity (the common assumption that only a few of the many factors actually
-        drive the response), a sufficiently large design has a further useful property. Jones and
-        Nachtsheim show it for six factors or more, where the :math:`2k+1` runs comfortably exceed
-        the ten that a three-factor full quadratic needs: restricted to any three of the factors,
-        the runs already form a design able to fit the full quadratic model in just those three
-        factors. So if only a handful of factors turn out to matter, the same single set of runs
+        drive the response), a sufficiently large design has a further useful property. A three-factor
+        full quadratic has ten parameters, so the design needs at least ten runs, a count the
+        :math:`2k+1` runs already meet from :math:`k = 5`. Meeting the run count is necessary but not
+        sufficient: Jones and Nachtsheim (2011) prove the stronger result that from six factors
+        upward, restricted to *any* three of the factors, the runs form a design able to fit the full
+        quadratic model in just those three factors. So if only a handful of factors turn out to matter, the same single set of runs
         supports a complete response-surface model in them. (A small DSD cannot do this: the
         nine-run, four-factor design used as the running example in
         :ref:`Judging and comparing designs <DOE-judging-and-comparing-designs>` has fewer runs

--- a/design-analysis-experiments/index.rst
+++ b/design-analysis-experiments/index.rst
@@ -16,13 +16,13 @@ Design and Analysis of Experiments
    fractional-factorial-designs/index
    blocking-and-confounding-for-disturbances
    response-surface-methods
-   general-approach-for-experimentation
-   extended-topics-related-to-designed-experiments
    optimal-designs
    definitive-screening-designs
    omars-designs
    judging-and-comparing-designs
    comparing-design-families
+   general-approach-for-experimentation
+   extended-topics-related-to-designed-experiments
    design-analysis-experiments-exercises
 
 

--- a/design-analysis-experiments/judging-and-comparing-designs.rst
+++ b/design-analysis-experiments/judging-and-comparing-designs.rst
@@ -32,8 +32,8 @@ your mind:
 
 Both questions are answered by a single object built from the design: the information
 matrix :math:`\mathbf{M} = \mathbf{X}^T\mathbf{X}`, together with the optimality criteria
-that summarise it. Both are introduced in the previous section,
-:ref:`Optimal designs and OMARS designs <DOE-optimal-and-omars-designs>`, so here we take
+that summarise it. Both were introduced in the earlier section on
+:ref:`optimal designs <DOE-optimal-and-omars-designs>`, so here we take
 them as given. This subchapter shows how prediction variance is derived from
 :math:`\mathbf{M}`, how to read a fraction-of-design-space plot, and how the separability, bias,
 and power measures play out on one running comparison of two designs. The
@@ -84,7 +84,9 @@ climbs steeply (already :math:`5.2\,\sigma^2` at :math:`x = 1.5`): a quantitativ
 against extrapolation.
 
 This and every figure in this subchapter is reproducible with `process_improve
-<https://github.com/kgdunn/process-improve>`_ (``pip install 'process-improve[expt]'``).
+<https://github.com/kgdunn/process-improve>`_ (``pip install 'process-improve[all]'``, which
+includes the ``expt`` and ``ilp`` extras needed for the Box-Behnken, central composite, and
+OMARS designs used below).
 Each block imports what it needs and reuses variables defined in the blocks before it, so paste
 them in order. The prediction variance of the three-run quadratic design is a closed form:
 

--- a/design-analysis-experiments/optimal-designs.rst
+++ b/design-analysis-experiments/optimal-designs.rst
@@ -58,7 +58,7 @@ situations:
 
     *   **Some factors are hard to change.** Resetting an oven temperature between every run
         is slow or expensive, so you would like a design that changes it as seldom as
-        possible. (This leads to :ref:`split-plot <DOE-RSM>` structures.)
+        possible. (This leads to *split-plot* structures, a topic beyond the scope of this chapter.)
 
     *   **You already have a fixed list of candidate runs**, or you have already run several
         experiments and want to add a few more to sharpen the estimates.
@@ -230,11 +230,13 @@ variances live in the reciprocals :math:`1/\lambda`.
         single worst-case direction can degrade the average (A) and joint (D) measures noticeably.
         Mnemonic: E for the Eigenvalue of the worst-Estimated direction.
 
-    *   **G-** and **V-optimality** are about the variance of the *predictions* rather than the
-        coefficients directly. G-optimality minimizes the largest prediction variance anywhere in
-        the region; V-optimality (also called *I-* or *IV-optimality*) minimizes the *average*
-        prediction variance over the region. Both are built on the prediction variance, which we
-        develop in :ref:`Judging and comparing designs <DOE-judging-and-comparing-designs>`.
+    *   **G-**, **I-**, and **V-optimality** are about the variance of the *predictions* rather than
+        the coefficients directly. G-optimality minimizes the largest prediction variance anywhere in
+        the region. I-optimality (also called *IV-optimality*) minimizes the *average* prediction
+        variance over the whole region. V-optimality is the closely related criterion that averages
+        the prediction variance over a chosen finite set of points instead of over the whole region.
+        All three are built on the prediction variance, which we develop in
+        :ref:`Judging and comparing designs <DOE-judging-and-comparing-designs>`.
 
 D multiplies the eigenvalues, A sums their reciprocals, E looks at the extreme one: the same
 matrix, aggregated differently. That is why a design can score well on one criterion and poorly on
@@ -411,6 +413,11 @@ constraint boundary :math:`x_1 + x_2 = 1`. In other words it pushes the runs to 
 forbidden corner. The full quadratic model remains estimable throughout. No catalogue design could
 have produced this; the optimal design simply read off the constraint and the model and did the
 sensible thing.
+
+A D-optimal design is not unique: several different run allocations can share the same maximum
+:math:`\det(\mathbf{M})`. The table above is one such optimum; your own solver, or a different random
+start for the coordinate-exchange search, may return a different allocation of the ten runs that is
+equally D-optimal.
 
 .. figure:: ../figures/doe/constrained-d-optimal-region.png
     :align: center


### PR DESCRIPTION
Third of four PRs from the Chapter 5 (Design and Analysis of Experiments) critique-and-repair sweep. This one covers the newer design sections (optimal designs, definitive screening, OMARS, judging, comparing) and the chapter's section ordering.

## What changed

**Terminology / cross-reference corrections**
- **V-optimality was defined two ways.** `optimal-designs.rst` equated V-optimality with I-/IV-optimality (average prediction variance over the whole region), but `judging-and-comparing-designs.rst` correctly distinguishes them (V averages over a chosen finite point set). Aligned `optimal-designs.rst` to the standard definitions: I/IV = over the region, V = over a finite point set.
- **Broken split-plot reference.** `:ref:`split-plot <DOE-RSM>`` pointed at the response-surface section, which has no split-plot material, and there is no split-plot section. Reworded as a topic beyond the chapter's scope.
- **Inaccurate "previous section" reference.** In `judging-and-comparing-designs.rst`, "the previous section, Optimal designs and OMARS designs" was actually three sections back, and the hard-coded link text did not match that section's real title. Reworded to name it accurately without "previous".
- **Install line was incomplete.** The OMARS panels call `generate_omars`, which needs the `ilp` extra (`pulp`) on top of `expt` (`pyDOE3`); the single `[expt]` instruction would fail with an ImportError. Changed to `process-improve[all]`.
- **Duplicate alt text.** The alias-matrix and correlation-colormap figures shared identical placeholder alt text; each now has a descriptive one.
- **DSD three-factor projection rationale.** The text implied the "six factors or more" threshold followed from the run count (`2k+1 > 10`), which is already met at `k = 5`. Reworded: the run count is necessary (and met from `k = 5`), but the stronger any-three-projection property is what Jones and Nachtsheim (2011) prove from six factors upward.
- Added a note that a D-optimal design is not unique (a reader's own solver may return a different but equally-optimal allocation).

**Section reordering (teaching)**
The two summary/overview sections, "General approach for experimentation" (a whole-workflow capstone) and "Extended topics", sat *before* five technical design sections in the toctree, so the general-approach section read as a premature conclusion and extended-topics forward-referenced optimal designs. Both are moved to the end of the chapter, after the design catalogue and before the exercises. The optimal-designs → definitive-screening adjacency is preserved, so the "next section" reference there stays valid.

## Verification
- Box-Behnken / DSD / OMARS numeric tables in these sections were independently reproduced against `process_improve` in the review phase and are unchanged here (this PR only touches prose, cross-references, alt text, and ordering).
- Confirmed no positional cross-references break under the reorder (checked "previous/next section" usages and inbound `:ref:` targets); no undefined-label or toctree warnings.
- `make text` succeeds with no new warnings in the edited files.

## Follow-up
The `optimal-designs` worked example (constrained 10-run D-optimal design) still has no inline code. A faithful reproduction needs the `pyoptex` backend and the `Constraint`-object API, and the design is non-unique, so it is deferred to a focused follow-up rather than shipping an unverified block here.

---
_Generated by [Claude Code](https://claude.ai/code/session_012frH3Zp8ED142St9Xcff3B)_