### PR TITLE
Process monitoring (Ch. 3) follow-up: technical depth, phase 1/2 walkthrough, reproducible figures

### DIFF
--- a/process-monitoring/cusum-charts.rst
+++ b/process-monitoring/cusum-charts.rst
@@ -39,6 +39,14 @@ What is of interest however is a persistent change in slope in the CUSUM chart. 
 
 The process is considered in control as long as all points are within the arms of the V shape.  The mask in the second row of the plot shows "in control" behaviour, while the mask in the fourth row detects the process mean has shifted, and an alarm should be raised.
 
-Once the process has been investigated the CUSUM value, :math:`S_t` is often reset to zero; though other resetting strategies exist. A tabular version of the CUSUM chart also exists which tends to be the version used in software systems.
+Once the process has been investigated the CUSUM value, :math:`S_t` is often reset to zero; though other resetting strategies exist. A tabular version of the CUSUM chart also exists, and it is the form used in most software systems. Rather than a single sum, it keeps two one-sided sums that accumulate only the deviations beyond a small reference value :math:`K`, and it signals when either sum exceeds a decision interval :math:`H`:
 
-The purpose of this section is not to provide formulas for the V-mask or tabular CUSUM charts, only to explain the CUSUM concept to put the next section on EWMA control charts in perspective.
+.. math::
+	:label: CUSUM-tabular
+
+	C_t^{+} &= \max\left(0,\ C_{t-1}^{+} + (x_t - T) - K\right) \\
+	C_t^{-} &= \max\left(0,\ C_{t-1}^{-} - (x_t - T) - K\right)
+
+The :index:`reference value <single: reference value (CUSUM)>` :math:`K` is usually set to half the shift you want to detect: :math:`K = \frac{1}{2}\,\delta\,\sigma` for a shift of :math:`\delta` standard deviations. The :index:`decision interval <single: decision interval (CUSUM)>` :math:`H` is commonly :math:`4\sigma` or :math:`5\sigma`, chosen to give an acceptable in-control average run length. An alarm is raised the first time :math:`C_t^{+} > H` or :math:`C_t^{-} > H`, after which the offending sum is reset to zero. These two parameters, :math:`K` and :math:`H`, play the same role as the angle and lead distance of the V-mask, and are what you will set in software such as Minitab or the R ``qcc`` package.
+
+The purpose of this section is not to provide formulas for the V-mask, only to explain the CUSUM concept to put the next section on EWMA control charts in perspective.

--- a/process-monitoring/ewma-charts.rst
+++ b/process-monitoring/ewma-charts.rst
@@ -71,6 +71,32 @@ In the next figure, we show a comparison of the weights used in different monito
 
 From the above discussion and the weights shown for the 4 different charts, it should be clear now how an EWMA chart is a tradeoff between a Shewhart chart and a CUSUM chart. As :math:`\lambda \rightarrow 1`, the EWMA chart behaves more as a Shewhart chart, giving only weight to the most recent observation. While as :math:`\lambda \rightarrow 0` the EWMA chart starts to have an infinite memory (like a CUSUM chart). There are 12 data points used in the example, so the CUSUM 'weight' is one twelfth or :math:`\approx 0.0833`.
 
+.. code-block:: python
+
+	import numpy as np
+	import plotly.graph_objects as go
+	from plotly.subplots import make_subplots
+
+	# Weight given to each past observation, newest at lag 0,
+	# for the four charts, using 12 data points and lambda = 0.4.
+	n_points, lam = 12, 0.4
+	lags = np.arange(n_points)
+	weights = {
+	    "Shewhart": np.where(lags == 0, 1.0, 0.0),
+	    "Moving average (n=5)": np.where(lags < 5, 1 / 5, 0.0),
+	    f"EWMA (lambda={lam})": lam * (1 - lam) ** lags,
+	    "CUSUM": np.full(n_points, 1 / n_points),  # 1/12 = 0.0833
+	}
+
+	fig = make_subplots(rows=2, cols=2, subplot_titles=list(weights))
+	for i, (name, w) in enumerate(weights.items()):
+	    row, col = divmod(i, 2)
+	    fig.add_trace(go.Bar(x=lags, y=w), row=row + 1, col=col + 1)
+	fig.update_layout(showlegend=False,
+	                  title="Weight given to each past observation "
+	                        "(lag 0 = most recent)")
+	fig.show()
+
 .. image:: ../figures/monitoring/explain-weights-for-process-monitoring.png
 	:alt: ../figures/monitoring/explain-weights-for-process-monitoring.R
 	:width: 900px

