### PR TITLE
Process monitoring (Ch. 3): reorder the EWMA subsection for clearer flow

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.07.06"
-date-released: 2026-07-06
+version: "2026.07.07"
+date-released: 2026-07-07
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/process-monitoring/ewma-charts.rst
+++ b/process-monitoring/ewma-charts.rst
@@ -9,7 +9,12 @@ EWMA charts
 
 The two previous charts highlight 2 extremes of monitoring charts. On the one hand, a Shewhart chart assumes each subgroup sample is independent (unrelated) to the next - implying there is no "memory" in the chart. On the other hand, a CUSUM chart has an infinite memory, all the way back to the time the chart was started or reset at :math:`t=0` (see the :ref:`equation in the prior section <monitoring_eqn_CUSUM-derivation>`).
 
-As an introduction to the exponentially weighted moving average (EWMA) chart, consider first the simple :index:`moving average` (MA) chart. This chart is used just like a Shewhart chart, except the samples that make up each subgroup are calculated using a moving window of width :math:`n`. The case of :math:`n=5` is shown below.
+We will see that the EWMA (exponentially weighted moving average) chart spans these two extremes through a single adjustable weight, :math:`\lambda`, chosen between 0 and 1. As :math:`\lambda \rightarrow 1`, the EWMA chart behaves more as a Shewhart chart, giving only weight to the most recent observation. As :math:`\lambda \rightarrow 0`, the EWMA chart starts to have an infinite memory, like a CUSUM chart. Depending on the weight :math:`\lambda`, the user can pick where between these two extremes to operate. The rest of this section derives the chart, shows how :math:`\lambda` sets the weight given to past data, and gives the control limits.
+
+From the moving average to the EWMA
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As a stepping stone to the EWMA chart, consider first the simple :index:`moving average` (MA) chart. This chart is used just like a Shewhart chart, except the samples that make up each subgroup are calculated using a moving window of width :math:`n`. The case of :math:`n=5` is shown below.
 
 .. image:: ../figures/monitoring/explain-moving-average-data-source.png
 	:width: 800px
@@ -45,7 +50,16 @@ To start the EWMA sequence we define the value for :math:`\hat{x}_0 = T` and :ma
 
 The last line in the equation group above shows that a 1-step-ahead prediction for :math:`x` at time :math:`t+1` is a weighted sum of two components: the current measured value, :math:`x_t`, and secondly the predicted value, :math:`\hat{x}_t`, with the weights summing up to 1. This gives a way to experimentally find a suitable :math:`\lambda` value from historical data: adjust it up and down until the differences between :math:`\hat{x}_{t+1}` and the actual measured values of :math:`x_{t+1}` are small.
 
-The code here shows one way of calculating the EWMA values for a vector of data. Once you have defined the function, use it as ``ewma(x, lam=..., target=...)``. It is reused below, both to generate the comparison figure and in the worked example at the end of this section.
+To see why :math:`\hat{x}_{t}` represents historical data, you can recursively substitute and show that:
+
+.. math::
+
+	\hat{x}_{t+1} &= \sum_{i=0}^{i=t}{w_i x_i} = w_0x_0 + w_1x_1 + w_2x_2 + \ldots \\
+	\text{where the weights are:} \qquad w_i &= \lambda (1-\lambda)^{t-i}
+
+which emphasizes that the prediction is a just a weighted sum of the raw measurements, with weights declining in time.
+
+The code here shows one way of calculating the EWMA values for a vector of data. Once you have defined the function, use it as ``ewma(x, lam=..., target=...)``. It is reused below, both to generate the comparison figures and in the worked example at the end of this section.
 
 .. code-block:: python
 
@@ -84,58 +98,10 @@ The code here shows one way of calculating the EWMA values for a vector of data.
 	x <- c(200, 210, 190, 190, 190, 190)
 	ewma(x, lambda = 0.3, target = 200)
 
-The next plot shows visually what happens as the weight of :math:`\lambda` is changed. In this example a shift of :math:`\Delta = 1\sigma = 3` units occurs abruptly at :math:`t=150`. This is of course not known in practice, but the purpose here is to illustrate the effects of choosing :math:`\lambda`. Prior to that change the process mean is :math:`\mu=20` and the raw data has :math:`\sigma = 3`.
+The EWMA weights
+~~~~~~~~~~~~~~~~~
 
