### PR TITLE
Chapter 1: correct box plot definitions and univariate plot advice

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.07.02"
-date-released: 2026-07-02
+version: "2026.07.03"
+date-released: 2026-07-03
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/data-visualization/bar-plots.rst
+++ b/data-visualization/bar-plots.rst
@@ -74,7 +74,8 @@ Here is some advice for bar plots:
 
 -	You can place the labels inside the bars.
 
--	You should start the noncategory axis at zero: the bar's area shows the magnitude. Starting bars at a nonzero value distorts the meaning.
+-	Start the value axis at zero: the reader judges each category by the length of its bar, so bars
+	that start at a nonzero value distort the comparison.
 
 ..
   Exception to starting at zero: todo Few, p 189 (ranges)

--- a/data-visualization/box-plots.rst
+++ b/data-visualization/box-plots.rst
@@ -90,6 +90,16 @@ a single function call, reusing the ``boards`` data frame loaded above:
 	fig.update_layout(xaxis_title_text="Thickness [mils]")
 	fig.show()
 
+.. image:: ../figures/visualization/raincloud-for-two-by-six-100-boards.png
+	:align: center
+	:scale: 55
+	:width: 900px
+	:alt: Raincloud plot of the board thickness at the six positions; each group shows a density curve, a box plot, and the jittered raw observations.
+
+The rainclouds confirm what the box plot showed, and add to it: the rain under position 1 shows the
+raw observations bunched around 1680 mils with stray points on both sides, and no second cluster
+hiding inside the box.
+
 
 **Example**
 

--- a/data-visualization/box-plots.rst
+++ b/data-visualization/box-plots.rst
@@ -8,11 +8,13 @@ Box plots
 	single: quartile
 	single: median, in a box plot
 	single: Wickham, Hadley
-	single: Stryjewsk, Lisa
+	single: Stryjewski, Lisa
+	single: Tukey, John
 
 :index:`Box plots <pair: box plot; visualization>` are an efficient summary of one variable (univariate chart), but can also be used effectively to compare variables that are in the same units of measurement.
 
-The box plot shows the so-called :index:`five-number summary <pair: five-number summary; box plot>` of a univariate data series:
+The box plot is built around the so-called :index:`five-number summary
+<pair: five-number summary; box plot>` of a univariate data series:
 
 1. Minimum sample value
 2. 25th `percentile <https://en.wikipedia.org/wiki/Percentile>`_ (1st `quartile <https://en.wikipedia.org/wiki/Quartile>`_)