--- a/process-monitoring/ewma-charts.rst
+++ b/process-monitoring/ewma-charts.rst
@@ -88,7 +88,9 @@ The upper and lower control limits for the EWMA plot are plotted in the same way
 		 \text{LCL} = \overline{\overline{x}} - K \cdot \sigma_{\text{Shewhart}}\sqrt{\frac{\displaystyle \lambda}{\displaystyle 2-\lambda}} &&  &&  \text{UCL} = \overline{\overline{x}} + K \cdot \sigma_{\text{Shewhart}} \sqrt{\frac{\displaystyle \lambda}{\displaystyle 2-\lambda}}
 	\end{array}
 
-where :math:`\sigma_{\text{Shewhart}}` represents the standard deviation as calculated for the Shewhart chart. :math:`K` is usually a value of 3, similar to the 3 standard deviations used in a Shewhart chart, but can of course be set to any level that balances the type I (false alarms) and type II errors (not detecting a deviation which is present already).
+where :math:`\sigma_{\text{Shewhart}}` represents the standard deviation as calculated for the Shewhart chart; for individual observations (subgroup size 1, as in the example above) this is simply the process standard deviation :math:`\sigma`. :math:`K` is usually a value of 3, similar to the 3 standard deviations used in a Shewhart chart, but can of course be set to any level that balances the type I (false alarms) and type II errors (not detecting a deviation which is present already).
+
+The limits in equation :eq:`ewma-limits` are the steady-state limits. For the first few points the exact standard deviation of :math:`\hat{x}_t` is smaller, by the factor :math:`\sqrt{1-(1-\lambda)^{2t}}`, so many software packages draw limits that start narrower and widen to the steady-state value within a handful of samples.
 
 An interesting implementation can be to show both the Shewhart and EWMA plot on the same chart, with both sets of limits. The EWMA value plotted is actually the one-step ahead prediction of the next :math:`x`-value, which can be informative for slow-moving processes.
 

--- a/process-monitoring/process-capability.rst
+++ b/process-monitoring/process-capability.rst
@@ -37,6 +37,48 @@ Interpretation of the PCR:
 
 The PCR is often called the :index:`process width`. Let's see why by taking a look at a process with PCR=0.5 and then PCR=2.0. In the first case :math:`\text{USL} - \text{LSL} = 3\sigma`. Since the interpretation of PCR assumes a :index:`centered process`, we can draw a diagram as shown below:
 
