### PR TITLE
DoE Ch.5: add run-allocation and screening-principles material

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.07.02"
-date-released: 2026-07-02
+version: "2026.07.04"
+date-released: 2026-07-04
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/design-analysis-experiments/examples-of-how-designed-experiments-are-used.rst
+++ b/design-analysis-experiments/examples-of-how-designed-experiments-are-used.rst
@@ -41,6 +41,7 @@ References and readings
 -	William Hill and William Hunter, "`A Review of Response Surface Methodology: A Literature Survey <https://doi.org/10.1080/00401706.1966.10490404>`_", *Technometrics*, **8**, 571-590, 1966.
 -	Owen L. Davies, `The Design and Analysis of Industrial Experiments <https://www.amazon.com/The-design-analysis-industrial-experiments/dp/B0007J7BME>`_, Chapter 11, revised 2nd edition, Hafner, 1967.
 -	Torbjörn Lundstedt, Elisabeth Seifert, Lisbeth Abramo, Bernt Thelin, Åsa Nyström, Jarle Pettersen and Rolf Bergman, `Experimental design and optimization <https://doi.org/10.1016/S0169-7439(98)00065-3>`_, *Chemometrics and Intelligent Laboratory Systems*, **42**, 3-40, 1998.
+-	Peter Goos and Bradley Jones, *Optimal Design of Experiments: A Case Study Approach*, Wiley, 2011. ISBN 978-0-470-74461-1.
 -	Bradley Jones and Christopher J. Nachtsheim, "`A Class of Three-Level Designs for Definitive Screening in the Presence of Second-Order Effects <https://doi.org/10.1080/00224065.2011.11917841>`_", *Journal of Quality Technology*, **43**, 1-15, 2011.
 -	José Núñez Ares and Peter Goos, "`Enumeration and Multicriteria Selection of Orthogonal Minimally Aliased Response Surface Designs <https://doi.org/10.1080/00401706.2018.1549103>`_", *Technometrics*, **62**, 21-36, 2020.
 -	Peter Goos, "`OMARS Designs for Factor Screening and Response Surface Experimentation in One Step: A Review <https://doi.org/10.1002/wics.70018>`_", *WIREs Computational Statistics*, **17**, e70018, 2025.

