### PR TITLE
Remove inert material from hidden RST comments (housekeeping from the comment scan)

### DIFF
--- a/data-visualization/data-visualization-in-context.rst
+++ b/data-visualization/data-visualization-in-context.rst
@@ -1,7 +1,6 @@
 .. todo:: another scatter plot question
 .. todo:: spectral data question
 .. todo:: batch data question
-.. todo:: add to slides: https://www.r-bloggers.com/one-liners-which-make-me-love-r-make-your-data-dance-hans-rosling-style-with-googlevis-rstats/
 
 .. index:: data visualization, quantitative plots
 

--- a/design-analysis-experiments/blocking-and-confounding-for-disturbances.rst
+++ b/design-analysis-experiments/blocking-and-confounding-for-disturbances.rst
@@ -20,7 +20,7 @@ Blocking is slightly different: blocking is a special way of running the experim
 Finally, a disturbance can be characterized as a **controlled disturbance**, in which case it isn't a disturbance anymore, as it is held constant for all experiments, and its effect cancels out. But it might be important to investigate  the controlled disturbance, especially if the system is operated later on when this disturbance is at a different level.
 
 
-.. Add discussion from MOOC about disturbances and covariates here. INclude the mind map from this discussion https://mail.google.com/mail/u/0/#sent/147a62c3237dc5fb
+.. Add discussion from MOOC about disturbances and covariates here, including the mind map from that discussion.
 
 
 

--- a/design-analysis-experiments/design-analysis-experiments.rst
+++ b/design-analysis-experiments/design-analysis-experiments.rst
@@ -171,7 +171,7 @@
 
 	I've noticed with the questions students are asking that they haven't understood what blocking is for, and how to generate expt with it.
 	Maybe include several examples in the text to justify why blocking is required and the thought process behind it.
-	Blocking: 4 batches in a 8 run experiment: use the example of /Users/kevindunn/Statistics course/Administrative/2010-handin/DOE project/Howard and Booker - 4C3 mini project.doc
+	Blocking: 4 batches in a 8 run experiment
 	DONE: Remove using a normal probability plot for significance of effects. I don't recall why I wanted to do this though: confusing interpretation, or perhaps q-q plots can misleading values?
 
 	Add some notes about factors that are uncontrollable, but still interesting: e.g. outside air humidity;  add it to your :math:`\mathbf{X}` matrix and even though not orthogonal, can still be understood in the model.
@@ -219,69 +219,6 @@
 	* Projectivity: use a better example than the 2^{6-2}_{IV} example: 3 factors remaining, vs 3 in is confusing.
 	* RSM: if it is a 2-factor factorial and the 2fi is high, then use a plot of the surface to decide on the next point, rather than just a plan \gamma step.
 
-
-.. Outline of third class
-
-	* Full factorial experiments
-	* Drop out terms that are not significant; extra DOF to estimate error
-	* Known, but uncontrollable disturbance: blocking parameter: confound on the highest interaction possible
-
-		-	2^3 example: we do least damage when confound with ABC interaction
-
-	* Next step: reduce the number of experiments. Question: which runs do we drop up so we cause least damage to the experiment?
-
-		- half fractions
-
-			- introduce a new terminology to deal with them: generators and defining relationship
-			- why? so we can determine aliasing (confounding pattern)
-			- why? we can see what we are loosing by running these half fractions
-
-			- running the other half fraction.
-
-			Side-issue:
-
-				* using generators to deal with blocking; B_1 = ABC for a 3-factor experiment:
-				* find the other half fraction: B_1 = -ABC
-
-		- fractionated experiments
-
-			-	use generators and def.rel. system to determine aliasing
-			-	why? decide which factors to assign to A, B, C, etc
-			-	worked example: complete
-			-	projectivity
-
-		- Special case: saturated experiments (III)
-
-	* RSM
-
-		- surfaces are smooth (p438 BHH2)
-		- models are approximations (p440 BHH2)
-		- direction of ascent:
-
-			- show a single curve: optimum by moving \gamma steps along x_1 (\gamma is our step size)
-			- two variables: by example
-
-		- as we approach optimum: we have to use higher order factorials to estimate 2nd order effects and curvature
-
-		- models that take second order effects into account: 3^k, CCD
-
-			- CCD: why and when: second order effects (b_AA, b_BB, b_CC terms)
-			- add axial points (\pm \alpha, 0, 0), etc
-			- use L/S to fit model
-
-		- show algorithm
-
-		- constraints? p 447 BHH2
-
-	* EVOP
-
-		- outline of it
-
-	* Guidance
-
-		- Umetrics book and Esbensen book: Start with screening design (resolution III) for a new system, or if you are unfamiliar with it
-		- Foldover idea to sequentially investigate and expand your design
-		- Half-fractions used when you don't have time to run full set of experiments (projectivity)
 
 .. TODO:
 