+.. code-block:: python
+
+	import numpy as np
+	import plotly.graph_objects as go
+	from scipy.stats import norm
+
+	# Fixed specification limits for this product:
+	LSL, USL = 65, 95
+	process_mean = 80
+
+	def plot_capability(mean, sigma, LSL=LSL, USL=USL):
+	    """Draw a centred normal curve with the out-of-spec tails
+	    shaded, and return the figure together with the PCR and the
+	    fraction of production outside the specification limits."""
+	    x = np.linspace(mean - 4 * sigma, mean + 4 * sigma, 500)
+	    y = norm.pdf(x, mean, sigma)
+	    pcr = (USL - LSL) / (6 * sigma)
+	    out_of_spec = (norm.cdf(LSL, mean, sigma)
+	                   + (1 - norm.cdf(USL, mean, sigma)))
+
+	    fig = go.Figure()
+	    fig.add_trace(go.Scatter(x=x, y=y, mode="lines",
+	                             line_color="black"))
+	    left, right = x <= LSL, x >= USL
+	    fig.add_trace(go.Scatter(x=x[left], y=y[left], fill="tozeroy",
+	                             mode="none",
+	                             fillcolor="rgba(200,0,0,0.4)"))
+	    fig.add_trace(go.Scatter(x=x[right], y=y[right], fill="tozeroy",
+	                             mode="none",
+	                             fillcolor="rgba(200,0,0,0.4)"))
+	    for limit in (LSL, USL):
+	        fig.add_vline(x=limit, line_dash="dash")
+	    fig.update_layout(showlegend=False,
+	                      xaxis_title="Quality attribute",
+	                      title=f"PCR = {pcr:.1f}; "
+	                            f"{100 * out_of_spec:.1f}% out of spec")
+	    return fig, pcr, out_of_spec
+
+	fig, pcr, oos = plot_capability(process_mean, sigma=10)
+	fig.show()
+	print(f"PCR = {pcr:.2f}, out of spec = {100 * oos:.1f}%")
+
 .. image:: ../figures/monitoring/explain-PCR-half.png
 	:align: center
 	:scale: 65
@@ -51,6 +93,14 @@ The diagram is from a process with mean of 80 and where LSL=65 and USL=95. These
 	-	Shaded area probability = ``pnorm(-1.5) + (1-pnorm(1.5))`` = 13.4% of production is out of the specification limits.
 
 Contrast this to the case where PCR = 2.0 for the same system. To achieve that level of process capability, using the *same upper and lower specifications* we have to  reduce the standard deviation by a factor of 4, down to :math:`\sigma = 2.5`.  The figure below illustrates that almost no off-specification product is produced for a centered process at PCR = 2.0. There is a width of :math:`12 \sigma` units from the LSL to the USL, giving the process location (mean) ample room to drift left or right without creating additional off-specification product.
+
+.. code-block:: python
+
+	# Reuse the helper: reduce the variability four-fold
+	# (sigma from 10 down to 2.5) for the same specifications.
+	fig, pcr, oos = plot_capability(process_mean, sigma=2.5)
+	fig.show()
+	print(f"PCR = {pcr:.2f}, out of spec = {100 * oos:.4f}%")
 
 .. image:: ../figures/monitoring/explain-PCR-two.png
 	:align: center

--- a/process-monitoring/shewhart-charts.rst
+++ b/process-monitoring/shewhart-charts.rst
@@ -224,7 +224,33 @@ In source code:
 	       '; ', round(UCL,0), ']')
 
 
-.. TODO: in the future, describe more clearly the difference between phase 1 and phase 2. Students were asking a lot of questions around this.
+Phase 1 versus phase 2 in this example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The rubber-bale calculation above is entirely **phase 1**: we used a batch of historical subgroups to *estimate* where the chart's limits should sit. The steps were:
+
+#.	collect :math:`K=20` subgroups believed to be from stable operation;
+#.	compute the grand mean |xdb| and the average subgroup standard deviation :math:`\overline{S}`, giving a first set of limits, [225.6, 252.0];
+#.	notice the subgroup with :math:`\overline{x}=253` lies above the UCL, exclude it, and recompute, arriving at the final limits, [224, 252].
+
+Nothing has been monitored yet. Phase 1 answers only the question "where should the limits sit?".
+
+**Phase 2** begins once those limits are frozen. Each new subgroup average, as its bale is tested, is plotted against the fixed centre line and the fixed [224, 252] limits; no limit is recomputed. A point outside the limits raises a signal. Suppose the next six bales give subgroup averages of 242, 236, 248, 254, 240, and 233. Only the fourth, :math:`\overline{x}=254`, lies above the UCL of 252, so the chart signals on that bale and the operator investigates.
+
+.. code-block:: python
+
+	# Phase 1 produced these frozen limits:
+	LCL, UCL = 224.0, 252.0
+
+	# Phase 2: plot each new subgroup average against
+	# the frozen limits and flag any that fall outside.
+	new_xbar = np.array([242, 236, 248, 254, 240, 233])
+	signals = (new_xbar > UCL) | (new_xbar < LCL)
+	for k, (value, flag) in enumerate(zip(new_xbar, signals), start=1):
+	    state = "SIGNAL" if flag else "in control"
+	    print(f"Bale {k}: xbar={value} -> {state}")
+
+The limits are calculated *once*, in phase 1, and then held fixed throughout phase 2. Re-estimating them from the phase 2 data as it arrives would let a slow drift quietly widen the limits and hide the very problem you are trying to detect.
 
 .. _monitoring_judging_performance:
 