--- a/design-analysis-experiments/experiments-with-a-single-variable-at-two-levels.rst
+++ b/design-analysis-experiments/experiments-with-a-single-variable-at-two-levels.rst
@@ -32,6 +32,103 @@ We have already seen in the :ref:`univariate statistics section <univariate-grou
 
 We consider the effect of changing from condition A to condition B to be a *statistically* significant effect when this confidence interval does not span zero. However, the width of this interval and how symmetrically it spans zero can cause us to come to a different, *practical* conclusion. In other words, we override the narrow statistical conclusion based on the richer information we can infer from the width of the confidence interval and the variance of the process.
 
+.. _DOE-two-level-allocation:
+
+How many runs at each level?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The recap above pooled the two groups into a single variance, :math:`s_P^2`, which already assumes the spread at level A equals the spread at level B. Before running the experiment, there is a planning question hiding inside that assumption: if the budget allows a fixed total of :math:`N` runs, how many should be measured at level A and how many at level B?
+
+Write :math:`n_A` for the number of runs at level A and :math:`n_B = N - n_A` for the number at level B. Keeping the two variances separate, the estimated difference :math:`\overline{x}_B - \overline{x}_A` has variance
+
+.. math::
+
+	\text{var}\left(\overline{x}_B - \overline{x}_A\right) = \frac{\sigma_A^2}{n_A} + \frac{\sigma_B^2}{n_B}
+
+where :math:`\sigma_A^2` and :math:`\sigma_B^2` are the variances of a single run at each level. A precise experiment makes this variance small, so the way we split the budget is itself a design choice. The function below computes the variance for every whole-run split of a budget, together with the *efficiency*: the smallest variance in the table divided by the variance of a given split, written as a percentage. The efficiency says how precise a split is relative to the best split of the same budget.
+
+.. code-block:: python
+
+	import pandas as pd
+
+	def allocation_table(var_A, var_B, cost_A, cost_B, budget):
+	    """Variance and efficiency of every whole-run split of a fixed budget."""
+	    rows = []
+	    n_A = 1
+	    while cost_A * n_A < budget:
+	        remainder = budget - cost_A * n_A
+	        if remainder % cost_B == 0:
+	            n_B = remainder // cost_B
+	            variance = var_A / n_A + var_B / n_B
+	            rows.append((n_A, n_B, variance))
+	        n_A += 1
+	    table = pd.DataFrame(rows, columns=["n_A", "n_B", "variance"])
+	    table["efficiency"] = 100 * table["variance"].min() / table["variance"]
+	    return table
+
+	# Equal variances, equal costs, twelve runs (balanced split is best):
+	print(allocation_table(1, 1, 1, 1, 12))
+
+	# Level B nine times as variable as level A, equal costs, twelve runs:
+	print(allocation_table(1, 9, 1, 1, 12))
+
+	# Equal variances, but a run at level A costs twice as much, budget of 24:
+	print(allocation_table(1, 1, 2, 1, 24))
+
+When the two levels have the same variance, :math:`\sigma_A^2 = \sigma_B^2 = \sigma^2`, and a run at either level costs the same, the variance is smallest when the runs are divided evenly. The first call above, with :math:`\sigma^2 = 1` and :math:`N = 12`, gives:
+
+.. tabularcolumns:: |c|c|c|c|
+
+=========  =========  ==========  ============
+Runs at A  Runs at B  Variance    Efficiency
+=========  =========  ==========  ============
+1          11         1.091       30.6%
+2          10         0.600       55.6%
+3          9          0.444       75.0%
+4          8          0.375       88.9%
+5          7          0.343       97.2%
+6          6          0.333       100.0%
+7          5          0.343       97.2%
+8          4          0.375       88.9%
+9          3          0.444       75.0%
+10         2          0.600       55.6%
+11         1          1.091       30.6%
+=========  =========  ==========  ============
+
+The balanced 6-and-6 split is best, matching the even division that most people would reach for. The penalty for a modest imbalance is small: a 5-and-7 split is still 97.2% efficient. The value of :math:`\sigma^2` does not change any of this. Doubling it doubles every variance in the table and leaves the efficiencies, and so the best split, unchanged.
+
+If the two levels do not have the same variance, the even split is no longer best. Suppose level B is nine times as variable as level A, so :math:`\sigma_A^2 = 1` and :math:`\sigma_B^2 = 9`. The second call above, over the same :math:`N = 12` runs, gives:
+
+.. tabularcolumns:: |c|c|c|c|
+
+=========  =========  ==========  ============
+Runs at A  Runs at B  Variance    Efficiency
+=========  =========  ==========  ============
+1          11         1.818       73.3%
+2          10         1.400       95.2%
+3          9          1.333       100.0%
+4          8          1.375       97.0%
+5          7          1.486       89.7%
+6          6          1.667       80.0%
+7          5          1.943       68.6%
+8          4          2.375       56.1%
+9          3          3.111       42.9%
+10         2          4.600       29.0%
+11         1          9.091       14.7%
+=========  =========  ==========  ============
+
+Now the best split is 3 runs at level A and 9 at level B, and the balanced split has fallen to 80.0% efficiency. The extra runs at level B offset its larger variance, keeping the term :math:`\sigma_B^2 / n_B` from dominating the sum. With equal costs the variance is smallest when the runs are shared in proportion to the standard deviations, :math:`n_A : n_B = \sigma_A : \sigma_B`, which places 3 and 9 runs here.
+
+Cost can move the split away from even in the same way. Suppose the two levels have the same variance, but a run at level A costs twice as much as a run at level B, and the budget is fixed at a total cost of 24, so that :math:`2 n_A + n_B = 24`. The third call above finds that the variance is smallest with 7 runs at level A and 10 at level B: an unbalanced design whose total run count is not even. Combining both effects, the variance is smallest when
+
+.. math::
+
+	n_A : n_B = \frac{\sigma_A}{\sqrt{c_A}} : \frac{\sigma_B}{\sqrt{c_B}}
+
+where :math:`c_A` and :math:`c_B` are the cost of a single run at each level. The general principle is to place more runs where the variance is larger and where the runs are cheaper. The even split is best only in the particular case of equal variances, equal costs, and an even number of runs. This allocation question, and the case study that motivates it, is treated in the opening chapter of :ref:`Goos and Jones <DOE_references>`.
+
+In practice the two variances are seldom known before the experiment, whereas the two costs usually are. The balanced split stayed at least 80% efficient across every case above, so it is a reasonable default when nothing is known about the variances. When a cost difference is known, the split that accounts for it can be chosen deliberately.
+
 Using linear least squares models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/design-analysis-experiments/fractional-factorial-designs/saturated-designs-for-screening.rst
+++ b/design-analysis-experiments/fractional-factorial-designs/saturated-designs-for-screening.rst
@@ -167,4 +167,21 @@ A side note on screening designs is a mention of :index:`Plackett and Burman des
 
 .. youtube:: https://www.youtube.com/watch?v=dbxijjAHeUU&list=PLHUnYbefLmeOPRuT1sukKmRyOVd4WSxJE&index=51
 