--- a/design-analysis-experiments/fractional-factorial-designs/design-foldover-and-projectivity.rst
+++ b/design-analysis-experiments/fractional-factorial-designs/design-foldover-and-projectivity.rst
@@ -11,8 +11,6 @@ Experiments are not a one-shot operation. They are almost always sequential, as 
 
 *Dealias a single main effect* (switch sign of one factor)
 
-.. See source code for this section: /Users/kevindunn/Sync/Figures/doe/check_foldover.m
-
 In the previous example we had a :math:`2^{7-4}_{\text{III}}` system with generators **D=AB**, **E=AC**, **F=BC**, and **G=ABC**. Effect **C** was the largest effect. But we cannot be sure it was large due to factor **C** alone: it might have been one of the interactions it is aliased with. The aliasing pattern for effect **C** was: :math:`\widehat{\beta}_{\mathbf{C}} \rightarrow` **C** + **AE** + **BF** + **DG**. For example, we might have reason to believe the **AE** interaction is large. We would like to do some additional experiments so that **C** becomes unconfounded with any two-factor interactions.
 
 The way we can do this is to run another 8 experiments, but this time just change the sign of **C** to **-C**; in other words, re-run the original 8 experiments where the *only* thing that is changed is to flip the signs on column **C**; the columns which are generated from column **C** should remain as they were. This implies that the generators have become **D=AB**, **E=-AC**, **F=-BC**, and **G=-ABC**. We must emphasize, do not re-create these generated columns from new signs in column **C**. What we have now is another :math:`2^{7-4}_{\text{III}}` design. You can calculate the aliasing pattern for the recent 8 experiments is :math:`\widehat{\beta}_{\mathbf{C}} \rightarrow` **C** - **AE** - **BF** - **DG**.

--- a/latent-variable-modelling/latent-variable-modelling.rst
+++ b/latent-variable-modelling/latent-variable-modelling.rst
@@ -12,17 +12,6 @@
 	* Importance of variation in your training PLS model (Kresta soft sensors paper as reference)
 	* Example of distillation column adding calculated variable and improving PLS model
 
-	Data sets
-	===========
-
-	See June's email on 22 Feb 2010
-	* GRINDER.DIF,
-	* Pulp digester.xls
-	* THICKNES.DIF
-	See Honglu's email on 1 March 2010: faulty reactor data set
-	Look at the MediBIC data: how does it compare to your made-up pastry data?
-	Board thickness
-
 
 .. FUTURE
 
@@ -37,7 +26,7 @@
 
 	Introduce a discussion about how much variance is captured in each latent variable early on (e.g. in the food texture example). The students are assuming LV1 explains variable 1.
 
-	When explaining t1p2 + t2p2+ ... : use a time-series example, like the room temperature example with the blip in the oscillations.  See the course email to Richard on 22 April 2010.
+	When explaining t1p2 + t2p2+ ... : use a time-series example, like the room temperature example with the blip in the oscillations.
 
 	Optimizing process: moving in score space while staying below SPE. Give it as an optimization formulation; example from Jaeckle.
 
@@ -62,7 +51,7 @@
 	Add "spectral-data-illustrate-residuals.svg" into the notes.\
 	Add "any other new illustrations not here, but in slides", e.g. geometric-interpretation-of-PCA-Hotellings-T2.png
 