-The first chart is the raw data and also a Shewhart chart with subgroup size of 1; the control limits are at :math:`\pm 3` times the standard deviation, so at 11.0 and 29.0 units. This control chart barely picks up the shift, as was explained in a :ref:`prior section <monitoring_shewart_chart_slugishness>`.
-
-The second, third and fourth charts are EWMA charts with different values of :math:`\lambda`; the line is the value on the left-hand side of equation :eq:`ewma-derivation-2`, in other words it is :math:`\hat{x}_{t+1}`, the EWMA value at time :math:`t`. We see that as :math:`\lambda` decreases, the charts are smoother, since the averaging effect is greater: more and more weight is given to the history, :math:`\hat{x}_{t}`, and less weight to the current data point, :math:`x_t`.  See equation :eq:`ewma-derivation-2` to understand that interpretation. Also note carefully how the control limits become narrower as the :math:`\lambda` decreases, as is explained shortly below.
-
-To see why :math:`\hat{x}_{t}` represents historical data, you can recursively substitute and show that:
-
-.. math::
-
-	\hat{x}_{t+1} &= \sum_{i=0}^{i=t}{w_i x_i} = w_0x_0 + w_1x_1 + w_2x_2 + \ldots \\
-	\text{where the weights are:} \qquad w_i &= \lambda (1-\lambda)^{t-i}
-
-which emphasizes that the prediction is a just a weighted sum of the raw measurements, with weights declining in time.
-
-The final chart of the sequence of 5 charts is a CUSUM chart, which is :ref:`the ideal chart <monitoring_CUSUM_charts>` for picking up such an abrupt shift in the level.
-
-.. code-block:: python
-
-	# Reuse the seeded series (base, mu, sigma, shift_at) from the
-	# CUSUM section, now with a larger shift of 1 sigma = 3 units.
-	data_shift = base.copy()
-	data_shift[shift_at:] += 1.0 * sigma
-
-	titles = ("Raw data (also a Shewhart chart, subgroup size 1)",
-	          "EWMA with lambda = 0.8", "EWMA with lambda = 0.4",
-	          "EWMA with lambda = 0.1", "CUSUM")
-	fig = make_subplots(rows=5, cols=1, subplot_titles=titles)
-	fig.add_trace(go.Scatter(y=data_shift, mode="lines"), row=1, col=1)
-	fig.add_hline(y=mu - 3 * sigma, line_color="red", row=1, col=1)
-	fig.add_hline(y=mu + 3 * sigma, line_color="red", row=1, col=1)
-	for row, lam in ((2, 0.8), (3, 0.4), (4, 0.1)):
-	    half_width = 3 * sigma * np.sqrt(lam / (2 - lam))
-	    fig.add_trace(go.Scatter(y=ewma(data_shift, lam, target=mu),
-	                             mode="lines"), row=row, col=1)
-	    fig.add_hline(y=mu - half_width, line_color="red", row=row, col=1)
-	    fig.add_hline(y=mu + half_width, line_color="red", row=row, col=1)
-	fig.add_trace(go.Scatter(y=np.cumsum(data_shift - mu), mode="lines"),
-	              row=5, col=1)
-	for row in range(1, 6):
-	    fig.add_vline(x=shift_at, line_dash="dash", row=row, col=1)
-	fig.update_layout(height=1200, showlegend=False)
-	fig.show()
-
-.. figure:: ../figures/monitoring/explain-EWMA.png
-	:width: 750px
-	:align: center
-	:scale: 80
-
-In the next figure, we show a comparison of the weights used in different monitoring charts studied so far.
-
-From the above discussion and the weights shown for the 4 different charts, it should be clear now how an EWMA chart is a tradeoff between a Shewhart chart and a CUSUM chart. As :math:`\lambda \rightarrow 1`, the EWMA chart behaves more as a Shewhart chart, giving only weight to the most recent observation. While as :math:`\lambda \rightarrow 0` the EWMA chart starts to have an infinite memory (like a CUSUM chart). There are 12 data points used in the example, so the CUSUM 'weight' is one twelfth or :math:`\approx 0.0833`.
+The next figure compares the weights each chart gives to past observations, for the four charts studied so far. There are 12 data points used in the example, so the CUSUM 'weight' is one twelfth, or :math:`\approx 0.0833`, spread equally over all points. The EWMA weights (here with :math:`\lambda=0.4`) decay geometrically, while the Shewhart chart places all its weight on the single most recent point. The figure makes concrete the trade-off previewed at the start of this section: :math:`\lambda` slides the EWMA between the Shewhart and CUSUM extremes.
 
 .. code-block:: python
 
