### PR TITLE
DoE Ch.5: complete the blocking treatment and the multi-block case

### DIFF
--- a/design-analysis-experiments/blocking-and-confounding-for-disturbances.rst
+++ b/design-analysis-experiments/blocking-and-confounding-for-disturbances.rst
@@ -80,19 +80,21 @@ If the raw material has a significant effect on the response variable, then we w
 
 But the small loss due to this confusion of effects, is the gain that we can still estimate the main effects and two-factor interactions without bias, provided the effect of the disturbance is constant. Let's see how we get this result by denoting :math:`\widetilde{y}_i` as a :math:`y` response from the first batch of materials and let :math:`\mathring{y}_i` denote a response from the second batch.
 
-Using the least squares equations you can show for yourself that (some are intentionally left blank for you to complete):
+Each estimate is the corresponding column of :math:`\pm 1` signs applied to the responses. Writing :math:`\widetilde{y}` for a batch 1 response and :math:`\mathring{y}` for a batch 2 response, the seven contrasts are:
 
 	.. math::
 
 		\hat{\beta}_A    &= -\widetilde{y}_1 + \mathring{y}_2 - \mathring{y}_3 + \widetilde{y}_4 - \mathring{y}_5 + \widetilde{y}_6 - \widetilde{y}_7 + \mathring{y}_8 \\
-		\hat{\beta}_B    &= \\
-		\hat{\beta}_C    &= \\
+		\hat{\beta}_B    &= -\widetilde{y}_1 - \mathring{y}_2 + \mathring{y}_3 + \widetilde{y}_4 - \mathring{y}_5 - \widetilde{y}_6 + \widetilde{y}_7 + \mathring{y}_8 \\
+		\hat{\beta}_C    &= -\widetilde{y}_1 - \mathring{y}_2 - \mathring{y}_3 - \widetilde{y}_4 + \mathring{y}_5 + \widetilde{y}_6 + \widetilde{y}_7 + \mathring{y}_8 \\
 		\hat{\beta}_{AB} &= +\widetilde{y}_1 - \mathring{y}_2 - \mathring{y}_3 + \widetilde{y}_4 + \mathring{y}_5 - \widetilde{y}_6 - \widetilde{y}_7 + \mathring{y}_8\\
-		\hat{\beta}_{AC} &= \\
-		\hat{\beta}_{BC} &= \\
-		\hat{\beta}_{ABC} &= \\
+		\hat{\beta}_{AC} &= +\widetilde{y}_1 - \mathring{y}_2 + \mathring{y}_3 - \widetilde{y}_4 - \mathring{y}_5 + \widetilde{y}_6 - \widetilde{y}_7 + \mathring{y}_8 \\
+		\hat{\beta}_{BC} &= +\widetilde{y}_1 + \mathring{y}_2 - \mathring{y}_3 - \widetilde{y}_4 - \mathring{y}_5 - \widetilde{y}_6 + \widetilde{y}_7 + \mathring{y}_8 \\
+		\hat{\beta}_{ABC} &= -\widetilde{y}_1 + \mathring{y}_2 + \mathring{y}_3 - \widetilde{y}_4 + \mathring{y}_5 - \widetilde{y}_6 - \widetilde{y}_7 + \mathring{y}_8 \\
 
-Imagine now the :math:`y` response was increased by :math:`g` units for the batch 1 experiments, and increased by :math:`h` units for batch 2 experiments. You can prove to yourself that these biases will cancel out for all main effects and all two-factor interactions. The three factor interaction of :math:`\hat{\beta}_{ABC}` will however be heavily confounded.
+Now imagine the :math:`y` response was raised by :math:`g` units for every batch 1 experiment and by :math:`h` units for every batch 2 experiment. The bias this adds to a contrast is :math:`g` times the sum of that contrast's signs on the batch 1 runs, plus :math:`h` times the sum of its signs on the batch 2 runs. Take :math:`\hat{\beta}_A`: its batch 1 runs are 1, 4, 6, 7 with signs :math:`-, +, +, -` which sum to zero, and its batch 2 runs are 2, 3, 5, 8 with signs :math:`+, -, -, +` which also sum to zero, so the bias is :math:`0 \cdot g + 0 \cdot h = 0`. The same holds for every main effect and every two-factor interaction: each is orthogonal to the :math:`ABC` column that defines the blocks, so its signs balance within each batch and the biases :math:`g` and :math:`h` cancel exactly.
+
+The :math:`ABC` contrast is the exception. By construction batch 1 is the four runs with :math:`ABC = -1` and batch 2 the four with :math:`ABC = +1`, so :math:`\hat{\beta}_{ABC}` has all :math:`-1` signs on batch 1 and all :math:`+1` on batch 2. Its bias is :math:`(-4)g + (+4)h = 4(h - g)`: the whole batch-to-batch difference lands on :math:`\hat{\beta}_{ABC}`, which is why the block is confounded with the three-factor interaction and nowhere else. This is exactly the outcome we wanted: the disturbance is quarantined in the one effect we expected to be negligible, leaving all the main effects and two-factor interactions clean.
 
 Another way to view this problem is that the first batch of materials and the second batch of materials can be represented by a new variable, called :math:`D` with value of :math:`D_{-} =` batch 1 and :math:`D_{+} =` batch 2. We will show next that we must consider this new factor to be generated from the other three: **D = ABC**.
 

