### PR TITLE
Process monitoring (Ch. 3): EWMA weights example + exercises correctness and Python solutions

### DIFF
--- a/process-monitoring/ewma-charts.rst
+++ b/process-monitoring/ewma-charts.rst
@@ -59,6 +59,16 @@ To see why :math:`\hat{x}_{t}` represents historical data, you can recursively s
 
 which emphasizes that the prediction is a just a weighted sum of the raw measurements, with weights declining in time.
 
+As a small example, take :math:`\lambda=0.5` and :math:`t=7`. The weight on each of the eight measurements :math:`x_0` to :math:`x_7` is :math:`w_i = \lambda(1-\lambda)^{t-i} = 0.5 \times 0.5^{\,7-i}`, so each weight is half the next more recent one:
+
+====  ======  ======  ======  ======  ======  ======  ======  ======
+i     0       1       2       3       4       5       6       7
+====  ======  ======  ======  ======  ======  ======  ======  ======
+w_i   0.0039  0.0078  0.0156  0.0313  0.0625  0.1250  0.2500  0.5000
+====  ======  ======  ======  ======  ======  ======  ======  ======
+
+These eight weights sum to 0.9961; the remaining 0.0039 is the weight :math:`(1-\lambda)^{t+1} = 0.5^{8}` carried by the starting value :math:`\hat{x}_0 = T`, so the weights total 1.
+
 The code here shows one way of calculating the EWMA values for a vector of data. Once you have defined the function, use it as ``ewma(x, lam=..., target=...)``. It is reused below, both to generate the comparison figures and in the worked example at the end of this section.
 
 .. code-block:: python
@@ -145,8 +155,9 @@ The upper and lower control limits for the EWMA plot are plotted in the same way
 .. math::
 	:label: ewma-limits
 
-	\begin{array}{rcccl}
-		 \text{LCL} = \overline{\overline{x}} - L \cdot \sigma_{\text{Shewhart}}\sqrt{\frac{\displaystyle \lambda}{\displaystyle 2-\lambda}} &&  &&  \text{UCL} = \overline{\overline{x}} + L \cdot \sigma_{\text{Shewhart}} \sqrt{\frac{\displaystyle \lambda}{\displaystyle 2-\lambda}}
+	\begin{array}{rcl}
+		 \text{LCL} &=& \overline{\overline{x}} - L \cdot \sigma_{\text{Shewhart}}\sqrt{\dfrac{\lambda}{2-\lambda}} \\ \\
+		 \text{UCL} &=& \overline{\overline{x}} + L \cdot \sigma_{\text{Shewhart}} \sqrt{\dfrac{\lambda}{2-\lambda}}
 	\end{array}
 
 where :math:`\sigma_{\text{Shewhart}}` represents the standard deviation as calculated for the Shewhart chart; for individual observations (subgroup size 1, as in the example below) this is simply the process standard deviation :math:`\sigma`. The multiplier :math:`L` is usually a value of 3, similar to the 3 standard deviations used in a Shewhart chart, but can of course be set to any level that balances the type I (false alarms) and type II errors (not detecting a deviation which is present already). We write :math:`L` rather than :math:`K` to avoid a clash with the CUSUM reference value :math:`K` of the :ref:`previous section <monitoring_CUSUM_charts>`.

--- a/process-monitoring/process-monitoring-exercises.rst
+++ b/process-monitoring/process-monitoring-exercises.rst
@@ -183,19 +183,19 @@ Exercises
 			:width: 750px
 			:align: center
 
-	#.	The initial Shewhart parameters found were:
+	#.	Each board carries six thickness measurements across its width; we use the median of those six values as the single thickness for that board. The initial Shewhart parameters found were:
 
-		-	UCL = 1701
-		-	Target = 1676
-		-	LCL	= 1652
+		-	UCL = 1699
+		-	Target = 1677
+		-	LCL	= 1655
 
 		When plotting these limits on the phase 1 data, there was only one subgroup that was found outside the limits (the first subgroup). This subgroup is removed and the limits recalculated. (For this case there was only one, very moderate, subgroup outside the limits - the new limits are basically the same). The new limits
 
