### PR TITLE
Widen readership stats display window to 60 days

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.07.05"
-date-released: 2026-07-05
+version: "2026.07.06"
+date-released: 2026-07-06
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/_static/js/telemetry.js
+++ b/_static/js/telemetry.js
@@ -57,7 +57,7 @@
   //   - stats.rst                            ("(last N days)" x3 + body)
   // and the backend (365) stays the same.
   // -------------------------------------------------------------------
-  var DISPLAY_DAYS = 30;
+  var DISPLAY_DAYS = 60;
   var DISPLAY_LABEL = DISPLAY_DAYS + " days";
 
   // Find the most recent date present anywhere in the JSON. Used as

--- a/_templates/pid-sidebar-extra.html
+++ b/_templates/pid-sidebar-extra.html
@@ -31,7 +31,7 @@
   <div id="pid-sparkline-block" style="display:none">
     <hr/>
     <p style="color:#777; font-size:0.85em; margin:0.3em 0 0.1em">
-      Page views (30 days)<span id="pid-sparkline-total"
+      Page views (60 days)<span id="pid-sparkline-total"
         style="float:right; font-variant-numeric:tabular-nums"></span>
     </p>
     <div id="pid-sparkline" style="width:100%; height:38px"

--- a/stats.rst
+++ b/stats.rst
@@ -14,7 +14,7 @@ See :ref:`privacy` for what is and isn't collected.
 
 .. note::
 
-   The in-book figures show the most recent **30 days** while the
+   The in-book figures show the most recent **60 days** while the
    pipeline is still bedding in. Two server-side fixes only took
    effect recently, so wider windows are not yet representative:
 
@@ -45,7 +45,7 @@ Summary
      the data file is reachable.</em></p>
    </div>
 
-Daily reads (last 30 days)
+Daily reads (last 60 days)
 --------------------------
 
 Total reads per day across the whole book. Each daily bucket
@@ -56,10 +56,10 @@ count once.
 
    <div id="pid-stats-daily" style="width:100%; height:280px; display:none"></div>
 
-Most-read pages (last 30 days)
+Most-read pages (last 60 days)
 ------------------------------
 
-The 20 pages with the most reads over the 30-day window. Page names
+The 20 pages with the most reads over the 60-day window. Page names
 are the Sphinx page identifiers (e.g. ``data-visualization/box-plots``);
 click through to read them.
 
@@ -67,10 +67,10 @@ click through to read them.
 
    <div id="pid-stats-top" style="display:none"></div>
 
-Least-read pages (last 30 days)
+Least-read pages (last 60 days)
 -------------------------------
 
-The 10 pages with the *fewest* reads over the 30-day window, lowest
+The 10 pages with the *fewest* reads over the 60-day window, lowest
 first. Useful for spotting sections that may need clearer links,
 better discoverability, or a refresh.
 


### PR DESCRIPTION
## What changed

The in-book readership statistics (the `/pid/stats` page and the per-page sidebar sparkline) previously showed the most recent **30 days**. This widens the display window to **60 days**.

The window is driven by a single configurable variable, `DISPLAY_DAYS`, in `_static/js/telemetry.js`. Its comment requires the human-facing "N days" labels to be kept in lockstep, so this PR updates all of them together:

- `_static/js/telemetry.js`: `DISPLAY_DAYS = 30` -> `60`.
- `_templates/pid-sidebar-extra.html`: sidebar heading "Page views (30 days)" -> "(60 days)".
- `stats.rst`: the note prose plus the three section headings/bodies ("last 30 days" x3, "30-day window" x2) -> 60.

The backend `sparklines.json` window (365 days) is unchanged; only the front-end display window widens.

## What didn't change

No pipeline, aggregation, or data-collection logic changed. This is purely the front-end display window and its labels. Unrelated "30 days" references (server log-rotation policy in `privacy.rst` / `docs/telemetry/`, and other chapters) were left untouched.

## Version

Per the repo's citation rule, `CITATION.cff` `version:` and `date-released:` were bumped to `2026.07.06` / `2026-07-06`.

## Verification

- `make text`: build succeeded, exit 0. The rendered `_build/text/stats.txt` shows "60 days" in all five spots. The 343 warnings are all pre-existing "image file not readable" / missing-include entries from the `figures/` symlink, which is not populated in this environment (it lives in the separate `kgdunn/figures` repo); none touch the changed files.
- No lock files were committed (`uv.lock` left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfzX71VfdjydfXBoGKRHFe

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfzX71VfdjydfXBoGKRHFe)_