### PR TITLE
Chapter 1: explain the lurking-variable example, fix causality and colour advice

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.07.02"
-date-released: 2026-07-02
+version: "2026.07.03"
+date-released: 2026-07-03
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/data-visualization/aesthetics-style-and-general-tips.rst
+++ b/data-visualization/aesthetics-style-and-general-tips.rst
@@ -12,8 +12,9 @@ Data frames (axes)
 
 Frames are the basic containers that surround the data and give context to our numbers. Here are some tips:
 
-#.	Use round numbers.
-#.	Generally, tighten the axes as much as possible, except ...
+#.	Use round numbers for the axis limits and tick marks.
+#.	Generally, tighten the axes as much as possible. Two exceptions: bar plots, where the value
+	axis must include zero, and comparison plots, described next.
 #.	When showing comparison plots, all axes must have the same minima and maxima.
 
 .. TODO: give an example of a bad visualization here that has unequal axes for comparison
@@ -23,7 +24,18 @@ Colour
 
 :index:`Colour <pair: colour; visualization>` is very effective in all graphical charts. However, you must bear in mind that your readers might be :index:`colour-blind <single: colour-blindness>`, or the document might be read from a :index:`grayscale <single: grayscale>` printout, or viewed on an electronic device where colours are shown differently than you might intend.
 
-Note also that a standard colour progression does *not* exist. We often see dark blues and purples representing low numbers and reds the higher numbers, with greens, yellows and orange in-between. There are several such `colour schemes <https://en.wikipedia.org/wiki/Color_scheme>`_ - there isn't a universal standard. The only safest colour progression is the grayscale axis, ranging from black to white at each extreme: this satisfies both colour-blind readers and users of your grayscale printed output.
+Note also that a single standard colour progression does *not* exist. We often see dark blues and
+purples representing low numbers and reds the higher numbers, with greens, yellows and orange
+in-between. There are several such `colour schemes
+<https://en.wikipedia.org/wiki/Color_scheme>`_ - there isn't a universal standard. Most plotting
+software now defaults to a colour scale designed to be *perceptually uniform*: equal steps in the
+data appear as equal steps in colour, the scale converts sensibly to grayscale, and it remains
+readable for colour-blind readers. Examples are the ColorBrewer schemes of Harrower and Brewer
+(2003), listed in the :ref:`references <visualization_references>`, and the viridis and cividis
+colour maps that ship with matplotlib, Plotly and R. Avoid the older rainbow (or "jet") colour
+scale: its perceived brightness rises and falls along the scale, which creates bands and false
+boundaries that are not in the data. A grayscale axis, ranging from black to white, remains a safe
+progression for printed output.
 
 See the :ref:`section on scatter plots <reference_to_use_of_colour>` for an example of the effective use of colour.
 
@@ -32,7 +44,12 @@ General summary: revealing complex data graphically
 
 There is no generic advice that applies in every instance. These tips are useful, though, in most cases:
 
--	If the question you want answered is causality, then show causality (the most effective way is with bivariate scatter plots). If trying to answer a question with alternatives, show comparisons (with :index:`tiles of plots <pair: small multiples; visualization>` or a simple table).
+-	If the question you want answered is about the relationship between two variables, show that
+	relationship (the most effective way is with bivariate scatter plots), keeping in mind that a
+	scatter plot shows association: establishing causality requires a
+	:ref:`designed experiment <SECTION-design-analysis-experiments>`. If trying to answer a
+	question with alternatives, show comparisons (with :index:`tiles of plots
+	<pair: small multiples; visualization>` or a simple table).
 
 -	Words and graphics belong together. Add labels to plots for outliers, and explain interesting points. Add equations and even small summary tables on top of your plots. Remember that a graph should be like a paragraph of text, not necessarily just a graphical display of numbers that you discuss later on.
 
@@ -44,4 +61,7 @@ There is no generic advice that applies in every instance. These tips are useful
 
 -	Maximize the :index:`data-ink ratio <pair: data-ink ratio; visualization>` = (ink for data) / (total ink for graphics). Maximizing this ratio, within reason, means you should (a) eliminate nondata ink and (b) erase redundant data-ink.
 