-		-	UCL = 1700
+		-	UCL = 1698
 		-	Target = 1676
-		- 	LCL = 1651
+		- 	LCL = 1654
 
-		A Shewhart chart of all the phase 1 data (including outliers, to highlight them) is shown here. The limits were the final limits, after iteratively removing the first unusual subgroup	. The code contains all the calculation steps.
+		A Shewhart chart of all the phase 1 data (including outliers, to highlight them) is shown here. The limits were the final limits, after iteratively removing the first unusual subgroup. The code contains all the calculation steps.
 
 		.. image:: ../figures/monitoring/boards-monitoring-Shewhart-phase1.png
 			:width: 750px
@@ -207,11 +207,11 @@ Exercises
 			:width: 750px
 			:align: center
 
-		Assuming the subgroups in phase 2 are all in control, the :math:`\alpha` value is sum of the points outside the limits, divided by the total number of subgroups in phase 2 = 9/214 = 4.2%. This is much greater than the theoretically expected :math:`\alpha` of 0.27%.
+		Assuming the subgroups in phase 2 are all in control, the :math:`\alpha` value is sum of the points outside the limits, divided by the total number of subgroups in phase 2 = 6/214 = 2.8%. This is much greater than the theoretically expected :math:`\alpha` of 0.27%.
 
 		Notice though there is a group of points all on one side of the target line. According to the Western Electric rules, a group of more than 8 points on one side of the target line is highly improbable and an alarm should be raised. This indicates that these phase 2 testing data are likely not from in-control operation.
 
-	#.	The ARL = :math:`1/\alpha = 1/0.042` = 23.8; i.e. 1 subgroup in every 24 will lie outside the control limits, even if that subgroup is from in-control operation. That number looks about right from the above phase 2 chart, although, most of the outliers seem to occur in the last half of the chart (see answer to part 4). The data set comes from about 5 hours and 15 minutes (315 minutes) of operation; during this time there were 286 subgroups that would have been shown on a real Shewhart chart. With an ARL of 24 subgroups, there would be about 12 (286/24) false alarms over these 315 minutes. In other words a false alarm about once every 26 minutes. This is much too high for practical use. Either the limits must be made wider, or this data really is not from in-control operation.
+	#.	The ARL = :math:`1/\alpha = 1/0.028` = 35.7; i.e. 1 subgroup in every 36 will lie outside the control limits, even if that subgroup is from in-control operation. That number looks about right from the above phase 2 chart, although, most of the outliers seem to occur in the last half of the chart (see answer to part 4). The time stamps in the raw data show that boards 1 to 2000 span about 5 hours and 24 minutes (324 minutes) of operation; during this time there were 285 subgroups that would have been shown on a real Shewhart chart. With an ARL of 36 subgroups, there would be about 8 (285/36) false alarms over these 324 minutes. In other words a false alarm about once every 41 minutes. This is still too high for practical use. Either the limits must be made wider, or this data really is not from in-control operation.
 
 
 	#.	To calculate the consumer's risk (:math:`\beta`) we require a period of data where we know the blades have shifted, so that the board thickness has been increased or decreased to a new level (mean operating point). Using that out of control, or unstable data, we calculate Shewhart subgroups as usual, and count the number of data points falling within the current LCL and UCL. A count of those in control subgroups divided by the total number of these out of control subgroups would be an estimate of :math:`\beta`.
@@ -230,9 +230,65 @@ Exercises
 			:scale: 80
 
 