@@ -171,6 +137,9 @@ From the above discussion and the weights shown for the 4 different charts, it s
 
 .. FAKE WIDTH ABOVE
 
+Control limits for the EWMA chart
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 The upper and lower control limits for the EWMA plot are plotted in the same way as the Shewhart limits, but calculated differently:
 
 .. math::
@@ -180,14 +149,57 @@ The upper and lower control limits for the EWMA plot are plotted in the same way
 		 \text{LCL} = \overline{\overline{x}} - L \cdot \sigma_{\text{Shewhart}}\sqrt{\frac{\displaystyle \lambda}{\displaystyle 2-\lambda}} &&  &&  \text{UCL} = \overline{\overline{x}} + L \cdot \sigma_{\text{Shewhart}} \sqrt{\frac{\displaystyle \lambda}{\displaystyle 2-\lambda}}
 	\end{array}
 
-where :math:`\sigma_{\text{Shewhart}}` represents the standard deviation as calculated for the Shewhart chart; for individual observations (subgroup size 1, as in the example above) this is simply the process standard deviation :math:`\sigma`. The multiplier :math:`L` is usually a value of 3, similar to the 3 standard deviations used in a Shewhart chart, but can of course be set to any level that balances the type I (false alarms) and type II errors (not detecting a deviation which is present already). We write :math:`L` rather than :math:`K` to avoid a clash with the CUSUM reference value :math:`K` of the :ref:`previous section <monitoring_CUSUM_charts>`.
+where :math:`\sigma_{\text{Shewhart}}` represents the standard deviation as calculated for the Shewhart chart; for individual observations (subgroup size 1, as in the example below) this is simply the process standard deviation :math:`\sigma`. The multiplier :math:`L` is usually a value of 3, similar to the 3 standard deviations used in a Shewhart chart, but can of course be set to any level that balances the type I (false alarms) and type II errors (not detecting a deviation which is present already). We write :math:`L` rather than :math:`K` to avoid a clash with the CUSUM reference value :math:`K` of the :ref:`previous section <monitoring_CUSUM_charts>`.
 
 The limits in equation :eq:`ewma-limits` are the steady-state limits. For the first few points the exact standard deviation of :math:`\hat{x}_t` is smaller, by the factor :math:`\sqrt{1-(1-\lambda)^{2t}}`, so many software packages draw limits that start narrower and widen to the steady-state value within a handful of samples.
+
+The next plot shows visually what happens as the weight of :math:`\lambda` is changed. In this example a shift of :math:`\Delta = 1\sigma = 3` units occurs abruptly at :math:`t=150`. This is of course not known in practice, but the purpose here is to illustrate the effects of choosing :math:`\lambda`. Prior to that change the process mean is :math:`\mu=20` and the raw data has :math:`\sigma = 3`.
+
+The first chart is the raw data and also a Shewhart chart with subgroup size of 1; the control limits are at :math:`\pm 3` times the standard deviation, so at 11.0 and 29.0 units. This control chart barely picks up the shift, as was explained in a :ref:`prior section <monitoring_shewart_chart_slugishness>`.
+
+The second, third and fourth charts are EWMA charts with different values of :math:`\lambda`; the line is the value on the left-hand side of equation :eq:`ewma-derivation-2`, in other words it is :math:`\hat{x}_{t+1}`, the EWMA value at time :math:`t`. We see that as :math:`\lambda` decreases, the charts are smoother, since the averaging effect is greater: more and more weight is given to the history, :math:`\hat{x}_{t}`, and less weight to the current data point, :math:`x_t`. The control limits also become narrower as :math:`\lambda` decreases: the half-width in equation :eq:`ewma-limits` above is proportional to :math:`\sqrt{\lambda/(2-\lambda)}`, which shrinks as :math:`\lambda \rightarrow 0`.
+
+The final chart of the sequence of 5 charts is a CUSUM chart, which is :ref:`the ideal chart <monitoring_CUSUM_charts>` for picking up such an abrupt shift in the level.
+
+.. code-block:: python
+
+	# Reuse the seeded series (base, mu, sigma, shift_at) from the
+	# CUSUM section, now with a larger shift of 1 sigma = 3 units.
+	data_shift = base.copy()
+	data_shift[shift_at:] += 1.0 * sigma
+
+	titles = ("Raw data (also a Shewhart chart, subgroup size 1)",
+	          "EWMA with lambda = 0.8", "EWMA with lambda = 0.4",
+	          "EWMA with lambda = 0.1", "CUSUM")
+	fig = make_subplots(rows=5, cols=1, subplot_titles=titles)
+	fig.add_trace(go.Scatter(y=data_shift, mode="lines"), row=1, col=1)
+	fig.add_hline(y=mu - 3 * sigma, line_color="red", row=1, col=1)
+	fig.add_hline(y=mu + 3 * sigma, line_color="red", row=1, col=1)
+	for row, lam in ((2, 0.8), (3, 0.4), (4, 0.1)):
+	    half_width = 3 * sigma * np.sqrt(lam / (2 - lam))
+	    fig.add_trace(go.Scatter(y=ewma(data_shift, lam, target=mu),
+	                             mode="lines"), row=row, col=1)
+	    fig.add_hline(y=mu - half_width, line_color="red", row=row, col=1)
+	    fig.add_hline(y=mu + half_width, line_color="red", row=row, col=1)
+	fig.add_trace(go.Scatter(y=np.cumsum(data_shift - mu), mode="lines"),
+	              row=5, col=1)
+	for row in range(1, 6):
+	    fig.add_vline(x=shift_at, line_dash="dash", row=row, col=1)
+	fig.update_layout(height=1200, showlegend=False)
+	fig.show()
+
+.. figure:: ../figures/monitoring/explain-EWMA.png
+	:width: 750px
+	:align: center
+	:scale: 80
 
 An interesting implementation can be to show both the Shewhart and EWMA plot on the same chart, with both sets of limits. The EWMA value plotted is actually the one-step ahead prediction of the next :math:`x`-value, which can be informative for slow-moving processes.
 
 .. EWMA can detect both changes in level and changes in variance
 .. TODO: After introducing concept, show why Shewhart fails with heavy autocorr. Have to increase Shewhart N, or widen the limits.