--	Maximize :index:`data density <pair: data density; visualization>`. Humans can `interpret data displays <https://www.edwardtufte.com/bboard/q-and-a-fetch-msg?msg_id=0001OR>`_ of around 100 data points per centimeter (250 data points per linear inch) and around 10000 per square centimeter (60000 data points per square inch).
+-	Maximize :index:`data density <pair: data density; visualization>`. Tufte `estimates
+	<https://www.edwardtufte.com/notebook/sparkline-theory-and-practice-edward-tufte/>`_ that
+	people can interpret data displays of around 100 data points per centimeter (250 data points
+	per linear inch) and around 10000 per square centimeter (60000 data points per square inch).

--- a/data-visualization/data-visualization-in-context.rst
+++ b/data-visualization/data-visualization-in-context.rst
@@ -29,8 +29,13 @@ You can use the material in this chapter when you must learn more about your sys
 
 .. rubric:: What we will cover
 
+We start with plots that show a single variable: time-series plots, bar plots and box plots. We
+then move to the scatter plot, which relates two (or more) variables, and to tables, which remain
+an effective display for small amounts of comparative data. The chapter ends with general advice
+on style, colour, and revealing complex data graphically.
+
 .. figure:: /figures/visualization/visualization-subject-mapping.png
-	:alt:	../figures/visualization/visualization-subject-mapping.xmind
+	:alt:	Mind map of the chapter's topics; time-series plots, bar plots, box plots, scatter plots, tables, and the use of colour.
 	:align: center
 	:scale: 60
 
@@ -54,5 +59,7 @@ References and readings
 #. Stephen Few, *Show Me the Numbers* and *Now You See It: Simple Visualization Techniques for Quantitative Analysis*; both from Analytics Press.
 #. William Cleveland, *Visualizing Data*, 1st edition, Hobart Press, 1993.
 #. William Cleveland, *The Elements of Graphing Data*, 2nd edition, Hobart Press, 1994.
+#. William Cleveland and Robert McGill, `Graphical Perception: Theory, Experimentation, and Application to the Development of Graphical Methods <https://doi.org/10.1080/01621459.1984.10478080>`_, *Journal of the American Statistical Association*, **79** (387), 531-554, 1984.
+#. Mark Harrower and Cynthia Brewer, `ColorBrewer.org: An Online Tool for Selecting Colour Schemes for Maps <https://doi.org/10.1179/000870403235002042>`_, *The Cartographic Journal*, **40** (1), 27-37, 2003.
 #. Su, `It's Easy to Produce Chartjunk Using Microsoft Excel 2007 but Hard to Make Good Graphs <https://dx.doi.org/10.1016/j.csda.2008.03.007>`_, *Computational Statistics and Data Analysis*, **52** (10), 4594-4601, 2008.
 #. Paul Geladi, Marena Manley and Torbjörn Lestander, `Scatter plotting in multivariate data analysis <https://literature.learnche.org/item/86/scatter-plotting-in-multivariate-data-analysis>`_, *Journal of Chemometrics*, **17**, 503-511, 2003.

--- a/data-visualization/relational-graphs-scatter-plots.rst
+++ b/data-visualization/relational-graphs-scatter-plots.rst
@@ -8,11 +8,24 @@ Relational graphs: scatter plots
 
 This is a plot many people are comfortable using. It helps you understand the relationship between two variables - a :index:`bivariate plot <pair: bivariate plot; visualization>` - as opposed to the previous charts that are univariate. A :index:`scatter plot <pair: scatter plot; visualization>` is a collection of points shown inside a box formed by two axes at 90 degrees to each other. The marker's position is located at the intersection of the values shown on the horizontal (*x*) axis and vertical (*y*) axis.
 
-The unspoken intention of a scatter plot is usually to ask the reader to draw a causal relationship between the two variables. However, not all scatter plots actually show causal phenomena, as the figure below tries to convince you:
+The unspoken intention of a scatter plot is usually to ask the reader to draw a causal relationship
+between the two variables. However, not all scatter plots actually show causal phenomena, as the
+figure below tries to convince you:
 
 .. image:: ../figures/visualization/scatterplot-figures.png
 