--- a/process-monitoring/shewhart-charts.rst
+++ b/process-monitoring/shewhart-charts.rst
@@ -17,7 +17,7 @@ The defining characteristics of a Shewhart chart are: a target, upper and lower 
 Derivation using theoretical parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Define the variable of interest as :math:`x`, and assume that we have samples of :math:`x` available in sequence order. No assumption is made regarding the distribution of :math:`x`. The average of :math:`n` of these :math:`x`-values is defined as :math:`\overline{x}`, which from the :ref:`Central limit theorem <central_limit_theorem>` we know will be more normally distributed with unknown population mean :math:`\mu` and unknown population variance :math:`\sigma^2/n`, where :math:`\mu` and :math:`\sigma` refer to the distribution that samples of :math:`x` came from. The figure here shows the case for :math:`n=5`.
+Define the variable of interest as :math:`x`, and assume that we have samples of :math:`x` available in sequence order. No assumption is made regarding the distribution of :math:`x`. The average of :math:`n` of these :math:`x`-values is defined as :math:`\overline{x}`, which from the :ref:`Central limit theorem <central_limit_theorem>` we know will be more normally distributed with unknown population mean :math:`\mu` and unknown population variance :math:`\sigma^2/n`, where :math:`\mu` and :math:`\sigma` refer to the distribution that samples of :math:`x` came from. The figure here shows the case for :math:`n=5`. This normal approximation for :math:`\overline{x}` improves as :math:`n` grows; for small subgroups drawn from a strongly skewed distribution it is weaker, and the nominal false-alarm rate derived below should then be read as approximate.
 
 .. image:: ../figures/monitoring/explain-Shewhart-data-source.png
 	:align: left
@@ -312,15 +312,19 @@ The table highlights that :math:`\beta` is a function of the amount by which the
 
 .. _monitoring_shewart_chart_slugishness:
 
-The key point you should note from the table is that a Shewhart chart is *not good* (it is slow) at detecting a change in the location (level) of a variable. This is surprising given the intention of the plot is to monitor the variable's location. Even a moderate shift of :math:`0.75\sigma` units :math:`(\Delta=0.75)` will only be detected around 6.7% of the time (:math:`100-93.3\%`) when :math:`n=4`. We will discuss :ref:`CUSUM charts <monitoring_CUSUM_charts>` and the Western Electric rules, next, as a way to overcome this issue.
+The key point you should note from the table is that a Shewhart chart is *not good* (it is slow) at detecting a change in the location (level) of a variable. This is surprising given the intention of the plot is to monitor the variable's location. Even a moderate shift of :math:`0.75\sigma` units :math:`(\Delta=0.75)` will only be detected around 6.7% of the time (:math:`100-93.3\%`) when :math:`n=4`. That 6.7% is the chance of detecting the shift on any *single* subgroup; because each new subgroup is another independent opportunity, the shift is caught after about 15 subgroups on average. The chart is slow, not blind, as the :ref:`average run length <monitoring_arl>` below makes precise. We will discuss :ref:`CUSUM charts <monitoring_CUSUM_charts>` and the Western Electric rules, next, as a way to speed up detection.
 
 It is straightforward to see how the type I, :math:`\alpha`, error rate can be adjusted - simply move the LCL and UCL up and down, as required, to achieve your desired error rates. There is nothing wrong in arbitrarily shifting these limits - :ref:`more on this later <monitoring_adjust_limits>` in the section on adjusting limits.
 
 However what happens to the type II error rate as the LCL and UCL bounds are shifted away from the target?  Imagine the case where you want to have :math:`\alpha \rightarrow 0`. As you make the UCL higher and higher, the value for :math:`\alpha` drops, but the value for :math:`\beta` will also increase, since the control limits have become wider!  **You cannot simultaneously have low type I and type II error**, or as said more colloquially, "there is no free lunch".
 
