### PR TITLE
DoE Ch.5 (4/4): exercise solution fixes + colourblind-safe figure

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.06.28"
-date-released: 2026-06-28
+version: "2026.07.02"
+date-released: 2026-07-02
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/design-analysis-experiments/design-analysis-experiments-exercises.rst
+++ b/design-analysis-experiments/design-analysis-experiments-exercises.rst
@@ -121,14 +121,14 @@ Exercises
 							 1 & -1 & +1 & -1 \\
 							 1 & +1 & +1 & +1
 			\end{bmatrix}
-			\begin{bmatrix} b_0 \\ b_\mathbf{A} \\ b_\mathbf{A} \\ b_\mathbf{AB} \end{bmatrix} + \begin{bmatrix}  e_1 \\ e_2 \\ e_3 \\ e_4 \end{bmatrix} \\
+			\begin{bmatrix} b_0 \\ b_\mathbf{A} \\ b_\mathbf{B} \\ b_\mathbf{AB} \end{bmatrix} + \begin{bmatrix}  e_1 \\ e_2 \\ e_3 \\ e_4 \end{bmatrix} \\
 			\begin{bmatrix}  3500 \\ 3610 \\ 3120 \\ 2505 \end{bmatrix} &=
 			\begin{bmatrix}  1 & -1 & -1 & +1 \\
 			                 1 & +1 & -1 & -1 \\
 							 1 & -1 & +1 & -1 \\
 							 1 & +1 & +1 & +1
 			\end{bmatrix}
-			\begin{bmatrix} b_0 \\ b_\mathbf{A} \\ b_\mathbf{A} \\ b_\mathbf{AB} \end{bmatrix} + \begin{bmatrix}  e_1 \\ e_2 \\ e_3 \\ e_4 \end{bmatrix}
+			\begin{bmatrix} b_0 \\ b_\mathbf{A} \\ b_\mathbf{B} \\ b_\mathbf{AB} \end{bmatrix} + \begin{bmatrix}  e_1 \\ e_2 \\ e_3 \\ e_4 \end{bmatrix}
 
 		And solving the regression coefficients (note the orthogonality in the :math:`\mathbf{X}^T\mathbf{X}` matrix):
 
@@ -149,7 +149,7 @@ Exercises
 							 0 & 0 & 0 & \tfrac{1}{4}
 			\end{bmatrix}
 			\begin{bmatrix}  12735 \\ -505 \\ -1485 \\ -725 \end{bmatrix} \\
-			\begin{bmatrix} b_0 \\ b_\mathbf{A} \\ b_\mathbf{A} \\ b_\mathbf{AB} \end{bmatrix} &= \begin{bmatrix}  3184 \\ -126  \\ -371 \\ -181 \end{bmatrix}
+			\begin{bmatrix} b_0 \\ b_\mathbf{A} \\ b_\mathbf{B} \\ b_\mathbf{AB} \end{bmatrix} &= \begin{bmatrix}  3184 \\ -126  \\ -371 \\ -181 \end{bmatrix}
 
 
 		The final model is :math:`y = 3184 - 126 x_\mathrm{A} - 371 x_\mathrm{B} - 181 x_\mathrm{AB}`.
@@ -313,7 +313,7 @@ Exercises
 		-	:math:`\widehat{b}_\mathbf{A} = -0.75 \rightarrow` **A + BCD** (previous estimate for **A**  was -0.625)
 		-	:math:`\widehat{b}_\mathbf{B} = 9.25 \rightarrow` **B + ACD** (previous estimate for **B**  was 9.9)
 		-	:math:`\widehat{b}_\mathbf{C} = 2.75 \rightarrow` **C + ABD** (previous estimate for **C**  was 4.0)
-		-	:math:`\widehat{b}_\mathbf{D} = -2.75 \rightarrow` **D + ABC** (previous estimate for **A**  was -3.9)
+		-	:math:`\widehat{b}_\mathbf{D} = -2.75 \rightarrow` **D + ABC** (previous estimate for **D**  was -3.9)
 		-	:math:`\widehat{b}_\mathbf{AB} = -5.75 \rightarrow` **AB + CD** (previous estimate for **AB**  was insignificant, while **CD** was -5.25)
 		-	:math:`\widehat{b}_\mathbf{AC} = 0.75 \rightarrow` **AC + BD** (previous estimates for both **AC** and **BD**  were insignificant)
 		-	:math:`\widehat{b}_\mathbf{AD} = 7.25 \rightarrow` **AD + BC** (previous estimate for **AD**  was insignificant, while **BC** was 6.4)
@@ -814,7 +814,7 @@ Exercises
 		In real-world units these points correspond to:
 
 		*	:math:`A_\text{actual} = 1.5 \times 10 \text{°C} + 150 \text{°C}` = 165 °C.