-This source code generates similar, but not identical, figures to those shows here in the text.
+The left-hand plot shows measurements from a distillation column: the temperature on a tray and the
+vapour pressure of the product move together because of a real physical mechanism. The right-hand
+plot shows (simulated) data of the number of white hairs on a person's scalp against their bone
+mineral density. The negative correlation is just as clear, yet neither variable causes the other:
+both change with a third variable that is not on the plot, the person's age. Such a hidden third
+variable is called a :index:`lurking variable <pair: lurking variable; scatter plot>`. A scatter
+plot shows the association between two variables; it cannot, on its own, tell you whether that
+association is causal. Establishing causality requires deliberately changing one variable and
+observing the response, which is the subject of the chapter on
+:ref:`designed experiments <SECTION-design-analysis-experiments>`.
+
+This source code generates similar, but not identical, figures to those shown here in the text.
 
 .. literalinclude:: /data-visualization/gists/scatter-plot-example.py
 	:language: python
@@ -31,7 +44,7 @@ Strive for graphical excellence by doing the following:
 
 There is an unfounded fear that others won't understand your 2D scatter plot. :index:`Tufte <single: Tufte, Edward>` `(2001) <https://literature.learnche.org/item/53/the-visual-display-of-quantitative-information>`_ (*Visual Display of Quantitative Information*, p 83) shows that there are no scatter plots in a sample (1974 to 1980) of U.S., German and British dailies, despite studies showing that 12-year-olds can interpret such plots: Japanese newspapers frequently use them.
 
-You will see this in industrial settings as well. The next time you go into an industrial control room (or look carefull at some screens in online videos), try finding any scatter plots. The audience is not to blame: it is the producers of these charts who assume the audience is incapable of interpreting them.
+You will see this in industrial settings as well. The next time you go into an industrial control room (or look carefully at some screens in online videos), try finding any scatter plots. The audience is not to blame: it is the producers of these charts who assume the audience is incapable of interpreting them.
 
 .. note::
 
@@ -43,7 +56,7 @@ Further improvements can be made to your scatter plots. For example, extend the 
 	.. image:: ../figures/visualization/scatterplot-figures-with-regression-lines.png
 		:scale: 75
 
-You can add box plots and histograms to the side of the axes to aide interpretation:
+You can add box plots and histograms to the side of the axes to aid interpretation:
 
 	.. image:: ../figures/visualization/scatterplot-with-histograms-updated.png
 		:scale: 42
@@ -62,14 +75,14 @@ Add a third variable to the plot by adjusting the :index:`marker size <single: m
 		:alt: fake width
 
 
-    This example, from :index:`GapMinder <single: GapMinder>` (`https://gapminder.org <https://yint.org/gapminder-example>`_) , shows data until 2007 for:
+    This example, from :index:`GapMinder <single: GapMinder>` (`https://gapminder.org <https://yint.org/gapminder-example>`_), shows data until 2007 for:
 
 		1. income per person (*x*-axis);
 		2. against fertility (*y*-axis);
 		3. the size of each data point is proportional to the country's population;
-		4. the marker colour shows life expectancy at birth (years).
-		5. The GapMinder website allows you to "play" the graph over time, effectively adding a fifth dimension to the 2D plot.
+		4. the marker colour shows life expectancy at birth (years);
+		5. and the GapMinder website allows you to "play" the graph over time, effectively adding a fifth dimension to the 2D plot.
 
-		So 5 dimensions in a 2D surface. A 6th dimension cab be added if using technology such as VR glasses, to create a 3rd dimension, to display another variable from the data set.
+		So 5 dimensions are shown on a 2D surface. A 6th dimension could be added with a technology such as a virtual-reality display, using the third spatial dimension to show another variable from the data set.
 
-		Use the hyperlink above to see how richer countries move towards lower fertility and higher income over time.
+		Use the hyperlink above to see how countries move towards higher income and lower fertility over time.

--- a/data-visualization/tables-as-a-form-of-data-visualization.rst
+++ b/data-visualization/tables-as-a-form-of-data-visualization.rst
@@ -39,11 +39,23 @@ Three common pitfalls to avoid:
 
 #.	*Avoid using* :index:`pie charts <pair: pie chart; visualization>` *when tables will do.*
 