+.. _monitoring_arl:
+
 .. rubric:: 2. Using the average run length (ARL)
 
-The :index:`average run length` (ARL) is defined as the average number of sequential samples we expect before seeing an out-of-bounds, or out-of-control signal. This is given by the inverse of :math:`\alpha`, as ARL = :math:`\frac{1}{\alpha}`. Recall for the theoretical distribution we had :math:`\alpha = 0.0027`, so the ARL = 370. Thus we expect a run of 370 samples before we get an out-of-control signal.
+The :index:`average run length` (ARL) is defined as the average number of sequential samples we expect before seeing an out-of-bounds, or out-of-control signal. When the process is on target, this is given by the inverse of :math:`\alpha`, as :math:`\text{ARL}_0 = \frac{1}{\alpha}`. Recall for the theoretical distribution we had :math:`\alpha = 0.0027`, so :math:`\text{ARL}_0 = 370`. Thus we expect a run of 370 samples between false alarms; this is the *in-control* ARL, written :math:`\text{ARL}_0`.
+
+The complementary quantity is the *out-of-control* ARL, :math:`\text{ARL}_1 = \frac{1}{1-\beta}`, the average number of subgroups needed to detect a shift that is genuinely present. For the :math:`0.75\sigma` shift discussed above (:math:`n=4`, :math:`\beta = 0.9332`), :math:`\text{ARL}_1 = 1/(1-0.9332) \approx 15` subgroups; for a :math:`1\sigma` shift it is :math:`1/(1-0.8413) \approx 6`. So the single-subgroup :math:`\beta` overstates how blind the chart is: each new subgroup is another chance to detect, and detection compounds over successive samples. A good chart has a large :math:`\text{ARL}_0` (rare false alarms) and a small :math:`\text{ARL}_1` (fast detection); the two are traded off against each other.
 
 
 Extensions to the basic Shewhart chart to help monitor stability of the location
@@ -329,13 +333,13 @@ Extensions to the basic Shewhart chart to help monitor stability of the location
 .. index::
 	single: center line
 
-The :index:`Western Electric rules`: we saw above how sluggish the Shewhart chart is in detecting a small shift in the process mean, from :math:`\mu` to :math:`\mu + \Delta\sigma`. The **Western Electric rules** are an attempt to more rapidly detect a process shift, by raising an alarm when these *improbable* events occur:
+The :index:`Western Electric rules`: we saw above how sluggish the Shewhart chart is in detecting a small shift in the process mean, from :math:`\mu` to :math:`\mu + \Delta\sigma`. The **Western Electric rules** are an attempt to more rapidly detect a process shift, by raising an alarm when these *improbable* events occur. The basic chart already implements the primary rule, a single point beyond :math:`3\sigma`; the three supplementary run rules are added on top of it:
 
 #. Two out of 3 points lie beyond :math:`2\sigma` on the same side of the centre line
 #. Four out of 5 points lie beyond :math:`1\sigma` on the same side of the centre line
 #. Eight successive points lie on the same side of the center line
 
-However, an alternative chart, the CUSUM chart is more effective at detecting a shift in the mean. Notice also that the theoretical ARL, :math:`1/\alpha`, is reduced by using these rules in addition to the LCL and UCL bounds.
+However, an alternative chart, the CUSUM chart is more effective at detecting a shift in the mean. Notice also that each extra rule is another way to signal, so the rules raise sensitivity but shorten the in-control ARL: the four rules together give :math:`\text{ARL}_0 \approx 92` rather than 370, meaning more frequent false alarms. Adding still more rules continues this trade-off.
 
 **Adding robustness**: the phase I derivation of a monitoring chart is iterative. If you find a point that violates the LCL and UCL limits, then the approach is to remove that point, and recompute the LCL and UCL values. That is because the LCL and UCL limits would have been biased up or down by these unusual points :math:`\overline{x}_k` points.
 