-		*	:math:`B_\text{actual} = 1.5 \times 0.5 \text{°C} + 7.5 \text{°C}` = 8.25 pH units.
+		*	:math:`B_\text{actual} = 1.5 \times 0.5 + 7.5` = 8.25 pH units.
 
 .. admonition:: Question
 
@@ -1186,7 +1186,7 @@ Exercises
 		*	Fix temperature at 40°C, implying that :math:`T^\text{(next)} = 40\text{°C}` and :math:`x_\text{T}^\text{(next)} = \frac{40-33}{3} = 2.33`.
 		*	Factor **G** must be run at the highest level possible, i.e. **G = Gp**
 		*	Factor **A** must be run at a lower level, specifically :math:`\Delta A = -0.25 \times 2.33 = -0.583`, or a deviation of -2.9 rpm from the baseline. Since we have to use integer values, that implies :math:`A^\text{(next)} = 12` rpm and :math:`x_\text{A}^\text{(next)} = \frac{12-15}{5} = -0.6`.
-		*	Factor **C** must be run at a higher level, specifically :math:`\Delta C = 3.5/4 \times 2.33 = 2.04`, or a deviation of +306 in actual units from the baseline. Since we have to round to the closest 50, that implies :math:`C^\text{(next)} = 1550` rpm and :math:`x_\text{C}^\text{(next)} = \frac{1550-1250}{150} = +2`.
+		*	Factor **C** must be run at a higher level, specifically :math:`\Delta C = 3.5/4 \times 2.33 = 2.04`, or a deviation of +306 in actual units from the baseline. Since we have to round to the closest 50, that implies :math:`C^\text{(next)} = 1550` concentration units and :math:`x_\text{C}^\text{(next)} = \frac{1550-1250}{150} = +2`.
 
 	#.	The predicted yield can be found by substituting the coded values into the model equation, choosing to either use or ignore the small interactions:
 
@@ -1196,7 +1196,7 @@ Exercises
 
 			\begin{array}{rcl}
 				y &=& 24 + 3 (+1) - 1.0 (-0.6) + 4.0 (2.33) - 0.2 (+1)(-0.6) - 0.79 (+1)(2.33) - 0.25(-0.6)(2.33) + 3.5 (+2) \\
-				y &=& {\bf 42.3}
+				y &=& {\bf 42.5}
 			\end{array}
 
 		Without interactions:


### PR DESCRIPTION
Fourth and final PR from the Chapter 5 (Design and Analysis of Experiments) critique-and-repair sweep. It fixes errors in the exercise solutions and regenerates the one rainbow-colormap figure.

## What changed

**Exercise solution corrections (all verified numerically)**
- **Web-sales solution:** the coefficient vector was printed as `[b₀, b_A, b_A, b_AB]` in three matrix equations; the third entry should be `b_B`. The final model line already used `x_B`, so it was a repeated label typo in the equations the student follows. Fixed all occurrences. (Recomputed `b = [3184, -126, -371, -181]`.)
- **Bioreactor solution (part 6):** "(previous estimate for **A** was -3.9)" sat on the `b_D` line and should read **D**.
- **Chemical-reaction solution:** "`1.5 × 0.5 °C + 7.5 °C = 8.25 pH units`" mislabeled pH units as degrees Celsius (factor B is pH). Removed the erroneous `°C` labels.
- **Biological-drug solution:** "`C = 1550 rpm`" mislabeled factor C (starting culture concentration, in concentration units) with factor A's `rpm` unit.
- **Biological-drug solution:** the with-interactions predicted yield was `42.3`; substituting the stated coded values gives `42.5` (`24 + 3 + 0.6 + 9.32 + 0.12 − 1.84 + 0.35 + 7 = 42.55`). The without-interactions value `43.9` is correct. Corrected to `42.5`.

**Figure (parallel repo)**
`chemical-reaction-contours.png` was the only Chapter 5 figure drawn with a rainbow colormap (MATLAB `hsv`). It is regenerated with a perceptually uniform, colourblind-safe colormap in **kgdunn/figures#33** (a matplotlib generator reproducing the exact model, plus a `parula` update to the archived MATLAB source). This PR's prose is unchanged by that; the two PRs should merge together.

## Verification
- Every corrected number re-derived in Python (web-sales coefficients, biological-drug yield `42.55 → 42.5`).
- `make text` succeeds with no new warnings in the exercises file (the pre-existing `Include file ... not found` and image-not-readable warnings come from the figures symlink being absent in the build sandbox, and are present on `main` too).

## Linked PR
- Figures: kgdunn/figures#33 (colourblind-safe `chemical-reaction-contours.png`).

---
_Generated by [Claude Code](https://claude.ai/code/session_012frH3Zp8ED142St9Xcff3B)_