@@ -20,9 +22,19 @@ The box plot shows the so-called :index:`five-number summary <pair: five-number 
 4. 75th percentile (3rd quartile)
 5. Maximum sample value
 
-The 25th percentile is the value below which 25% of the observations in the sample are found. The distance from the 3rd to the 1st quartile is also known as the :index:`interquartile range (IQR) <pair: interquartile range; box plot>` and represents the data's spread, similar to the standard deviation.
+The 25th percentile is the value below which 25% of the observations in the sample are found. The
+box spans from the 25th percentile (the box's lower edge) to the 75th percentile (the box's upper
+edge). The distance between those two edges, from the 1st to the 3rd quartile, is known as the
+:index:`interquartile range (IQR) <pair: interquartile range; box plot>`. The IQR is a measure of
+the data's spread, playing a similar role to the standard deviation, but it is less influenced by
+extreme values. In the simplest form of the plot the whiskers span the entire data range, from
+minimum to maximum; most software packages instead draw the whiskers by the convention described at
+the end of this section.
 
-The following data are thickness measurements of 2-by-6 boards (2-by-6 refers for the thickness and depth of a wooden board), taken at six locations around the edge. Here is a sample of the measurements and a summary of the first 100 boards (code in Python and R respectively):
+The following data are thickness measurements of 2-by-6 boards (2-by-6 refers to the nominal
+thickness and width of the wooden board, in inches), taken at six locations around the edge. Here is
+a sample of the measurements and a summary of the first 100 boards (code in Python and R
+respectively):
 
 .. literalinclude:: /data-visualization/gists/board-thickness-boxplot.py
 	:language: python
@@ -40,21 +52,52 @@ The following box plot is a graphical summary of these numbers.
 	:width: 900px
 	:alt: fake width
 
-A box plot is great for comparisons. In this figure we see how the thickness at position 1 is greater than at the other positions. It is also the position with high variability, indicating that something about the saw blade at that position is not what it should be. The median is also not balanced between the two quantiles for this box plot, when compared to the others.
+A box plot is great for comparisons. In this figure we see how the thickness at position 1 is
+greater than at the other positions. Position 1 also shows high variability: its whiskers span a
+wide range and several points lie beyond them. This indicates that something about the saw blade at
+that position is not what it should be. The median is also not centered between the two quartiles
+for this box plot, when compared to the others.
 
 Some variations for the box plot are possible:
 
-- Show :index:`outliers <pair: outlier; box plot>` as dots, where an outlier is most commonly defined as any point 1.5 IQR distance units away from the box. The box's upper bound is at the 25th percentile, and the boxes lower bound is at the 75th percentile.
-- The :index:`whiskers <pair: whisker; box plot>` on the plots are drawn *at most* 1.5 IQR distance units away from the box, however, if the whisker is to be drawn beyond the bound of the data vector, then it is redrawn at the edge of the data instead (i.e. it is clamped, to avoid it exceeding).
+- Show suspected :index:`outliers <pair: outlier; box plot>` as individual dots. The most common
+  rule, due to :index:`John Tukey <single: Tukey, John>`, flags any point lying more than 1.5 IQR
+  units beyond the edges of the box: below the box's lower edge (the 25th percentile), or above the
+  box's upper edge (the 75th percentile). Points beyond these fences are worth investigating, but
+  they are not necessarily errors: for normally distributed data about 0.7% of the observations
+  fall outside the fences, so a few flagged points are expected in large samples.
+- When that rule is used, the :index:`whiskers <pair: whisker; box plot>` are not drawn to the
+  sample minimum and maximum. Each whisker extends to the most extreme data point that still lies
+  within 1.5 IQR units of the box's edge, and the flagged points are drawn individually beyond the
+  whiskers. This is the default in most software packages.
 - Use the mean instead of the median [*not too common*].
-- Use the 2% and 98% percentiles rather than the upper and lower hinge values.
+- Draw the whiskers at fixed percentiles instead, such as the 2nd and 98th percentiles, rather than
+  at the most extreme points within the 1.5 IQR fences.
+
+A more recent variation is the :index:`raincloud plot <pair: raincloud plot; visualization>`, which
+combines three views of the same variable: a one-sided density curve (the "cloud"), the box plot,
+and the jittered raw observations (the "rain"). Showing the raw points guards against the box
+plot's main weakness: distributions that differ in important ways can still produce the same
+five-number summary. The accompanying ``process_improve`` library draws one raincloud per group with
+a single function call, reusing the ``boards`` data frame loaded above:
+
+.. code-block:: python
+
+	from process_improve.visualization import raincloud
+
+	stacked = boards.melt(var_name="Position", value_name="Thickness")
+	fig = raincloud(stacked, value="Thickness", group="Position")
+	fig.update_layout(xaxis_title_text="Thickness [mils]")
+	fig.show()
 
 
 **Example**
 
 In a final exam for a particular course at McMaster University there was an open-ended question. These `data values are the grades <https://openmv.net/info/systematic-method>`_ achieved for the answer to that question, broken down by whether the student used a systematic method, or not. No grades were given for using a systematic method; grades were awarded only for answering the question.
 
-A systematic method is any method that assists the student with problem solving. For example, a strategry could be to: define the problem, identify knowns/unknowns and assumptions, explore alternatives, plan a strategy, implement the strategy and then check the solution.
+A systematic method is any method that assists the student with problem solving. For example, a
+strategy could be to: define the problem, identify knowns/unknowns and assumptions, explore
+alternatives, plan a strategy, implement the strategy and then check the solution.
 
 Draw two box plots next to each other that compare the grades of students who did, or did not use a problem solving strategy. Comment on any features you notice in the comparison.
 
