### PR TITLE
Cross-link the case study's design-quality metrics into chapter 5

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.07.10"
-date-released: 2026-07-10
+version: "2026.07.11"
+date-released: 2026-07-11
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/design-analysis-experiments/judging-and-comparing-designs.rst
+++ b/design-analysis-experiments/judging-and-comparing-designs.rst
@@ -365,6 +365,8 @@ worst-case values; the next section uses it to draw the plot.
 	assert is_omars(dsd4) and is_omars(omars4)
 	model4 = " + ".join(list("ABCD") + [f"I({c}**2)" for c in "ABCD"])
 
+.. _DOE-fds-plot:
+
 The fraction-of-design-space (FDS) plot
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/product-development-product-improvement/mixed-level-profile-case-study.rst
+++ b/product-development-product-improvement/mixed-level-profile-case-study.rst
@@ -150,11 +150,12 @@ Judging the design before running it
 -------------------------------------
 
 Before any colour is measured, the design can be scored on how well it will support the model, using
-``evaluate_design`` on the same quadratic model. The D-efficiency summarises the information
-determinant :math:`|\mathbf{X}^T\mathbf{X}|`, higher being more information per run; the
-I-efficiency summarises the prediction variance averaged over the whole factor region, and the
-fraction-of-design-space (FDS) curve shows how that prediction variance is distributed, from the
-best-predicted point to the worst.
+``evaluate_design`` on the same quadratic model. The :ref:`D-efficiency
+<DOE-judging-and-comparing-designs>` summarises the information determinant
+:math:`|\mathbf{X}^T\mathbf{X}|`, higher being more information per run; the I-efficiency summarises
+the prediction variance averaged over the whole factor region, and the :ref:`fraction-of-design-space
+(FDS) curve <DOE-fds-plot>` shows how that prediction variance is distributed, from the best-predicted
+point to the worst.
 
 .. code-block:: python
 
@@ -181,7 +182,8 @@ best-predicted point to the worst.
                       yaxis_title="Scaled prediction variance")
     fig.show()
 
-Scoring the I-optimal and D-optimal designs at 48 and 60 runs lays out the trade-off. The
+Scoring the :ref:`I-optimal and D-optimal designs <DOE-optimal-designs>` at 48 and 60 runs lays out
+the trade-off. The
 I-optimal criterion minimizes the average prediction variance, and the D-optimal criterion
 maximizes the information determinant, so each design leads on its own criterion: the D-optimal
 design has the higher D-efficiency, and the I-optimal design has the higher I-efficiency and the
@@ -285,9 +287,9 @@ the shape difference the fourth question is about, and it is invisible in the en
     :width: 720px
     :alt: colour-development-curves.py
 
-    Mean colour-development curve for each chromogen. The curves rise together to about the fifth
-    time point, then diverge: the reference A and the analog B level off together, while D and E
-    keep developing colour and F drifts down.
+    Mean colour-development curve for each chromogen (A to C solid, D to F dashed). The curves rise
+    together to about the fifth time point, then diverge: the reference A and the analog B level off
+    together, while D and E keep developing colour and F drifts down.
 
 Modelling the profile with PLS
 ------------------------------


### PR DESCRIPTION
Small follow-up to the merged case study (#227). Adds cross-references from the "Judging the design" paragraph back to where the design-quality metrics are defined in the design-and-analysis-of-experiments chapter, and a caption note for the regenerated figure.

## Changes

- **D-efficiency** links to the `judging-and-comparing-designs` section (where the metric is defined), not to the D-optimal designs section.
- **fraction-of-design-space (FDS) curve** links to a new `.. _DOE-fds-plot:` label added on that section's FDS-plot subsection.
- **"I-optimal and D-optimal designs"** links to the optimal-designs section.
- Caption note on the colour-development figure: A to C solid, D to F dashed (matches the figure change in kgdunn/figures#43).
- `CITATION.cff` version / date-released bumped to today.

## Verification

- `make text` builds with no warnings; all three `:ref:` targets resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvUM1DPgi2S3JFLjRJTJWj

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvUM1DPgi2S3JFLjRJTJWj)_