-	Draw a picture of the geometric interpretation of SPE, showing a 3rd vector off the model plane. See email to David Gerardi on 29 June 2010.
+	Draw a picture of the geometric interpretation of SPE, showing a 3rd vector off the model plane.
 
 	Enhance the support on the other correlated illustration. Show numerically how small changes in highly correlated X's can lead to a rotated plane (and illustrate it: add the slope coefficient to the illustration)
 
@@ -70,7 +59,6 @@
 
 	Mark points, in black, in pastry example which are used in the notes (e.g. 33, 36, 44)
 	.. TODO lagging picture here
-	.. page 30 of pencil notes
 	.. PLOTS OF T2 with limit; plots of an ellipse.
 	Re-export the competitor model
 	SPE section: show contribution plot to SPE
@@ -101,81 +89,6 @@
 	* Google's translation
 	* bridge sensor network (Bridge in France)
 	* aircraft sensor network
-
-.. First class outline
-
-	Modern data sets
-	Value from data: what are we looking for from our data?
-	What is a latent variable
-
-		- averaging process from 4 temperatures
-		- pick up the average trends
-		- spinning cube
-
-	How are latent variables calculated
-
-		- axes
-		- spinning cube
-
-	PCA as a latent variables model
-
-		- specific equations for PCA
-		- X = TP' + E
-		- data = information + error
-
-
-	Interpreting latent variable models
-
-		- loadings plot
-		- score plot
-		- residuals
-		- SPE
-		- T2
-		- VIP (PCA)
-		- hat value for the n-th row: t_row \times (T'T)^{-1} t_row'
-		- clusters and outliers
-
-			- scores outlier
-			- SPE outlier
-			- T2 outlier
-
-	Extracting information from the latent variable model
-
-		- residuals
-		- contribution plot for errors
-		- contribution plot for scores
-		- Hat values
-		- Influence plot
-
-	Fitting a latent variable model in practice
-
-		- Eigenvalue or SVD
-		- NIPALS
-		- Missing data methods
-		- Q2 and R2
-
-	How PCA addresses issues raised earlier
-
-		- missing data
-		- signal to noise increase
-
-	In-class exercises (with R)
-
-		- PCA model on the temperature data
-		- Model on the thickness data (boards): 4 components
-		- Model on the quality data
-		- Foods data set
-
-.. Next class:
-
-	How to calculate the model
-	Number of components?
-	A taste of the 5 areas:
-		- Monitoring
-		- Troubleshooting
-		- etc
-	Calculating the model limits (SPE and T2): use a qq-plot to test if they really are F-distributed.
-
 
 .. Topics for future classes
 
@@ -286,7 +199,6 @@
 	============================
 
 	* Data compression in process historians (databases)
-	see pencil notes in thin black binder's front cover
 
 
 	Hat values: how to calculate; what they mean; plot of hats vs SPE (like influence plot in least squares)

--- a/latent-variable-modelling/principal-component-analysis/determining-the-number-of-components-to-use-in-the-model-with-cross-validation.rst
+++ b/latent-variable-modelling/principal-component-analysis/determining-the-number-of-components-to-use-in-the-model-with-cross-validation.rst
@@ -14,9 +14,7 @@ Determining the number of components to use in the model with cross-validation
 
 ..	- scree plot
 ..	- size of eigenvalue: :math:`\sum_a^{a=K}{\lambda_a} = K`
-..	- cross-validation: page 49 of pencil notes
-
-.. Review the ICS-L newsgroup postings around September 2009.
+..	- cross-validation
 
 .. Check Q2 values: in ProMV they keep increasing, never decreasing.
 
@@ -87,10 +85,8 @@ However, cross-validation's objective is useful for predictive models, such as P
 .. *	Batch data?
 .. *	Does it work well for DOE data (the usual shortcoming for Q2 calculations)
 .. *	Use a robust correlation estimate to guard against outliers in score correlations
-.. 	*	https://www.eric.ed.gov/ERICWebPortal/search/detailmini.jsp?_nfpb=true&_&ERICExtSearch_SearchValue_0=ED201658&ERICExtSearch_SearchType_0=no&accno=ED201658
 .. 	*	https://www.jstor.org/stable/2349088
 .. 	*	``covRob`` function in ``robust`` package in R
-.. 	*	https://www.unt.edu/benchmarks/archives/2001/december01/rss.htm
 ..
 .. *	Risk metric more interpretably for automated model fitting (quite common nowadays)
 .. *	Helpful to see the risk metric on a per-component basis, even if it is not used to determine the number of components.

--- a/latent-variable-modelling/projection-to-latent-structures/index.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/index.rst
@@ -37,7 +37,7 @@ But why use the PLS method at all?
    pls-exercises
 
 
-..	* page 52 of pencil notes
+..	Comparison of linear regression and projection to latent structures
 
 	Linear regression:
 		* Assumes no noise in X
@@ -59,35 +59,3 @@ But why use the PLS method at all?
 		*	If T2 and SPE value are below their limits, then we go ahead and make our prediction with confidence from the new X-vector.
 
 	* MLR shortcomings
-
-
-..	From Carlos' paper:
-
-	Projection to Latent Structures (PLS) is a multivariate regression tool that helps to reveal correlation amongst input-variables or
-	predictors (X-space) and also their impact on several responses (Y-space). This is done by separating regularities from noise in
-	the data. PLS handles data with strong collinearity, noise and missing values in both the X- and Y-spaces. This tool reduces the
-	dimension of the system to smaller number of ‘‘latent variables” (referred to as principal components or scores) that can simultaneously
-	explain the signifiant variance in X, and also predict Y. The higher the correlation in the data the fewer the principal components that
-	are computed. The scores are independent of each other and are a linear combination of the original predictors. The
-	weight of each predictor that is used to calculate the scores is directly related to their level of influence on the measured Y-space
-	properties. An important aspect of PLS is the ability to show the interrelationship among all predictors, the relationship among all
-	responses, and simultaneously the predictors’ influence on the measured responses, all of them in a single plot, the w*c plot. All
-	these calculations are usually carried out by first centering the data to have a mean of zero and then scaling to unit variance.
-	This process of mean centering and scaling is done in order to give each variable the same weight and importance prior to the analysis.
-	This is done to counteract the effect of scaling in different measurements units, and to allow each variable to contribute equally to
-	the model. As a regression tool, PLS provides a measure of the goodness of ﬁt, R2. R2 is an indication of how much variance in
-	the data is explained by the model. R2, for any regression tool, including PLS, can always be increased by adding more terms
-	(complexity) to the hypothesized model. A far better metric to gauge model performance is by using the so-called Q2 metric. Q2
-	is an indicator that measures how well the regression model can predict new data. One technique to estimate Q2 is by cross-validation.
-	This method consists of dividing the data into a number of groups. Models are built with a group of data left out – one group
-	at a time. With each model, the corresponding omitted data are predicted and the total prediction error sum of squares calculated.
-	Q2, like R2, varies between 0 and 1, where values closer to 1 indicate better prediction ability. The Q2 value will always be smaller
-	than R2. Finally, Q2 is used to select the number of principal components (model complexity) to avoid over-fitting.
-	PLS models can be converted to a standard linear regression form as given by the following equation:
-
-	:math:`\hat{y} = b_0 + \sum{b_i x_i}`
-
-	where k is a constant, bn is the coefﬁcient corresponding to the predictor xn and y is the predicted y-property. Details of the
-	PLS calculations can be found elsewhere [Wold S, Sjöström M, Eriksson L. PLS-regression: a basic tool of chemometrics.
-	Chemom Intell Lab Syst 2001;58(2):109–30.]. Several software packages are available to create PLS models. The SIMCA-P software by Umetrics
-	was used in this work.

--- a/least-squares-modelling/covariance-and-correlation.rst
+++ b/least-squares-modelling/covariance-and-correlation.rst
@@ -16,43 +16,6 @@ Consider the measurements from a gas cylinder; temperature (K) and pressure (kPa
 
 Given these numbers, we can simplify the ideal gas law to: :math:`p=\beta_1 T`, where :math:`\beta_1 = \dfrac{nR}{V} > 0`. These data are collected from sampling the system:
 
-.. wikitable
-
-	{| class="wikitable center"
-	|-
-	!
-	! :math:`T` = Cylinder temperature (K)
-	! :math:`p` = Cylinder pressure (kPa)
-	! :math:`h` = Room humidity (%)
-	|-
-	|||273|| 1600|| 42
-	|-
-	|||285|| 1670|| 48
-	|-
-	|||297|| 1730|| 45
-	|-
-	|||309|| 1830|| 49
-	|-
-	|||321|| 1880|| 41
-	|-
-	|||333|| 1920|| 46
-	|-
-	|||345|| 2000|| 48
-	|-
-	|||357|| 2100|| 48
-	|-
-	|||369|| 2170|| 45
-	|-
-	|||381|| 2200|| 49
-	|-
-	| || ||
-	|-
-	|'''Mean''' || 327 || 1910 || 46.1
-	|-
-	|'''Variance''' || 1320 || 43267 || 8.1
-	|}
-
-
 .. image:: ../figures/least-squares/table-of-cylinder-data.png
 	:width: 900px
 	:scale: 67

--- a/least-squares-modelling/least-squares-model-analysis.rst
+++ b/least-squares-modelling/least-squares-model-analysis.rst
@@ -89,41 +89,6 @@ Software packages report this number, together with the two degrees of freedom u
 it, and a p-value; we will point it out in the software output
 :ref:`later in this section <LS-software-output>`.
 
-..	Original table in wiki form
-
-		{| class="wikitable"
-		|-
-		! Type of variance
-		! Distance
-		! Degrees of freedom
-		! SSQ
-		! Mean square
-		|-
-		| Regression
-		| :math:`\hat{y}_i - \overline{\mathrm{y}}`
-		| :math:`k` (k=2 in the examples so far)
-		| RegSS
-		| :math:`RegSS/k`
-		|-
-		| Error
-		| :math:`y_i - \hat{y}_i`
-		| :math:`n-k`
-		| RSS
-		| :math:`RSS/(n-k)`
-		|-
-		|
-		|
-		|
-		|
-		|-
-		| Total
-		| :math:`y_i - \overline{\mathrm{y}}`
-		| :math:`n`
-		| TSS
-		| :math:`TSS/n`
-		|}
-
-
 .. _standard-error-section:
 
 Interpreting the standard error

--- a/least-squares-modelling/least-squares-modelling.rst
+++ b/least-squares-modelling/least-squares-modelling.rst
@@ -35,30 +35,6 @@
 	Non-linear least squares
 	Generalized linear models
 
-.. Outline
-
-	Correlation
-	Covariance
-	Least squares:
-		- minimizing errors as the objective function
-		- solution to the minimization problem: grid search vs analytically
-		- breakdown (allocation) of variance
-		- R2 derivation
-		- conf. interval for coefficients
-		- conf. interval for predictions
-		- interpretation of results from software packages
-		- assessment of residuals (interpretation)
-			- residuals in sequence
-			- residuals vs y-hat
-			- residuals vs y
-			- residuals vs x
-		- leverage, outliers and influence
-		- matrix approach
-			- introduce notation
-			- resolve the optimization problem
-			- interpretation of coefficients
-			- errors on the coefficients
-
 Least squares modelling in context
 ====================================
 

--- a/least-squares-modelling/least-squares-models-with-a-single-x-variable.rst
+++ b/least-squares-modelling/least-squares-models-with-a-single-x-variable.rst
@@ -188,41 +188,6 @@ We will refer back to the following example several times. Calculate the least s
 		:align: center
 		:scale: 40
 
-..	Raw data
-	{| class="wikitable" style="text-align: center; margin-left:auto; margin-right:auto;"  border="1"
-	|-
-	! :math:`x_1\,`
-	! :math:`y_1\,`
-	|-
-	| 10.0 ||  8.04
-	|-
-	|  8.0 ||  6.95
-	|-
-	| 13.0 ||  7.58
-	|-
-	|  9.0 ||  8.81
-	|-
-	| 11.0 ||  8.33
-	|-
-	| 14.0 ||  9.96
-	|-
-	|  6.0 ||  7.24
-	|-
-	|  4.0 ||  4.26
-	|-
-	| 12.0 || 10.84
-	|-
-	|  7.0 ||  4.82
-	|-
-	|  5.0 ||  5.68
-	|-
-	| colspan="2" align="left"|
-	* :math:`\overline{x}_1= 9.0`
-	* :math:`\overline{y}_1= 7.5`
-	* :math:`\sum_i{\left(x_i - \overline{\mathrm{x}}_1\right)\left(y_i - \overline{\mathrm{y}}_1\right) }= 55.0`
-	* :math:`\sum_i{\left( x_i - \overline{\mathrm{x}}_1\right)^2} = 110`
-	|}
-
 To calculate the least squares model:
 
 .. code-block:: python

--- a/process-monitoring/process-monitoring.rst
+++ b/process-monitoring/process-monitoring.rst
@@ -6,7 +6,6 @@
 	^^^^^
 	-----
 
-.. MIT courseware: https://ocw.mit.edu/OcwWeb/Mechanical-Engineering/2-830JSpring-2008/VideoLectures/index.htm
 
 .. TODO list of plots
     Plot of Shewhart chart
@@ -93,7 +92,7 @@ References and readings
 ..	Bisgaard, S., "`The Quality Detective: A Case Study <https://dx.doi.org/10.1098/rsta.1989.0006>`_", Philosophical Transactions of the Royal Society-A, **327**, p 499-511, 1989.
 .. UMetrics book: review chapter on (M)SPC
 .. MacGregors 1997 paper on MSPC
-.. * Controversy between monitoring charts and hypothesis tests, Woodall, Woodall, W. Controversies and Contradictions in Statistical Process Control, JQT, 32(4), 341-350, 2000 ([http://filebox.vt.edu/users/bwoodall/ Link])
+.. * Controversy between monitoring charts and hypothesis tests: Woodall, W., "Controversies and Contradictions in Statistical Process Control", Journal of Quality Technology, 32(4), 341-350, 2000. https://doi.org/10.1080/00224065.2000.11979963
 .. EWMV paper by MacGregor?
 .. Box, G.E.P., Comparisons, Absolute Values, and How I Got to Go to the Folies Bergeres, Quality Engineering, 14(1), p167-169, 2001.
 .. p 669 of Devore: see also Technometrics, 1989, p173-184, by David M Rocke

--- a/univariate-review/normal-distribution-and-checking-for-normality.rst
+++ b/univariate-review/normal-distribution-and-checking-for-normality.rst
@@ -141,7 +141,6 @@ We frequently violate this assumption of independence in engineering application
 
 .. See Hodges and Lehmann (1970): there is a whole Chapter devoted to it.
 
-.. See: https://www.rsscse.org.uk/ts/gtb/contents.html: article on Teaching Independence; see PDF file in Readings directory.
 
 
 Formal definition for the normal distribution

--- a/univariate-review/testing-for-differences-and-similarity.rst
+++ b/univariate-review/testing-for-differences-and-similarity.rst
@@ -20,45 +20,6 @@ Either we want to confirm things are statistically the same, or confirm they hav
 	:scale: 60
 	:align: center
 
-.. wikicode for table:
-
-	{| class="wikitable center"
-	|-
-	! Experiment number
-	! Feedback system
-	! Yield
-	!
-	! Experiment number
-	! Feedback system
-	! Yield
-	|-
-	| 1 || A ||  92.7 ||  || 11 || B || 83.5
-	|-
-	| 2 || A ||  73.3 ||  || 12 || B || 78.9
-	|-
-	| 3 || A ||  80.5 ||  || 13 || B || 82.7
-	|-
-	| 4 || A ||  81.2 ||  || 14 || B || 93.2
-	|-
-	| 5 || A ||  87.1 ||  || 15 || B || 86.3
-	|-
-	| 6 || A ||  69.2 ||  || 16 || B || 74.7
-	|-
-	| 7 || A ||  81.9 ||  || 17 || B || 81.6
-	|-
-	| 8 || A ||  73.9 ||  || 18 || B || 92.4
-	|-
-	| 9 || A ||  78.6 ||  || 19 || B || 83.6
-	|-
-	| 10 || A || 80.5 ||  || 20 || B || 72.4
-	|-
-	| colspan="7" |
-	|-
-	| colspan="2" |Mean  || 79.89|| || colspan="2" | Mean || 82.93
-	|-
-	| colspan="2" |Standard deviation  || 6.81|| || colspan="2" | Standard deviation || 6.70
-	|}
-
 .. image:: ../figures/univariate/system-comparison-wikitable.png
 	:align: center
 

--- a/univariate-review/univariate-data-analysis-in-context.rst
+++ b/univariate-review/univariate-data-analysis-in-context.rst
@@ -42,23 +42,6 @@ What we will cover
   :align: center
   :scale: 92
 
-.. Concepts
-.. ========
-..
-.. Concepts that you must be familiar with by the end of this section:
-..
-.. .. tabularcolumns:: LLL
-..
-.. .. csv-table::
-..    :widths: 10, 10, 10
-..
-.. 	, independence, outliers
-.. 	"frequency histogram", probability, variation
-.. 	"cumulative distribution", median, MAD
-.. 	population, sample, error
-.. 	"Central limit theorem", parameter, statistic
-.. 	"confidence interval", outlier, "paired test"
-
 References and readings
 =======================
 


### PR DESCRIPTION
## What this is

The follow-up to the hidden-RST-comment scan: all `..` comment blocks in the book source (author notes that never render in the HTML/PDF) were catalogued. The actionable ones became issues #203-#217 (10 technical-accuracy flags, 5 grouped work lists). This PR deletes only the inert debris; **no rendered output changes**.

## What was removed (386 deletions across 15 files)

- **Local machine paths, personal email references, "pencil notes" pointers** that no reader or future editor can act on: `/Users/kevindunn/...` script and document paths, "See June's/Honglu's/Richard's/David Gerardi's email (2010)", "page 30/49/52 of pencil notes", a Gmail deep link (the underlying MOOC-discussion idea was kept, only the unusable link dropped).
- **Dead links from around 2010**: the old MIT OCW `OcwWeb` URL scheme, the ERIC portal search URL, UNT benchmarks, rsscse.org.uk, an "add to slides" r-bloggers note (slides are not in this repo). The Woodall (2000) JQT citation kept its text and now points at its DOI instead of the retired `filebox.vt.edu` host; that closes the comment-line item of #77 (the rendered exercise link in `process-monitoring-exercises.rst` is still open there).
- **Leftover MediaWiki-format tables** in four least-squares/univariate files, relics of the wiki-to-RST migration whose data already appears in rendered form (image or RST table) immediately next to them.
- **A verbatim excerpt from "Carlos' paper"** in the PLS index, which was only ever reference material.
- **Classroom lecture outlines** ("First class outline", "Next class", "Outline of third class", a commented concepts table, a chapter outline), which predate the book form of the material.

## What was deliberately kept

- Every comment block holding drafted content, a technical doubt, or a reusable idea: those are catalogued in issues #203-#217 with sha-pinned permalinks, so this PR shifting line numbers does not break the references.
- Provenance/permission notes (the Heydari-Cook data source, the Ghassan Marjaba solution-permission record).
- The "Topics for future classes" blocks that carry content ideas rather than a lecture plan.

## Verification

- `make text`: build succeeded, **zero warnings**.
- Rendered-output invariance: `_build/text` from this branch is **byte-identical** (`diff -r`) to the build from `main`.
- `make html`: succeeded; `grep -r goatcounter _build/html/contents` returns zero hits.
- `CITATION.cff` already carries today's version (2026.07.05) from this morning's merged PRs, so no bump was needed.
- No lock files are included in the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L51ST1xP1XXSABb6wDUv6y

---
_Generated by [Claude Code](https://claude.ai/code/session_01L51ST1xP1XXSABb6wDUv6y)_