--- a/process-monitoring/shewhart-charts.rst
+++ b/process-monitoring/shewhart-charts.rst
@@ -48,6 +48,26 @@ The algebra above is written as an interval that brackets :math:`\mu`, but in op
 
 The following illustration should help connect the concepts: the raw data's distribution happens to have a mean of 6 and standard deviation of 2, while it is clear the distribution of the subgroups of 5 samples (thicker line) is much narrower.
 
+.. code-block:: python
+
+	import numpy as np
+	import plotly.graph_objects as go
+	from scipy.stats import norm
+
+	# The raw data distribution, and the distribution of
+	# subgroup averages (n = 5), which is narrower by sqrt(n).
+	raw_mean, raw_sd, n = 6, 2, 5
+	sub_sd = raw_sd / np.sqrt(n)
+	x = np.linspace(raw_mean - 4 * raw_sd, raw_mean + 4 * raw_sd, 500)
+
+	fig = go.Figure()
+	fig.add_trace(go.Scatter(x=x, y=norm.pdf(x, raw_mean, raw_sd),
+	                         name="raw data, x"))
+	fig.add_trace(go.Scatter(x=x, y=norm.pdf(x, raw_mean, sub_sd),
+	                         name="subgroup average (n=5)"))
+	fig.update_layout(xaxis_title="x", yaxis_title="Probability density")
+	fig.show()
+
 .. image:: ../figures/monitoring/explain-shewhart.png
 	:alt:	../figures/monitoring/explain-shewhart.R
 	:scale: 70
@@ -291,6 +311,30 @@ To quantify the probability :math:`\beta`, recall that a Shewhart chart is for m
 
 	\alpha &= Pr\left(\overline{x}\,\,\text{is in control, but lies outside the limits}\right) = \text{type I error rate}\\
 	\beta &= Pr\left(\overline{x}\,\,\text{is not in control, but lies inside the limits}\right) = \text{type II error rate}
+
+.. code-block:: python
+
+	# Type II error: the probability a shifted subgroup mean still
+	# lands inside the limits. Working in units of the raw sigma,
+	# with n = 4 and a shift of delta = 1 sigma.
+	n, delta = 4, 1.0
+	se = 1 / np.sqrt(n)              # standard error of xbar, in sigma units
+	LCL, UCL = -3 * se, 3 * se       # limits around the in-control mean of 0
+	beta = norm.cdf(UCL, delta, se) - norm.cdf(LCL, delta, se)
+	print(f"beta = {beta:.4f} for a {delta} sigma shift, n = {n}")
+
+	x = np.linspace(-4 * se, delta + 4 * se, 600)
+	fig = go.Figure()
+	fig.add_trace(go.Scatter(x=x, y=norm.pdf(x, 0, se), name="in control"))
+	fig.add_trace(go.Scatter(x=x, y=norm.pdf(x, delta, se), name="shifted"))
+	# Shade the beta region: the shifted curve between the limits.
+	mask = (x >= LCL) & (x <= UCL)
+	fig.add_trace(go.Scatter(x=x[mask], y=norm.pdf(x[mask], delta, se),
+	                         fill="tozeroy", mode="none",
+	                         fillcolor="rgba(0,0,200,0.3)", name="beta"))
+	for limit in (LCL, UCL):
+	    fig.add_vline(x=limit, line_dash="dash")
+	fig.show()
 
 .. figure:: ../figures/monitoring/show-shift-beta-error.png
 	:width: 800px

--- a/process-monitoring/what-is-process-monitoring-about.rst
+++ b/process-monitoring/what-is-process-monitoring-about.rst
@@ -37,6 +37,28 @@ Here is an example that shows these properties.
 
 .. TODO: show a time-series on the x-axis instead
 