--- a/design-analysis-experiments/fractional-factorial-designs/generators-defining-relationships-blocking.rst
+++ b/design-analysis-experiments/fractional-factorial-designs/generators-defining-relationships-blocking.rst
@@ -128,84 +128,32 @@ Here are the block generators you can use when splitting a :math:`2^k` factorial
 | 5         | :math:`2^{5-1}` | **I=ABCDE**                   | **I=-ABCDE**                  |
 +-----------+-----------------+-------------------------------+-------------------------------+
 
-.. My notes on this section are not clear:  how to clearly illustrate that A will be aliased with DE?  And how is it obvious that this aliasing with DE (the block effect contrast) is problematic?  Perhaps use an example where the blocks are biased and factor A was never really significant.
 
-	What if the block effect has more than two levels?  For example, for a :math:`2^3` factorial, there is only enough material for 2 experiments. So :math:`g=4` groups of experiments will be run. How do we assign these groups to minimize confounding?  Find the smallest full factorial that can accommodate these :math:`g` groups, in this case a :math:`2^2` factorial. Write out this factorial and assign the groups accordingly:
+Blocking into more than two groups
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-	.. tabularcolumns:: |c||c|c|c|
+What if the disturbance has more than two levels? Suppose we must run a :math:`2^3` factorial, but there is only enough material for two experiments from each lot, so the eight runs are split across four lots. We have :math:`g = 4` groups, and we want to arrange them so that the differences between lots do the least damage.
 
-	+-------------------+-------------+-------------+
-	| Lot of material   | D           | E           |
-	+===================+=============+=============+
-	|  1                | |-|         | |-|         |
-	+-------------------+-------------+-------------+
-	|  2                | |+|         | |-|         |
-	+-------------------+-------------+-------------+
-	|  3                | |-|         | |+|         |
-	+-------------------+-------------+-------------+
-	|  4                | |+|         | |+|         |
-	+-------------------+-------------+-------------+
+Find the smallest full factorial that can index the :math:`g` groups: here a :math:`2^2` factorial, with two new indicator variables **D** and **E** labelling the four lots.
 
-	It is as if we are introducing two new variables into our :math:`2^3` factorial: in addition to the factors **A**, **B** and **C**, we also have factors **D** and **E** corresponding to the different groups of materials. For example, when we use lot 3, then :math:`D = -1` and :math:`E = +1`.
+.. tabularcolumns:: |c||c|c|
 
-	How do we assign **D** and **E** so that the confounding is minimized?  We might be tempted to use **D = ABC** and then assign **E** to **BC**, an interaction that we are not concerned
-	about. The generators are then **I = ABCD** and **I = BCE** respectively. The *defining relationship* is found from all possible products of all generators. In this case there are just two generators, so the defining relationship, which is the product of all generators is: **I = ABCD = BCE = ADE**.
++-------------------+-------------+-------------+
+| Lot of material   | D           | E           |
++===================+=============+=============+
+|  1                | |-|         | |-|         |
++-------------------+-------------+-------------+
+|  2                | |+|         | |-|         |
++-------------------+-------------+-------------+
+|  3                | |-|         | |+|         |
++-------------------+-------------+-------------+
+|  4                | |+|         | |+|         |
++-------------------+-------------+-------------+
 
-	Now let's calculate the aliasing structure:
+It is as if we have added two new variables to the :math:`2^3` factorial: alongside the real factors **A**, **B** and **C**, the block indicators **D** and **E** record which lot was used (for lot 3, :math:`D = -1` and :math:`E = +1`). Three contrasts carry the differences among the four lots: **D**, **E**, and their product **DE**. The goal is to keep those three block contrasts away from the effects we care about, and especially away from the main effects.
 
-		-	A: aliased with A + BCD + ABCE + DE
-		-	Fix this: **B x ADE = ABDE**
-		-	Fix this: **C x ADE = ACDE**
-		-	Fix this: **AB x ADE = BDE**
-		-	Fix this: **AC x ADE = CDE**
-		-	Fix this: **BC x ADE = ABCDE**
-		-	Fix this: **ABC x ADE = BCDE**
+A tempting but poor choice is **D = ABC** and **E = BC**. The generators are then **I = ABCD** and **I = BCE**, and the defining relationship is the product of all the generators, **I = ABCD = BCE = ADE** (the product **ABCD** :math:`\times` **BCE** repeats **B** and **C**, and any letter times itself is the identity, which leaves **ADE**). The three block contrasts are therefore **D = ABC**, **E = BC**, and **DE = A**. That last one is the trouble: **DE = A** means the difference between the lots is confounded with the main effect of **A**. If the lots happen to differ, that difference is indistinguishable from a real **A** effect, and a main effect is what we least want to lose.
 