-	Pie charts are tempting when we want to graphically break down a quantity into components. I have used them erroneously myself (here is an example on a website that I helped with: https://www.macc.mcmaster.ca/gradstudies.php). We won't go into details here, but I strongly suggest you read the convincing evidence of :index:`Stephen Few <single: Few, Stephen>` in: `"Save the pies for dessert" <https://www.perceptualedge.com/articles/08-21-07.pdf>`_. The key problem is that the human eye cannot adequately decode angles; however, we have no problem with linear data.
+	Pie charts are tempting when we want to graphically break down a quantity into components. I
+	have used them erroneously myself (here is an example on a website that I helped with:
+	https://www.macc.mcmaster.ca/gradstudies.php). We won't go into details here, but I strongly
+	suggest you read the convincing evidence of :index:`Stephen Few <single: Few, Stephen>` in:
+	`"Save the pies for dessert" <https://www.perceptualedge.com/articles/08-21-07.pdf>`_. The key
+	problem is that the human eye decodes angles far less accurately than it judges positions and
+	lengths. The graphical-perception experiments of Cleveland and McGill (1984), listed in the
+	:ref:`references <visualization_references>`, measured this ranking directly: judgements based
+	on position along a common scale were the most accurate, followed by length, with angle and
+	area well behind.
 
-#.	*Avoid arbitrary ordering along the first column; usually, alphabetically or in time order is better.*
+#.	*Avoid arbitrary ordering along the first column; order the rows by a criterion of interest.*
 
-	Listing the car types alphabetically is trivial: instead, list them by some other third criterion of interest, perhaps minimum down payment required, typical lease duration, or total amount of interest paid on the loan. That way you get some extra context to the table for free.
+	Listing the car types alphabetically is trivial, and time order is only meaningful when the
+	rows are events. Instead, list the rows by another criterion of interest: perhaps minimum down
+	payment required, typical lease duration, or total amount of interest paid on the loan. That
+	way you get some extra context from the table for free.
 
 #.	*Avoid using excessive grid lines.*
 


### PR DESCRIPTION
Part 2 of 3 of a critique-and-repair sweep of chapter 1 (Visualizing Process Data). This PR covers the scatter plot, tables, style/aesthetics, and chapter-intro sections. Part 1 (#196) covers the univariate plot sections; part 3 covers the exercises.

## What changed

**Scatter plots (pedagogical gap):**
- The section's centrepiece figure pairs a real physical relationship (tray temperature vs vapour pressure) with a fabricated white-hairs vs bone-mineral-density correlation, and says the figure "tries to convince you" that not all scatter plots are causal - but never explains how. A new paragraph walks through both panels, names the lurking variable (age drives both quantities in the right-hand panel), defines the term, and links to the designed-experiments chapter as the place where causality is actually established. This mirrors the reasoning the chapter's own kidnappings exercise expects from students.
- GapMinder example: the garbled "A 6th dimension cab be added if using technology such as VR glasses" sentence repaired; the circular "richer countries move towards ... higher income" phrasing fixed; list punctuation made consistent.
- Typos: "shows here" -> "shown here", "carefull" -> "carefully", "aide" -> "aid".

**General tips (technical error):**
- "If the question you want answered is causality, then show causality (the most effective way is with bivariate scatter plots)" - a scatter plot shows association, and the claim contradicted both the scatter plot section and the DOE chapter. Reworded to relationship/association with a `:ref:` to designed experiments.
- Colour guidance was a 2000s-era snapshot ("the only safest colour progression is the grayscale axis"). It now describes perceptually uniform scales (ColorBrewer, viridis, cividis) as the current software default, explains why the rainbow/jet scale creates false boundaries, and keeps grayscale as the safe choice for print.
- The axis-frames tip list contained a literal dangling "except ..."; the exceptions (zero-based bar plots, equal-axis comparison plots) are now spelled out.
- The 100-points-per-cm data-density numbers are attributed to Tufte as estimates, and the dead `edwardtufte.com/bboard` link is replaced with the live essay URL.

**Tables:**
- The pie chart criticism ("the human eye cannot adequately decode angles") is anchored to Cleveland and McGill's 1984 graphical-perception experiments: position > length > angle/area.
- The row-ordering pitfall contradicted itself: the heading recommended alphabetical or time order, the body immediately advised against alphabetical. Both now agree: order rows by a criterion of interest.

**Chapter intro:**
- A one-paragraph roadmap (univariate plots -> scatter plots -> tables -> style) before the mind-map figure, and a descriptive alt text on that figure instead of the `.xmind` source path.
- References list gains Cleveland & McGill (1984) and Harrower & Brewer (2003), which the edits above cite.

## What did not change

All figures, datasets, and code gists are unchanged.

## Verification

- `make text`: zero warnings, zero errors.
- `make html`: builds clean; `grep -r goatcounter _build/html/contents` returns zero hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdbBix33WkbeVQzqJuBarQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdbBix33WkbeVQzqJuBarQ)_