+.. code-block:: python
+
+	import numpy as np
+	import plotly.graph_objects as go
+
+	# A synthetic example: 40 samples that drift out of
+	# control over the final few points.
+	rng = np.random.default_rng(7)
+	target, sd = 50, 4
+	series = rng.normal(target, sd, 40)
+	series[32:] += np.arange(8) * 2.0     # a slow drift near the end
+	UCL, LCL = target + 3 * sd, target - 3 * sd
+
+	fig = go.Figure()
+	fig.add_trace(go.Scatter(y=series, mode="lines+markers"))
+	fig.add_hline(y=target, line_dash="dot", annotation_text="Target")
+	fig.add_hline(y=UCL, line_color="red", annotation_text="UCL")
+	fig.add_hline(y=LCL, line_color="red", annotation_text="LCL")
+	fig.update_layout(xaxis_title="Sample number",
+	                  yaxis_title="Monitored value")
+	fig.show()
+
 .. image:: ../figures/monitoring/demo-of-monitoring-chart.png
 	:width: 750px
 	:scale: 80


### PR DESCRIPTION
Follow-up to #163, addressing the three larger items flagged in that PR's critique. All three you asked for have now landed, as three commits.

## 1. Technical-rigor pass
- **CUSUM:** added the tabular two-sided (`C+`/`C-`) form used by software, naming the reference value `K` (half the shift to detect) and decision interval `H` (typically 4σ–5σ), and how they map to the V-mask parameters.
- **Shewhart / ARL:** distinguished in-control `ARL₀ = 1/α = 370` from out-of-control `ARL₁ = 1/(1−β)`, with worked numbers (0.75σ shift → ≈15 subgroups; 1σ → ≈6), so the single-subgroup β is not misread as the chart being blind.
- **Western Electric rules:** named the primary rule (one point beyond 3σ) alongside the three run rules, and noted the four together give `ARL₀ ≈ 92`, not 370.
- **Normality caveat** added to the Shewhart derivation (CLT approximation weakens for small, skewed subgroups).
- **EWMA:** noted steady-state vs time-varying early limits; `σ_Shewhart` is the process σ for individuals.

## 2. Phase 1 / Phase 2 walkthrough
Closes the long-standing TODO in the Shewhart section. After the rubber-bale example, it spells out that everything so far was phase 1 (estimating the limits), then shows phase 2 as freezing those limits and plotting fresh subgroup averages against them, with a short worked example where a new bale (`x̄=254`) trips the frozen UCL of 252, and a note on why limits are held fixed.

## 3. Inline reproducible figure code
A runnable Plotly block before each data-driven figure, per the chapter-rework playbook:
- **Process capability:** a reusable `plot_capability()` helper, called for σ=10 (PCR 0.5, 13.4% out of spec) and σ=2.5 (PCR 2.0, ~0%).
- **Shewhart:** raw-vs-subgroup-average distributions, and the type II (β) shaded-region figure (prints β=0.8413 at 1σ, n=4).
- **EWMA:** the weight-comparison small multiples (CUSUM weight 1/12 = 0.0833).
- **What-is section:** the demonstration chart with target, limits, and an end-of-series drift.

Committed PNGs are unchanged (they stay the matplotlib images); the blocks are the reproducible Plotly equivalents. The two seed-based multi-panel explainer figures (`explain-CUSUM`, `explain-EWMA`) are left as static images, since they can't be byte-reproduced from the R seed and would need the `ewma()` definition reordered ahead of them.

## Verification
- `make text`: succeeds, no monitoring-chapter warnings.
- `make html`: succeeds; `grep -r goatcounter _build/html/contents` → **0**.
- All chapter code re-run end to end: PCR 0.5/13.4% and 2.0/~0%; Shewhart LCL 225.6 / UCL 252.0; β=0.8413; phase-2 flags only bale 4; EWMA table `[200, 203, 199.1, 196.4, 194.5, 193.1]`; CUSUM weight 0.0833.
- No lock files committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1hx9U3TydSonCDWXL2Q2D