+
+Worked example
+~~~~~~~~~~~~~~~
 
 Here is a worked example, starting with the assumption the process is at the target value of :math:`T = 200` units, and :math:`\lambda=0.3`. We intentionally show what happens if the new value stays fixed at 190: you see the value plotted gets only a weight of 0.3, while the 0.7 weight is for the prior historical value. Slowly the value plotted catches up, but there is always a lag. The value plotted on the chart is from the first equation in the set of :eq:`ewma-derivation-2`, namely :math:`\hat{x}_t = \lambda x_t + (1-\lambda)\hat{x}_{t-1}`.
 


### PR DESCRIPTION
## Why
The EWMA subsection was confusingly ordered:
1. Its central idea, that the EWMA chart bridges the Shewhart and CUSUM extremes through the single weight λ, was buried near the **end** of the section.
2. The control limits (LCL/UCL) were **referred to before their equation appeared** ("control limits become narrower … as is explained shortly below", well above the `ewma-limits` equation).

## What changed (prose reorder only)
- **Lead with the λ framing:** moved the "as λ→1 it acts like a Shewhart chart; as λ→0 like a CUSUM chart; the user picks the trade-off" statement to the top of the section and reworded it as a forward-looking preview.
- **Four subsection headings** added: *From the moving average to the EWMA*, *The EWMA weights*, *Control limits for the EWMA chart*, *Worked example*.
- **Control-limit equation moved ahead** of the five-panel comparison figure, so the limits are defined before any prose/figure uses them. The old forward reference now points back at the preceding `ewma-limits` equation ("the half-width … is proportional to √(λ/(2−λ))").
- **Weight-recursion derivation** (w_i = λ(1−λ)^{t−i}) moved out of the figure description and into the derivation where it belongs.

## What did NOT change
No equations, figures, code, or numbers were altered. The chapter still reads top-to-bottom as one runnable script (ewma() is still defined before its use; the 5-panel block still reuses the CUSUM section's seeded series).

## Verification
- Ran the EWMA code blocks in the new order (after the CUSUM page): they execute and the worked-example table still reproduces `[200, 203, 199.1, 196.4, 194.5, 193.1]`; λ=0.1 EWMA half-width 2.065; CUSUM weight 0.0833.
- `make text`: succeeds, **zero warnings** (headings render as 3.6.1–3.6.4).
- `make html`: succeeds; `grep -r goatcounter _build/html/contents` → **0**.
- Confirmed no "shortly below" / "from the above discussion" forward references remain, and the limits section (3.6.3) now precedes the figure that displays them.
- `CITATION.cff` date bumped to 2026-07-07.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1hx9U3TydSonCDWXL2Q2D

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1hx9U3TydSonCDWXL2Q2D)_