@@ -69,10 +112,14 @@ Several points are apparent in the box plot:
 
 * students in either category achieved the highest grade possible
 * the spread (interquartile distance) when using the problem solving method is smaller
-* both box plots show a skew to the lower left tail (compare the median to the first and third quartiles)
+* both box plots show a skew towards the lower grades (compare the distance from the median to each
+  of the first and third quartiles)
 * we will use a :ref:`confidence interval <univariate-group-to-group-differences-no-reference-set>` in a later chapter to judge whether this difference is statistically significant or not.
 
 
 **More readings**
 
-You can read more about box plots in the `paper by Hadley Wickham and Lisa Stryjewsk <https://vita.had.co.nz/papers/boxplots.pdf>`_. It summarizes variations of this plot, such as the :index:`violin plot <pair: violin plot; visualization>`, and two-dimensional versions of it. It is a power summary plot that has been around since 1970.
+You can read more about box plots in the `paper by Hadley Wickham and Lisa Stryjewski
+<https://vita.had.co.nz/papers/boxplots.pdf>`_. It summarizes variations of this plot, such as the
+:index:`violin plot <pair: violin plot; visualization>`, and two-dimensional versions of it. The box
+plot is a powerful summary plot, introduced by John Tukey around 1970.

--- a/data-visualization/time-series-plots.rst
+++ b/data-visualization/time-series-plots.rst
@@ -7,7 +7,7 @@ Time-series plots
 
 We start off by considering a plot most often seen in engineering applications: the :index:`time-series plot <pair: time-series plots; visualization>`. The time-series plot is a univariate plot: it shows only one variable. It is a 2-dimensional plot in which one axis, the time-axis, shows graduations at an appropriate scale (seconds, minutes, weeks, quarters, years), while the other axis shows the numeric values. Usually, the time-axis is displayed horizontally, but this is not a requirement: some interesting analysis can be done with time running vertically.
 
-Many statistical packages call this a :index:`line plot <pair: line plot; visualization>`, as it can be used generally to display any sort of sequence, whether it is along time or some other ordering. The time-series plot is an excellent way to visualize long sequences of data. It tells a visual story along the sequence axis, and the human brain is incredible at absorbing this high density of data, locating patterns in the data such as sinusoids, spikes, and outliers, and separating any noise from signal.
+Many statistical packages call this a :index:`line plot <pair: line plot; visualization>`, as it can be used generally to display any sort of sequence, whether it is along time or some other ordering. The time-series plot is an excellent way to visualize long sequences of data. It tells a visual story along the sequence axis, and the human brain is remarkably good at absorbing this high density of data, locating patterns in the data such as sinusoids, spikes, and outliers, and separating any noise from signal.
 
 Here are some tips for effective time-series plots:
 
@@ -29,26 +29,37 @@ Here are some tips for effective time-series plots:
 	.. literalinclude:: /data-visualization/gists/time-series-plot.py
 		:language: python
 
-.. AU: The last sentence in the following paragraph seemed a little convoluted. Please verify edits.
-
--	When plotting more than one trajectory (a vector of values) against time, it is helpful if the lines do not cross or jumble too much. This allows you to clearly see the relationship with other variables. The use of a second *y*-axis on the right-hand side is helpful when plotting two trajectories, but when plotting three or more trajectories that are in the same numeric range, it is better to use several :index:`parallel axes <pair: parallel axes; visualization>`.
+-	When plotting more than one trajectory (a vector of values) against time, it is helpful if the
+	lines do not cross or jumble too much. This allows you to clearly see the relationship with
+	other variables. A second *y*-axis on the right-hand side is sometimes used when plotting two
+	trajectories that have different units or ranges. Interpret such plots with care: the two
+	vertical scales are chosen independently of each other, so the point where the lines cross, and
+	how strongly the lines appear to move together, depends on the scaling and is not a property of
+	the data. When plotting three or more trajectories that are in the same numeric range, it is
+	better to use several :index:`parallel axes <pair: parallel axes; visualization>`.
 
 	.. _visualization-cluttered-trajectories:
 
 	.. image:: ../figures/visualization/three_correlated_variables_-_badly_displayed_in_Numbers.png
 