-	.. literalinclude:: ../figures/monitoring/boards-monitoring-assignment4-2010.R
-	       :language: s
-	       :lines: 1-8, 12,14-15,19-20,22-57,61-65,67-69,73-77,79-101,105-106
+	The calculation steps, in Python:
+
+	.. code-block:: python
+
+		import numpy as np
+		import pandas as pd
+		from scipy.special import gamma
+
+		pd.options.plotting.backend = "plotly"
+
+		file = "https://openmv.net/file/six-point-board-thickness.csv"
+		boards = pd.read_csv(file)
+
+		# One thickness per board: the median of the six positions.
+		positions = ["Pos1", "Pos2", "Pos3", "Pos4", "Pos5", "Pos6"]
+		thickness = boards[positions].median(axis=1).to_numpy()
+
+		N_sub = 7                    # subgroup size (7 boards)
+		phase1_end = 500 // N_sub    # boards 1-500  -> 71 subgroups
+		phase2_end = 2000 // N_sub   # boards 1-2000 -> 285 subgroups
+
+		def an(n):
+		    return (np.sqrt(2) * gamma(n / 2)
+		            / (np.sqrt(n - 1) * gamma((n - 1) / 2)))
+
+		# Subgroup means and standard deviations (7 consecutive boards).
+		g = thickness[: (len(thickness) // N_sub) * N_sub].reshape(-1, N_sub).T
+		xbar, S = g.mean(axis=0), g.std(axis=0, ddof=1)
+
+		def limits(mask):
+		    xdb, sbar = xbar[mask].mean(), S[mask].mean()
+		    half = 3 * sbar / (an(N_sub) * np.sqrt(N_sub))
+		    return xdb - half, xdb, xdb + half
+
+		# Round 1: all phase-1 subgroups.
+		phase1 = np.arange(phase1_end)
+		LCL, target, UCL = limits(phase1)
+		print(f"Round 1: LCL={LCL:.0f}, target={target:.0f}, UCL={UCL:.0f}")
+		# Round 1: LCL=1655, target=1677, UCL=1699
+
+		# Round 2: drop the phase-1 subgroups outside, then recompute.
+		inside = phase1[(xbar[phase1] >= LCL) & (xbar[phase1] <= UCL)]
+		LCL, target, UCL = limits(inside)
+		print(f"Round 2: LCL={LCL:.0f}, target={target:.0f}, UCL={UCL:.0f}")
+		# Round 2: LCL=1654, target=1676, UCL=1698
+
+		# Phase 2: subgroups 72 to 285 (boards ~501 to 2000).
+		x2 = xbar[phase1_end:phase2_end]
+		outside = int((x2 < LCL).sum() + (x2 > UCL).sum())
+		alpha = outside / len(x2)
+		print(f"Phase 2: {outside} of {len(x2)} outside, "
+		      f"alpha={100 * alpha:.1f}%, ARL={1 / alpha:.1f}")
+		# Phase 2: 6 of 214 outside, alpha=2.8%, ARL=35.7
+
+		# Part g: subgroup standard deviation rises over time, a sign the
+		# saw blades are slowly going out of alignment.
+		pd.Series(S[:phase2_end]).plot.line().update_layout(
+		    xaxis_title_text="Subgroup number",
+		    yaxis_title_text="Subgroup standard deviation").show()
 
 .. admonition:: Question
 

--- a/process-monitoring/process-monitoring-exercises.rst
+++ b/process-monitoring/process-monitoring-exercises.rst
@@ -346,6 +346,47 @@ Exercises
 
 	If you used the Western Electric rules, in addition to the Shewhart chart limits, you would have picked up a consecutive sequence of 8 points on one side of the target around :math:`t=350`.
 
+	The full solution in Python (the original R is in the ``literalinclude`` above):
+
+	.. code-block:: python
+
+		import numpy as np
+		import pandas as pd
+		from scipy.special import gamma
+
+		pd.options.plotting.backend = "plotly"
+
+		file = "https://openmv.net/file/aeration-rate.csv"
+		aeration = pd.read_csv(file)["Aeration"].to_numpy()
+
+		# Part 2: plot the raw data.
+		pd.Series(aeration).plot.line().update_layout(
+		    xaxis_title_text="Time [minutes]",
+		    yaxis_title_text="Aeration rate").show()
+
+		# Parts 3 and 4: CUSUM chart, using the median of the first
+		# 200 points (before the suspected problem) as a robust target.
+		target = np.median(aeration[:200])       # 23.95
+		S = np.cumsum(aeration - target)
+		print(f"mean={aeration.mean():.2f}, median={np.median(aeration):.2f}, "
+		      f"CUSUM target={target:.2f}")
+		pd.Series(S).plot.line(title="CUSUM chart").update_layout(
+		    xaxis_title_text="Time [minutes]",
+		    yaxis_title_text="Cumulative sum, S(t)").show()
+
+		# Part 5: Shewhart chart, phase 1 = first 200 points, subgroup n=5.
+		N_sub = 5
+		p1 = aeration[:200]
+		g = p1[: (len(p1) // N_sub) * N_sub].reshape(-1, N_sub).T
+		an = (np.sqrt(2) * gamma(N_sub / 2)
+		      / (np.sqrt(N_sub - 1) * gamma((N_sub - 1) / 2)))
+		xdb = g.mean(axis=0).mean()
+		sbar = g.std(axis=0, ddof=1).mean()
+		half = 3 * sbar / (an * np.sqrt(N_sub))
+		print(f"Shewhart phase 1: xbar={xdb:.1f}, Sbar={sbar:.2f}, "
+		      f"LCL={xdb - half:.1f}, UCL={xdb + half:.1f}")
+		# xbar=23.9, Sbar=1.28, LCL=22.1, UCL=25.8
+
 .. admonition:: Question
 
 	Do you think a Shewhart chart would be suitable for monitoring the closing price of a stock on the stock market?  Please explain your answer if you agree, or describe an alternative if you disagree.
@@ -488,7 +529,25 @@ Exercises
 		:align: center
 		:width: 600px
 
-	The R code used to generate this figure:
+	The numbers in parts 2 and 3, in Python:
+
+	.. code-block:: python
+
+		import numpy as np
+
+		# Cp relates the specification width to 6 standard deviations.
+		Cp = 1.7
+		USL, LSL = 2.0 + 0.4, 2.0 - 0.4
+		sigma = (USL - LSL) / (Cp * 6)
+		print(f"Process standard deviation = {sigma:.4f} mm")   # 0.0784
+
+		# Shewhart limits for subgroups of size n = 4, at the target.
+		n, target = 4, 2.0
+		LCL = target - 3 * sigma / np.sqrt(n)
+		UCL = target + 3 * sigma / np.sqrt(n)
+		print(f"LCL = {LCL:.2f} mm, UCL = {UCL:.2f} mm")   # 1.88, 2.12
+
+	The R code used to generate the figure:
 
 	.. literalinclude:: ../figures/monitoring/plastic-sheet-control-specification-limits.R
 			:language: s
@@ -567,7 +626,54 @@ Exercises
 
 	The limits identify 2 prolonged periods of unusual operation at sequence point 80 and 140. If we apply the Western Electric rules, we see a third unusual region around sequence step 220. A few other alarms are scattered in the phase 2 data. About 7% of the subgroups lie outside these control limits, so these phase 2 data are definitely not from in-control operation; which we expected from the raw data plot at the start of this question.
 
-	The code for all the calculation steps is provided here:
+	The code for all the calculation steps is provided here in Python, followed by the original R:
+
+	.. code-block:: python
+
+		import numpy as np
+		import pandas as pd
+		from scipy.special import gamma
+
+		pd.options.plotting.backend = "plotly"
+
+		file = "https://openmv.net/file/kappa-number.csv"
+		kappa = pd.read_csv(file)["Kappa"].to_numpy()
+
+		N_sub = 6              # subgroup size; try other sizes too
+		phase1 = kappa[:2000]  # the first 2000 points are phase 1
+
+		def an(n):
+		    return (np.sqrt(2) * gamma(n / 2)
+		            / (np.sqrt(n - 1) * gamma((n - 1) / 2)))
+
+		def shewhart_limits(x):
+		    """Subgroup ``x`` into columns of N_sub and return the subgroup
+		    means together with the (LCL, target, UCL) Shewhart limits."""
+		    g = x[: (len(x) // N_sub) * N_sub].reshape(-1, N_sub).T
+		    xbar, S = g.mean(axis=0), g.std(axis=0, ddof=1)
+		    xdb, sbar = xbar.mean(), S.mean()
+		    half = 3 * sbar / (an(N_sub) * np.sqrt(N_sub))
+		    return xbar, xdb - half, xdb, xdb + half
+
+		# Round 1: all phase-1 subgroups.
+		xbar, LCL, target, UCL = shewhart_limits(phase1)
+		print(f"Round 1: LCL={LCL:.2f}, target={target:.2f}, UCL={UCL:.2f}")
+		# Round 1: LCL=18.26, target=21.73, UCL=25.21
+
+		# Round 2: drop the subgroups that fell outside, then recompute.
+		keep = (xbar >= LCL) & (xbar <= UCL)
+		kept = phase1[: len(xbar) * N_sub].reshape(-1, N_sub)[keep].ravel()
+		_, LCL, target, UCL = shewhart_limits(kept)
+		print(f"Round 2: LCL={LCL:.2f}, target={target:.2f}, UCL={UCL:.2f}")
+		# Round 2: LCL=18.24, target=21.71, UCL=25.19
+
+		# Phase 2: everything after the first 2000 points.
+		phase2 = kappa[2000:]
+		g2 = phase2[: (len(phase2) // N_sub) * N_sub].reshape(-1, N_sub).T
+		x2 = g2.mean(axis=0)
+		frac = ((x2 < LCL) | (x2 > UCL)).mean()
+		print(f"Phase 2 fraction outside limits = {100 * frac:.1f}%")
+		# Phase 2 fraction outside limits = 7.1%
 
 	.. literalinclude:: ../figures/monitoring/Kappa-number-monitoring.R
 	       :language: s

--- a/process-monitoring/process-monitoring-exercises.rst
+++ b/process-monitoring/process-monitoring-exercises.rst
@@ -240,7 +240,7 @@ Exercises
 
 .. admonition:: Solution
 
-	The new Cpk value is 1.5. The number of defects per million items at Cpk = 2.0 is 0.00098 (essentially no defects), while at Cpk = 1.5 it is 3.4 defects per million items. You only have to consider one-side of the distribution, since Cpk is by definition for an uncentered process, and deals with the side closest to the specification limits.
+	The new Cpk value is 1.5. The number of defects per million items at Cpk = 2.0 is 0.00099 (essentially no defects), while at Cpk = 1.5 it is 3.4 defects per million items. You only have to consider one-side of the distribution, since Cpk is by definition for an uncentered process, and deals with the side closest to the specification limits.
 
 	.. code-block:: python
 
@@ -431,7 +431,7 @@ Exercises
 	.. math::
 		\text{PCR}_\text{k} = \min \left( \frac{\text{Upper specification limit} - \overline{\overline{x}}}{3\sigma};  \frac{\overline{\overline{x}} - \text{Lower specification limit}}{3\sigma} \right)
 
-	The two adjustable parameters are :math:`\overline{\overline{x}}`, the process target (operating point) and :math:`\sigma`, the process variance. The current process standard deviation is:
+	The two adjustable parameters are :math:`\overline{\overline{x}}`, the process target (operating point) and :math:`\sigma`, the process standard deviation. The current process standard deviation is:
 
 	.. math::
 		1.30 &= \frac{64.0 - 56.0}{3\sigma} \\
@@ -547,13 +547,13 @@ Exercises
 
 	I used subgroups of size 6 for the figures in this answer, however, the code below is very general, and you can regenerate the plots if you chose a different subgroup size. Just change one of the lines near the top.
 
-	The upper and lower control limits are calculated, and with a subgroup size of :math:`n=6`, there are 333 subgroups and the limits are: UCL = 18.26, target = 21.73, and UCL = 25.21. This is illustrated on the phase 1 data here:
+	The upper and lower control limits are calculated, and with a subgroup size of :math:`n=6`, there are 333 subgroups and the limits are: LCL = 18.26, target = 21.73, and UCL = 25.21. This is illustrated on the phase 1 data here:
 
 	.. image:: ../figures/monitoring/Kappa-phaseI-first-round.png
 		:align: center
 		:width: 750px
 
-	Next we remove the subgroups which lie outside the limits. Please try using the R code to see how to do it automatically. The new limits, after removing the subgroups beyond the limits from the first round are: LCL = 18.24, target = 21.71 and UCL = 25.18. They barely changed. But the updated plot with subgroups removed is now shown below. There is no need to perform another round of pruning. Only if you used a subgroup size of 4 would you need to do a third round. You could also have just shifted the limits to a different level, for example, to :math:`\pm 4` standard deviations. We can do this if we have enough process knowledge to understand the implication of it, in terms of profit.
+	Next we remove the subgroups which lie outside the limits. Please try using the code to see how to do it automatically. The new limits, after removing the subgroups beyond the limits from the first round are: LCL = 18.24, target = 21.71 and UCL = 25.19. They barely changed. But the updated plot with subgroups removed is now shown below. There is no need to perform another round of pruning. Only if you used a subgroup size of 4 would you need to do a third round. You could also have just shifted the limits to a different level, for example, to :math:`\pm 4` standard deviations. We can do this if we have enough process knowledge to understand the implication of it, in terms of profit.
 
 	.. image:: ../figures/monitoring/Kappa-phaseI-second-round.png
 		:align: center


### PR DESCRIPTION
Polish pass on Chapter 3 (Process Monitoring). Companion figures PR: **kgdunn/figures#40**.

## Part 1 - EWMA section (`ewma-charts.rst`)
- **Weights example (requested):** after the weight-recursion derivation, a small worked example for λ=0.5, t=7 with a two-row (i / w_i) table, showing each weight is half the next more recent one and that they sum with the initial-condition weight to 1.
- **Split the LCL/UCL equation** onto two lines.

## Part 2 - exercises (`process-monitoring-exercises.rst`)
**Correctness fixes** (every quoted number re-verified against the datasets):
- Kappa: `UCL 18.26` → **LCL 18.26** typo; round-2 UCL is **25.19**, not 25.18.
- Cpk = 2.0 gives **0.00099** dpm, not 0.00098.
- PCR_k: "σ, the process **variance**" → "standard deviation".

**Python solution code** added for the four solutions that shipped only R:
- **Kappa** (round 1 18.26/21.73/25.21 → round 2 18.24/21.71/25.19; phase 2 7.1%).
- **Aeration** (CUSUM vs median-of-first-200 target 23.95; phase-1 Shewhart 23.9/1.28, 22.1/25.8).
- **Plastic sheets** (σ = 0.0784 mm from Cp; n=4 limits 1.88/2.12).
- **Boards** — see below.

## Boards solution re-baselined (option a)
The boards answer was computed from `board-thickness.csv`, which now **404s** (replaced by `six-point-board-thickness.csv`). Re-derived on the current dataset using the **median of the six positions** per board, with an inline Python solution replacing the dead R `literalinclude`, and **regenerated figures in kgdunn/figures#40**. New numbers (subgroups of 7; phase 1 = boards 1–500, phase 2 = 501–2000):
- Round 1 limits 1655 / 1677 / 1699 (first subgroup outside); round 2 1654 / 1676 / 1698.
- Phase 2: 6 of 214 outside, α = 2.8%, ARL = 35.7.
- Timing from the `Date.Time` column: boards 1–2000 span 324 min → ≈ 8 false alarms (285/36), one every 41 min, still too frequent for practical use. The run of >8 points on one side (Western Electric) still triggers, and the subgroup-sd trend still rises (part g).

**Verified reproducing (unchanged):** batch-yields, batch-yield-and-purity, gas-furnace CO2, aeration Shewhart, kappa round 1, and all pure-calculation answers.

## Verification
- `make text`: zero warnings. `make html`: succeeds; `grep -r goatcounter _build/html/contents` → 0.
- Every code block run against the live openmv.net data; numbers reproduce.
- `CITATION.cff` at 2026.07.07. No lock files committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1hx9U3TydSonCDWXL2Q2D