### PR TITLE
Keep web-only Privacy and Readership statistics pages out of the PDF

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -23,6 +23,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinxcontrib.jquery",
     "my-extensions.youtube",
+    "my-extensions.pdf_exclude",
 ]
 
 # Avoid Subresource Integrity errors for the bundled jQuery.

--- a/my-extensions/pdf_exclude.py
+++ b/my-extensions/pdf_exclude.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+"""Keep the web-only pages (Privacy, Readership statistics) out of the PDF.
+
+The privacy policy and the live readership-statistics dashboard are HTML-only
+pages: ``stats.rst`` is built almost entirely from ``.. raw:: html`` blocks fed
+by JavaScript, and neither belongs in the printable book. They stay in the HTML
+sidebar via the hidden toctree in ``contents.rst``, but the LaTeX builder would
+otherwise render them as numbered chapters. Before this extension they appeared
+as chapters 1 and 2 in the PDF, ahead of "Visualizing Process Data".
+
+Wrapping the toctree in ``.. only:: html`` does not help here, because
+``latex_documents`` uses ``toctree_only=True``: the LaTeX builder harvests every
+toctree node directly (``sphinx.builders.latex.LaTeXBuilder.assemble_doctree``)
+and discards the surrounding ``only`` wrapper. Instead we drop the pages after
+the toctree has been inlined. ``inline_all_toctrees`` wraps each included
+document in a ``start_of_file`` node carrying its docname, so we remove those
+wrappers for the two web-only pages.
+
+This runs as a post-transform restricted to the ``latex`` format, on the
+assembled tree, so the shared doctree cache is untouched and the HTML sidebar is
+unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sphinx import addnodes
+from sphinx.transforms.post_transforms import SphinxPostTransform
+
+# Docnames that must never appear in the LaTeX / PDF edition.
+PDF_EXCLUDED_DOCS = frozenset({"privacy", "stats"})
+
+
+class DropWebOnlyPagesFromLaTeX(SphinxPostTransform):
+    """Remove the Privacy and Readership-statistics pages from the PDF build."""
+
+    # Only the LaTeX builder; HTML and text are left untouched.
+    formats = ("latex",)
+    # After references are resolved and toctrees inlined, before serialisation.
+    default_priority = 400
+
+    def run(self, **kwargs: Any) -> None:
+        for start_of_file in list(self.document.findall(addnodes.start_of_file)):
+            if start_of_file.get("docname") in PDF_EXCLUDED_DOCS:
+                start_of_file.parent.remove(start_of_file)
+
+
+def setup(app: Any) -> dict[str, Any]:
+    app.add_post_transform(DropWebOnlyPagesFromLaTeX)
+    return {
+        "version": "1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }


### PR DESCRIPTION
## What changed

In the generated PDF, the Table of Contents opened with two web-only pages as numbered chapters:

- **1 Privacy** (page 1)
- **2 Readership statistics** (page 3)
- 3 Visualizing Process Data (page 5)

`privacy.rst` is the telemetry privacy contract and `stats.rst` is a live readership dashboard built almost entirely from `.. raw:: html` blocks and JavaScript that fetch `sparklines.json`. In a PDF those blocks render as empty sections, and neither belongs in the printable book. They are wired into the hidden toctree in `contents.rst` so they show up in the HTML sidebar (which is correct and unchanged).

After this change the PDF opens with the Preface, then **chapter 1, Visualizing Process Data**, starting on page 1.

## How

Wrapping the toctree in `.. only:: html` does not work here: `latex_documents` uses `toctree_only=True`, so the LaTeX builder (`assemble_doctree`) harvests every toctree node directly and discards the surrounding `only` wrapper.

Instead, a small post-transform in `my-extensions/pdf_exclude.py` runs only for the `latex` format and drops the two pages after the toctree has been inlined. It matches on the `start_of_file` docname that `inline_all_toctrees` attaches to each included document (`privacy`, `stats`). Because it runs on the assembled tree at write time, the shared doctree cache is untouched and the HTML sidebar is unchanged.

Files:
- `my-extensions/pdf_exclude.py` (new): the LaTeX-only post-transform.
- `conf.py`: register the extension. `contents.rst` is unchanged.

## What did not change

- HTML edition: `privacy` and `stats` are still built and still appear in the sidebar navigation. No behavioural change to the web book.
- No content edits; no analysis changes.

## Verification

- `make latex`: succeeds. In the generated `_build/latex/PID.tex`, `\chapter{Privacy}` and `\chapter{Readership statistics}` no longer appear; the first numbered chapter is `\chapter{Visualizing Process Data}`, following the (unnumbered) Preface. No lingering `privacy:privacy` / `stats:stats` label references.
- `make html`: succeeds. `privacy` and `stats` pages built and linked in the sidebar; `grep -r goatcounter _build/html/contents` returns zero hits.
- The extension loads cleanly and introduces no new warnings. (The sandbox has no `figures/` checkout, so both builds emit the usual pre-existing missing-image warnings; those are unrelated to this change.)
- `make latexpdf` (the actual PDF) could not be run in this sandbox (no `pdflatex`), but `make latex` confirms the document structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Q1NtAdknz3H5tJK1N4mJW

---
_Generated by [Claude Code](https://claude.ai/code/session_016Q1NtAdknz3H5tJK1N4mJW)_