-.. AU: The term "here" is ambiguous. In the following paragraph, is "here" referring to the figures above and below?
+	The previous figure shows this jumbled result, drawn with the default settings of a spreadsheet
+	package (Apple iWork's *Numbers*, 2009). Differently coloured lines and/or markers may work in
+	selected instances, but with three trajectories the lines already clutter each other.
 
-	As shown in the previous figure, even using differently coloured lines and/or markers may work in selected instances, but this still leads to a clutter of lines and markers. The following chart shows this principle, created with the default settings from Apple iWork's *Numbers* (2009).
-
-	Using different markers, improving the axis labelling, tightening up the axis ranges, and thinning out the ink improves the chart slightly. This took about 3 minutes extra in the software, because I had not used the software before and had to find the settings.
+	Using different markers, improving the axis labelling, tightening up the axis ranges, and
+	thinning out the ink improves the chart slightly, as shown next. This took about 3 minutes extra
+	in the software, because I had not used the software before and had to find the settings.
 
 	.. figure:: ../figures/visualization/three_correlated_variables_-_slightly_better.png
 
-	This final example with parallel axes is greatly improved, but took about 10 minutes to assemble and would likely take a similar amount of time to format in MATLAB, Excel, Python or other packages. The results are clearer to interpret: variables "Type A" and "Type B" move up and down together, while variable "Type C" moves in the opposite direction. Note how the *y*-axis for "Type C" is rescaled to start from its minimum value, rather than a value of zero. You should always use "tight" limits on the *y*-axis.
+	The version below, with parallel axes, is greatly improved. It took about 10 minutes to
+	assemble, and would likely take a similar amount of time to format in MATLAB, Excel, Python or
+	other packages. The results are clearer to interpret: variables "Type A" and "Type B" move up
+	and down together, while variable "Type C" moves in the opposite direction. Note how the
+	*y*-axis for "Type C" is rescaled to start from its minimum value, rather than a value of zero.
+	Use tight limits on the *y*-axis, so that the vertical space is used to show the data.
 
-
-.. image:: ../figures/visualization/three_correlated_variables_-_better.png
+	.. image:: ../figures/visualization/three_correlated_variables_-_better.png
 
 -	Using the same data as in the previous tip, a much improved visualization technique is to use sparklines to represent the sequence of data.
 
@@ -59,7 +70,14 @@ Here are some tips for effective time-series plots:
 			:scale: 50
 			:align: center
 
-	Sparklines are small graphics that carry a high :index:`density of information <pair: data density; visualization>`. The human eye is easily capable of absorbing about 100 dots or points per linear centimeter and around 10000 points per square centimeter. These :index:`sparklines <pair: sparklines; visualization>` convey the same amount of information as the previous plots and are easy to consume on hand-held devices such as cellphones and tablet computing devices that are common in chemical plants and other engineering facilities. Read more about them from `this hyperlink <https://www.edwardtufte.com/bboard/q-and-a-fetch-msg?msg_id=0001OR>`_.
+	Sparklines are small graphics that carry a high :index:`density of information
+	<pair: data density; visualization>`. Tufte, who introduced them, estimates that the human eye
+	can comfortably resolve around 100 points per linear centimeter, and around 10000 points per
+	square centimeter. These :index:`sparklines <pair: sparklines; visualization>` show the same
+	data as the previous plots in a fraction of the space, and are easy to consume on hand-held
+	devices such as cellphones and tablet computing devices that are common in chemical plants and
+	other engineering facilities. Read more about them in `Tufte's essay on sparklines
+	<https://www.edwardtufte.com/notebook/sparkline-theory-and-practice-edward-tufte/>`_.
 
 
 -	When plotting money values over time (e.g. sales of your product over the past 10 years), adjust for :index:`inflation effects <single: inflation; adjusting for>` by dividing by the consumer price index or an appropriate factor. Distortions due to the time value of money can be very misleading, as this `example of retail sales shows <https://people.duke.edu/~rnau/411infla.htm>`_. For Canadians, here is a `Canadian inflation calculator <https://www.bankofcanada.ca/rates/related/inflation-calculator>`_ from the Bank of Canada that can help you. For most countries you can almost certainly find something similar from the country's national bank or a government office.


### PR DESCRIPTION
Part 1 of 3 of a critique-and-repair sweep of chapter 1 (Visualizing Process Data). This PR covers the univariate plot sections: time-series plots, bar plots, and box plots. Companion PRs: #197 (scatter plots, tables, style), #198 (exercises), and kgdunn/figures#36 (the raincloud PNG embedded here).

> [!IMPORTANT]
> **Merge order: kgdunn/figures#36 must merge before this PR's CI can pass.** The build-and-deploy workflow checks out `kgdunn/figures` at its default branch, so the raincloud PNG referenced here is missing until figures#36 lands; the latexpdf step then fails with "File ... raincloud-for-two-by-six-100-boards.png not found". Once figures#36 is merged, re-run the failed job here (I will re-trigger it automatically at my next scheduled check-in if it has merged by then). The first commit of this PR built green on its own.

## What changed

**Box plots (the most heavily visited section, and the one with a real error):**
- The box edges were described inverted: "The box's upper bound is at the 25th percentile, and the boxes lower bound is at the 75th percentile." Now stated correctly (lower edge = 25th, upper edge = 75th), and the box/IQR relationship is explained where the IQR is introduced.
- The section claimed the box plot shows the five-number summary (with sample minimum and maximum) and, three bullets later, that whiskers stop at 1.5 IQR. The two conventions are now reconciled: the min/max version is the simplest form, and Tukey's 1.5 IQR whisker-and-fence convention (the software default) is described as one coherent rule, with a note that ~0.7% of normally distributed data falls outside the fences, so flagged points are suspected outliers, not certain errors.
- The 2%/98% variation was described as replacing "the upper and lower hinge values" (the hinges are the box edges); it replaces the whisker ends.
- The box plot is now attributed to John Tukey; "power summary plot" -> "powerful"; "Stryjewsk" -> "Stryjewski"; "quantiles" -> "quartiles"; "strategry" -> "strategy"; "2-by-6 refers for the thickness and depth" -> nominal thickness and width in inches.
- Added a raincloud plot example drawn with the accompanying `process_improve` library (`process_improve.visualization.raincloud`), reusing the `boards` data frame already loaded in the section. The code block was executed against the real six-point board thickness CSV, and the rendered output is embedded as a figure (PNG in kgdunn/figures#36, generated from the exact call shown in the chapter) with a short paragraph reading the rainclouds against the box plot interpretation.

**Time-series plots:**
- The dual y-axis tip recommended second axes without qualification. Experts flag this hard: where the lines cross and how strongly they appear to co-move is an artifact of two independently chosen scales. The tip now says so.
- The three-trajectories walkthrough referred to figures out of order ("The following chart" for a figure already shown; the parallel-axes figure appeared after the paragraph discussing it, outside the list item). Restructured so each figure is referenced in order, resolving the two `AU:` editorial notes left in the source.
- The sparkline claim "convey the same amount of information as the previous plots" softened to "show the same data in a fraction of the space", and the 100 points/cm density figures are attributed to Tufte as estimates rather than stated as perceptual fact.
- The Tufte sparklines link pointed at the retired `bboard` URL (now a 301 to a generic index); replaced with the live essay URL.
- "the human brain is incredible at" -> "remarkably good at".

**Bar plots:**
- The zero-baseline rule was justified by "the bar's area shows the magnitude"; the reader actually judges bars by length (width is constant). Reworded, and "noncategory axis" replaced with the value-axis term the section itself defines.

## What did not change

The underlying analyses and datasets are unchanged; the board-thickness box plot figure was checked against the prose and supports the (reworded) interpretation. The only new figure is the raincloud PNG from kgdunn/figures#36.

## Verification

- `make text`: zero warnings, zero errors.
- `make html`: builds clean; `grep -r goatcounter _build/html/contents` returns zero hits; extensionless output confirmed; the raincloud image resolves in the built box-plots page (local build, with the figures branch symlinked).
- The new raincloud code block runs end-to-end against the real dataset with `process_improve` installed from source; the embedded PNG is that figure's rendered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdbBix33WkbeVQzqJuBarQ