+.. _DOE-screening-principles:
+
+Three principles behind screening: sparsity, hierarchy, and heredity
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Screening works because real systems tend to behave in a particular way. Three empirical principles describe that behaviour. Together they explain why a saturated design can find the important factors, and how to build a model from the results. All three are discussed at length in :ref:`Goos and Jones <DOE_references>`.
+
+*Sparsity.* The principle of effect sparsity states that only a few of the many factors studied drive most of the variation in the response. This is the experimental form of the Pareto principle: a small number of causes account for a large part of the effect. The saturated :math:`2^{7-4}_{\text{III}}` design above relied on it. It spent 8 runs on 7 factors and found that only **A**, **C**, and **G** mattered. Sparsity is what lets the :ref:`Pareto plot <DOE-Pareto-plot>` separate the few large effects from the many small ones. As the number of active effects grows towards half the number of runs, that separation becomes harder to make.
+
+*Hierarchy.* The principle of effect hierarchy states that main effects tend to be larger than two-factor interactions, which in turn tend to be larger than three-factor and higher-order interactions. This is why a resolution III design confounds main effects with two-factor interactions rather than confounding main effects with each other: the terms it gives up to save runs are the ones expected to be small. In model building, hierarchy suggests adding the main effects before any interaction or quadratic term.
+
+*Heredity.* The principle of effect heredity concerns which interactions are plausible. Under *strong* heredity, a two-factor interaction :math:`x_i x_j` is included in a model only if both of its parent main effects, :math:`x_i` and :math:`x_j`, are also in the model. Under *weak* heredity, only one of the two parents needs to be present. Heredity is the usual reason for keeping a main effect in a model even when its own coefficient looks small: if its interaction is active, the main effect stays.
+
+A small example shows why. Suppose the true response is :math:`y = 10 + 4 x_A - 2 x_B + 23 x_A x_B`, and a full factorial is run at the :math:`\pm 1` levels. A model that keeps only the intercept and the interaction, dropping both main effects, fits the four corner points with :math:`y = 10 + 23 x_A x_B`. Its coefficients are close to the true ones, and at most corners it predicts well. But at the corner :math:`x_A = +1, x_B = -1`, where the main effects and the interaction push in opposite directions, it predicts :math:`10 + 23(+1)(-1) = -13`, while the true value is :math:`10 + 4(+1) - 2(-1) + 23(+1)(-1) = -7`. Retaining the parent main effects avoids this error. A model built under strong heredity has a further technical advantage: its predictions do not change if the factors are rescaled.
+
+These are tendencies, not laws. An empirical review of 113 published factorial experiments, summarised in :ref:`Goos and Jones <DOE_references>`, found that hierarchy and heredity usually hold, while also noting that violations occur more often than the screening literature suggests. The same review found that most active two-factor interactions are synergistic: they reinforce the direction of their parent main effects. When the goal is to increase the response, exploiting the large main effects tends to carry the interactions along in the same direction. When the goal is to decrease it, the interactions can work against the main effects.
+
 An important mention to readers interested in other, arguable better screening strategies, is to consider :ref:`definitive screening designs <DOE-definitive-screening-designs>`.


### PR DESCRIPTION
## What this adds

Two topics that were missing from the Design and Analysis of Experiments chapter.

### 1. "How many runs at each level?" (single-variable, two-level experiments)

A new subsection that treats the split of a fixed budget between the two levels as a design choice, building directly on the pooled-variance recap that precedes it. It covers:

- the separate-variance form `var(x_B - x_A) = σ_A²/n_A + σ_B²/n_B`, which the earlier pooled form assumes away;
- why the balanced split is optimal only under equal variances, equal costs, and an even run count;
- how unequal variances move the optimum toward the noisier level (`n_A : n_B = σ_A : σ_B`);
- how unequal costs move it toward the cheaper level (`n_A : n_B = σ_A/√c_A : σ_B/√c_B`);
- a short, reproducible `allocation_table(...)` function, with the general principle stated plainly.

Three worked tables (equal variance, a 9x variance ratio, and a 2:1 cost ratio) accompany the text. Every value was recomputed from the function.

### 2. "Three principles behind screening: sparsity, hierarchy, and heredity" (saturated screening designs)

A new subsection that names and defines the three principles a reader needs to reason about screening and model building:

- **sparsity** (few factors drive most variation; the basis for reading a Pareto plot);
- **hierarchy** (main effects tend to exceed two-factor interactions, which exceed higher-order ones);
- **heredity** (strong vs weak; why parent main effects are kept alongside an active interaction), with a worked example showing the prediction error that follows from dropping them.

This promotes a long-standing author note in the chapter source into rendered text, and adds the empirical caveat that these are tendencies rather than laws.

## Supporting changes

- Adds the Goos and Jones optimal-design book to the chapter reference list and cites it at both new subsections.
- Bumps `CITATION.cff` `version` and `date-released` to today.

## What did not change

No existing prose, figures, code, or analysis was altered. Both additions are new subsections plus one reference entry.

## Verification

- `make text`: succeeds. The only warnings are the pre-existing "image file not readable" / "include file not found" ones from the `figures/` submodule not being present in the build environment; there are no RST, cross-reference, or table warnings, and both new `:ref:` links resolve.
- `make html`: succeeds; pages build as extensionless files; `grep -r goatcounter _build/html/contents` returns zero hits.
- The allocation tables were verified numerically against the function shown in the text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TH8TdNx3iJmWqvaoZz5mQx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TH8TdNx3iJmWqvaoZz5mQx)_