-	This indicates the main effect of **A** is aliased with the two-factor interaction **DE**. Why is this problematic?
+A better choice is **D = AB** and **E = AC** (any two distinct two-factor interactions will do). The generators are **I = ABD** and **I = ACE**, giving the defining relationship **I = ABD = ACE = BCDE** (the product **ABD** :math:`\times` **ACE** repeats **A**, which cancels to the identity, leaving **BCDE**). Now the three block contrasts are **D = AB**, **E = AC**, and **DE = BC**, all two-factor interactions. No main effect is confounded with a block; the price of blocking falls entirely on the three two-factor interactions **AB**, **AC** and **BC**, which is usually acceptable.
 
-	The other effects are confounded with three-factor interactions
-
-	A better choice of generators is **D = AB** and **E = AC** (or use the other two-factor interaction). Now calculate:
-
-		-	The defining relationship =
-
-			.. I = ABD = ACE = ABD x ACE = BCDE
-
-		-	Aliasing for:
-
-			* **A**
-			* **B**
-			* **C**
-			* **AB**
-			* **AC**
-			* **BC**
-			* **ABC**
-
-	Rather than determine the best aliasing structure by trial-and-error, refer to a table, such as Table 5A.1 (page 221) in the second edition of Box, Hunter and Hunter to read which generators should be assigned to which blocks to minimize confounding. For this example, you would use the row in the table with :math:`k=3`, block size = 2 (two experiments per block). Another example is given in this same reference, page 219, that describes how a 64 run experiments is broken down into 8 blocks of 8 runs.
-
-.. Don't try this example: it's still too early.
-	For example, for a :math:`2^3` factorial, the block size is 3 experiments when there is only enough material for 3 experiments. So two experiments will be run with one lot of material, then 3 runs with another lot, and then the final 3 runs.
-
-	Start by rounding down to the closest power of 2, which is :math:`p = 2^1 = 2` in this case. Create a full factorial with :math:`2^p` runs. Assign the blocks according to the different runs in this factorial:
-
-	.. tabularcolumns:: |c||c|c|c|
-	                          D              E
-	+-------------------+-------------+-------------+
-	| Batch of material | :math:`B_1` | :math:`B_2` |
-	+===================+=============+=============+
-	|  1                | |-|         | |-|         |
-	+-------------------+-------------+-------------+
-	|  2                | |+|         | |-|         |
-	+-------------------+-------------+-------------+
-	|  3                | |-|         | |+|         |
-	+-------------------+-------------+-------------+
-	|  4 (ignored)      | |+|         | |+|         |
-	+-------------------+-------------+-------------+
-
-	B_1: I=ABCD;
-	B_2: I=BCE
-
-	overall generator: ABCD.BCE = ADE
-	A: DE
-	B: ABDE
-	C: ACDE
+Rather than search for the best assignment by trial and error, you can read it from a table, such as Table 5A.1 (page 221) in the second edition of Box, Hunter and Hunter, which lists the generators to use for each combination of factor count and block size. For this example you would use the row with :math:`k = 3` and a block size of 2. The same reference (page 219) works a larger case: a 64-run experiment split into 8 blocks of 8 runs.


### PR DESCRIPTION
Second of the deeper Chapter 5 round. The author's own hidden notes flagged the blocking material as unclear and incomplete ("my notes on this section are not clear... how to illustrate that A will be aliased with DE?"). This completes it and fixes an error.

## What changed

**`blocking-and-confounding-for-disturbances.rst`**
- **Filled in the five contrasts left blank** in the text (`β_B, β_C, β_AC, β_BC, β_ABC`); all verified against the design matrix.
- **Replaced "you can prove to yourself" with an actual short proof** of the bias cancellation. The bias a batch effect adds to a contrast is `g` × (sum of its signs on batch 1) + `h` × (sum on batch 2). For every main effect and two-factor interaction those within-batch sign sums are zero (each is orthogonal to the `ABC` column that defines the blocks), so `g` and `h` cancel exactly. Only `β_ABC`, whose signs are all `−1` on batch 1 and all `+1` on batch 2, carries the batch difference `4(h − g)`. The disturbance is quarantined in the one effect we expected to be negligible.

**`generators-defining-relationships-blocking.rst`**
- **Un-commented and corrected the "more than two blocks" case**, which was entirely hidden in a source comment. Fixed the erroneous line "A: aliased with A + BCD + ABCE + DE" (an effect is not among its own aliases) and, crucially, supplied the point the section was missing: with the poor generators `D=ABC, E=BC` the defining relation gives **DE = A**, so a block contrast is confounded with a main effect; with `D=AB, E=AC` the three block contrasts are **AB, AC, BC** (all two-factor interactions) and no main effect is confounded. Both defining relations were verified numerically.
- Dropped the incomplete, commented block-size-3 fragment.

## Verification
- All seven blocking contrasts and both 4-block defining relations reproduced in numpy (batch sign-sums: 0 for every main effect and 2fi, ±4 for ABC; bad choice → DE≡A, good choice → block contrasts AB/AC/BC).
- `make text` and `make html` succeed with no new warnings; `grep goatcounter` → 0.

No figures change in this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_012frH3Zp8ED142St9Xcff3B)_