### PR TITLE
Model diagnostics, categorical coding, and PLS inversion in the profile case study

### DIFF
--- a/product-development-product-improvement/mixed-level-profile-case-study.rst
+++ b/product-development-product-improvement/mixed-level-profile-case-study.rst
@@ -996,15 +996,13 @@ for new rows (SPE for a model with named columns reads correctly from process-im
 The goal's SPE is 1.7 and its :math:`T^2` is 0.05, both well inside the 95% limits of 6.5 and 8.7. It
 sits in the region the design covered, so the model's prediction there can be used as an inversion
 target. Most of the sixty runs also fall inside both limits. The exceptions, four beyond the
-:math:`T^2` limit and five beyond the SPE limit, are all compound F, and this follows from the
-sum-coding reference rather than from F's chemistry. Sum coding drops the last level, F, and
-represents it as the negative sum of the other contrasts, the corner of the contrast space farthest
-from the centre, so F runs read as both high leverage (:math:`T^2`, one at 26 against the limit of
-8.7) and less fully reconstructed (SPE). Change which level is dropped and the flags move with it:
-making B the reference sends B's runs past both limits by the same margin, while treatment or
-cell-means coding, where no level sits at that corner, leaves every compound inside. The goal check
-holds because A, the reference chromogen, is not the omitted level, so it projects to a low-leverage,
-well-reconstructed point in this parameterization.
+:math:`T^2` limit and five beyond the SPE limit, are all compound F. That grouping is a property of
+the sum coding used for the compound factor, not of F's chemistry: the :ref:`next section
+<profile-categorical-coding>` writes the same model three ways and shows the flag move from F to
+another level, or disappear, as the coding changes. The goal check is unaffected, because chromogen
+A, the reference, is never the omitted level, so it projects to a low-leverage, well-reconstructed
+point under every coding tried (its :math:`T^2` stays near or below 0.1 and its SPE between about 1
+and 2).
 
 .. figure:: ../figures/doe/colour-pls-t2-spe.png
     :align: center
@@ -1012,10 +1010,136 @@ well-reconstructed point in this parameterization.
     :alt: colour-pls-t2-spe.py
 
     Hotelling's :math:`T^2` against SPE for the sixty runs, with the 95% limits as dashed lines. A
-    run in the lower-left rectangle is within both. Several compound-F runs cross the limits, an
-    artifact of F being the omitted sum-coding level rather than a fault in those runs. The reference
-    goal, chromogen A at the centre point (asterisk), sits well inside both limits, so its predicted
-    profile can be used as an inversion target.
+    run in the lower-left rectangle is within both. Several compound-F runs cross the limits, a
+    consequence of F being the omitted sum-coding level rather than a fault in those runs. The
+    reference goal, chromogen A at the centre point (asterisk), sits well inside both limits, so its
+    predicted profile can be used as an inversion target.
+
+.. _profile-categorical-coding:
+
+Coding the categorical factor
+-----------------------------
+
+The compound has entered every model so far through sum-to-zero coding, written
+``C(compound, Sum)``. That is one of several ways to turn a categorical factor into numeric columns,
+and the choice has stayed in the background: the interaction F-tests did not depend on it, and the
+least-squares coefficients only divided the compound effect differently between the levels. The
+diagnostics just raised it directly, with every flagged run belonging to the omitted level. This
+section writes the same model three ways to separate what the coding changes from what it does not.
+
+Three codings of a six-level factor are in common use:
+
+- **Sum (effects) coding**, ``C(compound, Sum)``: each column is a compound's departure from the
+  average of all six. One level is omitted and carried as the negative sum of the other five
+  contrasts, so it has no column of its own and its runs sit at the corner of the contrast space
+  farthest from the centre.
+- **Treatment (reference) coding**, ``C(compound, Treatment)``: each column is a compound's
+  difference from a chosen reference level, here A. The reference is the all-zero row.
+- **Cell-means coding**, ``0 + C(compound)``: every compound has its own indicator column, with no
+  intercept and no omitted level.
+
+All three span the same model space: any fit written in one can be rewritten in the others, and a
+full-rank ordinary least squares fit returns the same predictions whichever is used. A small
+illustration, a three-level factor and one continuous factor, makes the point and shows where it
+stops holding:
+
+.. code-block:: python
+
+    rng = np.random.default_rng(0)
+    n = 30
+    g = np.array(["A"] * 11 + ["B"] * 10 + ["C"] * 9); rng.shuffle(g)
+    xcol = rng.normal(size=n)
+    truth = {"A": 0.0, "B": 1.0, "C": -0.5}
+    y = np.array([truth[v] for v in g]) + 0.7 * xcol + 0.1 * rng.normal(size=n)
+    demo = pd.DataFrame({"g": g, "x": xcol}); ydf = pd.DataFrame({"y": y})
+
+    X_sum = dmatrix("C(g, Sum) + x", demo, return_type="dataframe").drop(columns=["Intercept"])
+    X_trt = dmatrix("C(g, Treatment) + x", demo, return_type="dataframe").drop(columns=["Intercept"])
+    for a in (1, 2, 3):                 # three model terms, so three components is full rank
+        p_sum = PLS(n_components=a, scale=True).fit(X_sum, ydf).predictions_
+        p_trt = PLS(n_components=a, scale=True).fit(X_trt, ydf).predictions_
+        print(a, float(np.max(np.abs(np.asarray(p_sum) - np.asarray(p_trt)))))
+    # 1 -> 0.37, 2 -> 0.17, 3 -> 0.00
+
+The full-rank ordinary least squares predictions match to :math:`10^{-15}` across the two codings. A
+PLS kept at one or two components does not: its predictions differ by 0.37 and 0.17 between sum and
+treatment coding, and only at three components, which is full rank for a three-term model, do they
+agree. The reason is in how each method builds its fit. Ordinary least squares projects the response
+onto the column space of the model, and that subspace is the same for every coding, so the fitted
+values are identical. PLS builds its components to maximise the covariance between a score direction
+and the response; the leading directions depend on the actual numbers in the model matrix, which the
+coding sets, so a PLS truncated below full rank keeps a coding-specific summary. Centring and scaling
+a component model shift its fit in the same way, and for the same reason (Bro and Smilde, 2003, on
+centring and scaling in component analysis). At
+full rank the truncation is gone and PLS spans the same space as least squares, so the dependence
+disappears; below full rank it remains.
+
+The interaction model here keeps three of a possible twenty-four components, well below full rank, so
+the coding has an effect. Its cumulative :math:`R^2_Y` at three components is 0.88 under sum coding,
+0.90 under treatment coding, and 0.91 under cell-means coding: the same model space, but a
+rank-three truncation keeps a different part of it in each case.
+
+The clearest place to see the effect is the leverage diagnostic. Refitting the three-component model
+under each coding and reading Hotelling's :math:`T^2` per run:
+
+.. code-block:: python
+
+    rhs_sum = rhs                                       # C(compound, Sum)*... from earlier
+    rhs_trt = rhs.replace("Sum", "Treatment")
+    rhs_cell = ("0 + C(compound)*co_solvent + C(compound)*pH "
+                "+ C(compound)*temperature + concentration")
+
+    def fit_coding(formula, order=("A", "B", "C", "D", "E", "F")):
+        frame = adf.copy()
+        frame["compound"] = pd.Categorical(frame["compound"].astype(str), categories=list(order))
+        X = dmatrix(formula, frame, return_type="dataframe").drop(columns=["Intercept"], errors="ignore")
+        return PLS(n_components=3, scale=True).fit(X, curves)
+
+    panels = [("sum, F omitted", rhs_sum, ("A", "B", "C", "D", "E", "F")),
+              ("sum, A omitted", rhs_sum, ("F", "E", "D", "C", "B", "A")),
+              ("treatment, A reference", rhs_trt, ("A", "B", "C", "D", "E", "F")),
+              ("cell-means", rhs_cell, ("A", "B", "C", "D", "E", "F"))]
+
+    fig = make_subplots(rows=2, cols=2, subplot_titles=[p[0] for p in panels])
+    for k, (title, formula, order) in enumerate(panels):
+        model = fit_coding(formula, order)
+        t2 = model.hotellings_t2_.iloc[:, -1]
+        r, c = divmod(k, 2)
+        for comp in compounds:
+            sel = (adf["compound"] == comp).to_numpy()
+            fig.add_scatter(x=[comp] * int(sel.sum()), y=t2[sel], mode="markers",
+                            marker=dict(color=colour_of[comp]), row=r + 1, col=c + 1, showlegend=False)
+        fig.add_hline(y=model.hotellings_t2_limit(), line_dash="dash", row=r + 1, col=c + 1)
+    fig.show()
+
+Under sum coding with F omitted, the four runs past the 95% :math:`T^2` limit of 8.7 are all compound
+F, and the largest reaches 26. Omit A instead, by reversing the level order, and the flagged runs
+become compound A, at a :math:`T^2` up to 18, while F now sits inside. Under treatment or cell-means
+coding, where no level is written at the far corner of the contrast space, no run crosses the limit.
+The omitted level's runs are pushed out because sum coding places them at the :math:`(-1, \ldots, -1)`
+corner and ``scale=True`` then gives that corner column unit variance, raising its leverage; the
+effect belongs to the parameterization, and it moves with whichever level is omitted. This is why the
+diagnostics flagged F: F is the level sum coding drops, not a run the chemistry sets apart.
+
+.. figure:: ../figures/doe/colour-coding-diagnostics.png
+    :align: center
+    :width: 760px
+    :alt: colour-coding-diagnostics.py
+
+    Hotelling's :math:`T^2` for each run at three components, under four codings of the same
+    interaction model. The dashed line is the 95% limit (8.7). The runs over the limit follow the
+    omitted sum-coding level, F when F is dropped and A when A is dropped; treatment and cell-means
+    coding, which place no level at the far corner of the contrast space, flag none. The leverage is
+    a property of the coding, not of the chemistry.
+
+Two things do not move with the coding. The interaction F-tests and the full-rank least-squares
+coefficients are the same under all three, because they use the whole column space. And the goal
+projection stays inside both limits under every coding: chromogen A at the centre point is not an
+omitted level in any of them, so its :math:`T^2` stays near or below 0.1 and its SPE between about 1
+and 2. The goal check the inversion relies on does not depend on the choice.
+
+What does depend on it is any reading taken from the truncated score, including the model inversion
+in the next section, where the reachable set of candidates changes with the coding.
 
 Which compound matches the reference
 ------------------------------------
@@ -1104,13 +1228,13 @@ the reference profile:
         - no: concentration and pH above range
 
 The studied ranges are concentration 2 to 8 umol/L, co-solvent 5 to 25% v/v, pH 4.0 to 7.0, and
-temperature 15 to 35 degC. Chromogen B needs almost no change from the nominal centre: it already
-develops colour close to the reference. C and D need a moderate move, a higher pH and temperature,
-but stay inside the ranges. E and F cannot be brought onto the goal within the window: E needs a pH of
-7.7 and F a pH of 8.2 and a concentration of 8.7 umol/L, all beyond the values the experiment
-explored. The ordering, B then C and D then E and F, is the order of the late-time drift built into
-each compound, so the inversion recovers the same ranking the design was built to reveal, now as a
-set of concrete settings rather than a distance.
+temperature 15 to 35 degC. Chromogen B needs almost no change from the nominal centre. C and D need a
+moderate move, a higher pH and temperature, but stay inside the ranges. E and F fall outside the
+window: E at a pH of 7.7 and F at a pH of 8.2 and a concentration of 8.7 umol/L, beyond the values the
+experiment explored. This table is the inversion read under sum coding. Because the three-component
+score is coding-dependent, as the :ref:`coding section <profile-categorical-coding>` showed, so is
+the reachable set, and the paragraphs below repeat the inversion under the other codings and under a
+reading that does not depend on the coding at all.
 
 .. figure:: ../figures/doe/colour-pls-inversion.png
     :align: center
@@ -1140,9 +1264,74 @@ shaded:
 Inversion is non-unique, and this reports one member of the operating window, the smallest move from
 the nominal centre. A subject-matter expert might spend the free direction differently, for instance
 holding one factor fixed and solving for the rest, as the :ref:`product-development worked example
-<LVM_model_inversion_example>` does with a fixed hardness. The result is the same either way for the
-question asked here: B, C and D can be tuned to the reference colour development, and E and F cannot,
-not without moving outside the ranges the design covered.
+<LVM_model_inversion_example>` does with a fixed hardness. That freedom is a property of the score
+match under any coding; the reachable set, in contrast, moves with the coding.
+
+Repeating the score match under treatment and cell-means coding gives a different reachable set each
+time. Under sum coding B, C and D are inside the ranges; under treatment coding all five candidates
+are; under cell-means coding B, C, D and F are, while E is not. B, C and D are reachable under every
+coding, and E and F move in and out. The three codings answer the same question about the same data
+and return three different candidate lists.
+
+.. figure:: ../figures/doe/colour-coding-inversion.png
+    :align: center
+    :width: 720px
+    :alt: colour-coding-inversion.py
+
+    Which candidates can be brought onto the reference goal within the studied ranges, under four
+    ways of posing the inversion. The first three match the three-component score, one per coding, and
+    give three different reachable sets. The fourth matches the predicted ten-point curve at full
+    rank, which is the same under any coding, and places only F inside the ranges.
+
+A reading that does not depend on the coding matches the predicted curve rather than the score. The
+predicted ten-point profile is a full-rank quantity, identical under every coding, so requiring a
+candidate's predicted curve to reach the goal's gives one answer. The match is over-determined, ten
+time points against four factors, so it returns the least-squares closest curve:
+
+.. code-block:: python
+
+    from patsy import build_design_matrices
+
+    info_full = dmatrix(rhs, adf, return_type="dataframe")       # keep the intercept: full rank
+    beta = np.linalg.lstsq(info_full.to_numpy(), curves.to_numpy(), rcond=None)[0]
+
+    def curve_of(compound, coded):
+        row = pd.DataFrame({"compound": [compound], "concentration": [coded[0]],
+                            "co_solvent": [coded[1]], "pH": [coded[2]], "temperature": [coded[3]]})
+        x = build_design_matrices([info_full.design_info], row, return_type="dataframe")[0]
+        return x.to_numpy().ravel() @ beta
+
+    y_goal = curve_of("A", [0, 0, 0, 0])
+
+    def curve_match(compound):
+        y0 = curve_of(compound, [0, 0, 0, 0])
+        step = np.column_stack([
+            curve_of(compound, [float(k == j) for k in range(4)]) - y0 for j in range(4)])
+        coded, *_ = np.linalg.lstsq(step, y_goal - y0, rcond=None)
+        return coded            # coded [concentration, co_solvent, pH, temperature]
+
+    for c in ["B", "C", "D", "E", "F"]:
+        print(c, np.round(curve_match(c), 2))
+
+The curve match places only F inside the studied ranges, and only just: its pH sits at 7.0, the top
+of the window. B, C, D and E each need a factor beyond the ranges to bring their whole predicted curve
+onto the goal (B a co-solvent below 5% v/v and a pH below 4.0; C and D a pH near 8, with D also a
+co-solvent of 45% v/v; E a temperature near :math:`-28` degC). The score match and the curve match
+ask different questions. Matching a three-component score asks a candidate to reach a low-rank summary
+of the goal, which several candidates do with small moves; matching the full curve asks it to
+reproduce the whole profile, which the continuous factors mostly cannot, because they move the
+curve's amplitude while the compounds differ in late-time shape. Shape, not amplitude, is the binding
+constraint, which returns to the shape-distance ranking that opened the fourth question: B is closest
+to the reference in shape, then F, and no factor setting closes a shape gap.
+
+So the answer to which compound matches the reference is not read from the data alone; it depends on
+how the inversion is posed: the coding, the number of components, and whether the match is taken in
+the latent score or in the predicted response. Scoping the codings together, rather than fixing one
+at the outset, separates the conclusions that hold from those that move. The reading that holds is
+that the compounds differ in a curve shape the four continuous factors cannot reproduce, so no
+candidate is brought exactly onto the reference within the ranges, and B is nearest in shape. The
+reading that moves is the score-matching reachable set, a statement about a low-rank projection that
+changes with the coding.
 
 What the design and the library carried
 ---------------------------------------
@@ -1156,9 +1345,11 @@ coordinate-exchange optimiser, ``pyoptex``, which powers the I-optimal and split
 and is installed on its own.
 
 The study answered its questions from a single design: the three interactions are significant
-(objectives 1 to 3), inverting the model onto a reference goal shows that B, C and D can be tuned to
-develop colour like the reference while E and F cannot within the studied ranges (objective 4), and
-the fitted model over the continuous factors locates settings for a target colour intensity for the
-chosen compound (objective 5). The same design supported a scalar analysis of variance on the peak, a
-multivariate model of the full curve, and the inversion of that model back to factor settings,
-because the design was chosen for the model, not for a particular way of reducing the response.
+(objectives 1 to 3); inverting the model onto a reference goal shows that a low-rank score match
+makes B, C and D reachable within the ranges but that the reachable set depends on the categorical
+coding, while a coding-free curve match indicates the compounds differ in a shape the continuous
+factors cannot reproduce, leaving B nearest the reference (objective 4); and the fitted model over the
+continuous factors locates settings for a target colour intensity for the chosen compound (objective
+5). The same design supported a scalar analysis of variance on the peak, a multivariate model of the
+full curve, and the inversion of that model back to factor settings, because the design was chosen for
+the model, not for a particular way of reducing the response.

--- a/product-development-product-improvement/mixed-level-profile-case-study.rst
+++ b/product-development-product-improvement/mixed-level-profile-case-study.rst
@@ -995,11 +995,16 @@ for new rows (SPE for a model with named columns reads correctly from process-im
 
 The goal's SPE is 1.7 and its :math:`T^2` is 0.05, both well inside the 95% limits of 6.5 and 8.7. It
 sits in the region the design covered, so the model's prediction there can be used as an inversion
-target. Most of the sixty runs also fall inside both limits. Four cross the :math:`T^2` limit and
-five cross the SPE limit; the :math:`T^2` outliers are all compound F, one at :math:`T^2 = 26`
-against the limit of 8.7. Sum coding drops the last level, F, and carries it as the negative sum of
-the other contrasts, so an F run sits at an extreme position in the contrast space and reads as a
-high-leverage point. That is a property of the coding, not a fault in those runs.
+target. Most of the sixty runs also fall inside both limits. The exceptions, four beyond the
+:math:`T^2` limit and five beyond the SPE limit, are all compound F, and this follows from the
+sum-coding reference rather than from F's chemistry. Sum coding drops the last level, F, and
+represents it as the negative sum of the other contrasts, the corner of the contrast space farthest
+from the centre, so F runs read as both high leverage (:math:`T^2`, one at 26 against the limit of
+8.7) and less fully reconstructed (SPE). Change which level is dropped and the flags move with it:
+making B the reference sends B's runs past both limits by the same margin, while treatment or
+cell-means coding, where no level sits at that corner, leaves every compound inside. The goal check
+holds because A, the reference chromogen, is not the omitted level, so it projects to a low-leverage,
+well-reconstructed point in this parameterization.
 
 .. figure:: ../figures/doe/colour-pls-t2-spe.png
     :align: center
@@ -1007,9 +1012,10 @@ high-leverage point. That is a property of the coding, not a fault in those runs
     :alt: colour-pls-t2-spe.py
 
     Hotelling's :math:`T^2` against SPE for the sixty runs, with the 95% limits as dashed lines. A
-    run in the lower-left rectangle is within both. Several compound-F runs cross the :math:`T^2`
-    limit. The reference goal, chromogen A at the centre point (asterisk), sits well inside both
-    limits, so its predicted profile can be used as an inversion target.
+    run in the lower-left rectangle is within both. Several compound-F runs cross the limits, an
+    artifact of F being the omitted sum-coding level rather than a fault in those runs. The reference
+    goal, chromogen A at the centre point (asterisk), sits well inside both limits, so its predicted
+    profile can be used as an inversion target.
 
 Which compound matches the reference
 ------------------------------------

--- a/product-development-product-improvement/mixed-level-profile-case-study.rst
+++ b/product-development-product-improvement/mixed-level-profile-case-study.rst
@@ -941,36 +941,202 @@ functional-data route separates the two steps: describe the curve shape first fr
 alone, then relate that description to the factors. Which is more convenient depends on the study;
 both return a model that maps the factors to a predicted curve.
 
-Which compound matches the reference
-------------------------------------
+Model diagnostics: SPE and Hotelling's T2
+-----------------------------------------
 
-The fourth question compares curve *shape*, not colour depth, so amplitude is divided out first:
-each compound's mean curve is scaled to unit peak, and the Euclidean distance to the reference
-compound A's scaled curve measures how differently the colour develops over time.
+Before the model is used to answer the fourth question, it is worth checking where its own runs sit
+relative to it. Two distances summarise that. Hotelling's :math:`T^2` measures how far a run lies
+from the centre *within* the model plane, scaled by the score spread; the squared prediction error
+(SPE) measures how far it lies *off* the plane, the part of the ten-point curve the three components
+do not reconstruct. Each has a 95% limit, from ``hotellings_t2_limit`` and ``spe_limit``.
+
+New rows are needed here and in the inversion that follows, so a small helper builds a model-matrix
+row for one setting with the same coding as the fitted matrix:
 
 .. code-block:: python
 
-    shapes = mean_curve.div(mean_curve.max(axis=1), axis=0)
-    distance = ((shapes - shapes.loc["A"]) ** 2).sum(axis=1) ** 0.5
-    print(distance.drop("A").sort_values())
+    from patsy import build_design_matrices
 
-    order_c = distance.drop("A").sort_values()
-    fig = go.Figure(go.Bar(x=order_c.values, y=order_c.index, orientation="h"))
-    fig.update_layout(xaxis_title="shape distance to reference A", yaxis_title="candidate")
+    info = dmatrix(rhs, adf, return_type="dataframe").design_info
+
+    def encode(compound, concentration, co_solvent, pH, temperature):
+        row = pd.DataFrame({"compound": [compound], "concentration": [concentration],
+                            "co_solvent": [co_solvent], "pH": [pH], "temperature": [temperature]})
+        return build_design_matrices([info], row, return_type="dataframe")[0].drop(columns=["Intercept"])
+
+The fourth question asks which candidate develops colour like the reference chromogen A. To make that
+precise, take chromogen A at the centre point, the nominal mid-range value of every continuous factor,
+as the *goal*: the colour-development profile to reproduce. Projecting the goal onto the model gives
+its score and its own SPE and :math:`T^2`, so it can be checked the same way as any run before it is
+used. The projection is ``diagnose``, which returns the scores, SPE, :math:`T^2` and predicted curve
+for new rows (SPE for a model with named columns reads correctly from process-improve 1.52.4 onward):
+
+.. code-block:: python
+
+    goal_x = encode("A", concentration=0, co_solvent=0, pH=0, temperature=0)
+    goal = pls_full.diagnose(goal_x)
+    print(float(goal.spe.iloc[0]), float(goal.hotellings_t2.iloc[0]))   # 1.7, 0.05
+
+    t2 = pls_full.hotellings_t2_.iloc[:, -1]        # per-run T2 at three components
+    spe = pls_full.spe_.iloc[:, -1]                 # per-run SPE at three components
+    print(pls_full.hotellings_t2_limit(), pls_full.spe_limit())         # 8.7, 6.5
+
+    fig = go.Figure()
+    for c in compounds:
+        m = (design.design["compound"] == c).to_numpy()
+        fig.add_scatter(x=t2[m], y=spe[m], mode="markers", name=c)
+    fig.add_scatter(x=[float(goal.hotellings_t2.iloc[0])], y=[float(goal.spe.iloc[0])],
+                    mode="markers", name="goal: A at centre",
+                    marker=dict(symbol="star", size=16, color="black"))
+    fig.add_vline(x=pls_full.hotellings_t2_limit(), line_dash="dash")
+    fig.add_hline(y=pls_full.spe_limit(), line_dash="dash")
+    fig.update_layout(xaxis_title="Hotelling's T2", yaxis_title="SPE")
     fig.show()
 
-Compound B is closest to the reference, at a distance of 0.07, well ahead of the next candidate F at
-0.15, with C, D and E progressively further. The ranking, B then F then C then D then E, is exactly
-the order of the late-time drift that was built into each compound, so the analysis recovers the
-shape ordering from the noisy data.
+The goal's SPE is 1.7 and its :math:`T^2` is 0.05, both well inside the 95% limits of 6.5 and 8.7. It
+sits in the region the design covered, so the model's prediction there can be used as an inversion
+target. Most of the sixty runs also fall inside both limits. Four cross the :math:`T^2` limit and
+five cross the SPE limit; the :math:`T^2` outliers are all compound F, one at :math:`T^2 = 26`
+against the limit of 8.7. Sum coding drops the last level, F, and carries it as the negative sum of
+the other contrasts, so an F run sits at an extreme position in the contrast space and reads as a
+high-leverage point. That is a property of the coding, not a fault in those runs.
 
-.. figure:: ../figures/doe/colour-shape-distance.png
+.. figure:: ../figures/doe/colour-pls-t2-spe.png
     :align: center
-    :width: 700px
-    :alt: colour-shape-distance.py
+    :width: 680px
+    :alt: colour-pls-t2-spe.py
 
-    Shape distance from each candidate's colour-development curve to the reference A, with amplitude
-    divided out. Compound B (highlighted) develops colour most like the reference; E is furthest.
+    Hotelling's :math:`T^2` against SPE for the sixty runs, with the 95% limits as dashed lines. A
+    run in the lower-left rectangle is within both. Several compound-F runs cross the :math:`T^2`
+    limit. The reference goal, chromogen A at the centre point (asterisk), sits well inside both
+    limits, so its predicted profile can be used as an inversion target.
+
+Which compound matches the reference
+------------------------------------
+
+The fourth question is which candidate can be made to develop colour like the reference. With the
+goal profile fixed, that becomes a model-inversion question: for each candidate chromogen, what
+settings of the four continuous factors place its score on the goal? Inversion runs the model
+backwards, from a target score to the factors that reach it. The :ref:`product-development chapter
+<LVM_model_inversion_example>` sets this out for a PCA model, using the loadings to map a target score
+to a recipe; here the same idea is applied to the PLS interaction model, with the compound held fixed
+and the continuous factors as the manipulated variables. The starting point for the method is Jaeckle
+and MacGregor's 1998 paper on product design through multivariate analysis of process data.
+
+The forward map is ``pls_full.transform(X)``: it standardizes the model-matrix row and multiplies by
+the direct weights :math:`\mathbf{W}^*`. Holding the compound fixed makes this map affine in the four
+continuous factors, so matching the three-component goal score is a small linear system, built here
+by reading the score at the centre and along each continuous factor in turn. Four factors against
+three components leaves one free direction, the operating window; the least-squares solution is the
+minimum adjustment from the nominal centre.
+
+.. code-block:: python
+
+    import numpy as np
+
+    t_goal = pls_full.transform(goal_x).to_numpy().ravel()
+
+    def compensate(compound):
+        base = pls_full.transform(encode(compound, 0, 0, 0, 0)).to_numpy().ravel()
+        step = np.column_stack([
+            pls_full.transform(encode(compound, *[float(k == j) for k in range(4)])).to_numpy().ravel() - base
+            for j in range(4)])
+        coded, *_ = np.linalg.lstsq(step, t_goal - base, rcond=None)
+        return coded            # coded [concentration, co_solvent, pH, temperature]
+
+    for c in ["B", "C", "D", "E", "F"]:
+        print(c, np.round(compensate(c), 2))
+
+Converting each coded setting to real units gives the recipe that would make each candidate reproduce
+the reference profile:
+
+.. list-table:: Continuous-factor settings that reproduce the reference goal (chromogen A at centre)
+    :widths: 16 20 18 12 18 24
+    :header-rows: 1
+
+    *   - Chromogen
+        - Concentration (umol/L)
+        - Co-solvent (% v/v)
+        - pH
+        - Temperature (degC)
+        - Within studied ranges?
+    *   - A (reference)
+        - 5.0
+        - 15.0
+        - 5.5
+        - 25.0
+        - nominal centre
+    *   - B
+        - 4.9
+        - 14.8
+        - 5.4
+        - 25.6
+        - yes
+    *   - C
+        - 5.5
+        - 13.5
+        - 6.1
+        - 27.7
+        - yes
+    *   - D
+        - 5.1
+        - 13.6
+        - 6.1
+        - 27.2
+        - yes
+    *   - E
+        - 5.4
+        - 6.9
+        - 7.7
+        - 31.0
+        - no: pH above 7.0
+    *   - F
+        - 8.7
+        - 15.5
+        - 8.2
+        - 28.0
+        - no: concentration and pH above range
+
+The studied ranges are concentration 2 to 8 umol/L, co-solvent 5 to 25% v/v, pH 4.0 to 7.0, and
+temperature 15 to 35 degC. Chromogen B needs almost no change from the nominal centre: it already
+develops colour close to the reference. C and D need a moderate move, a higher pH and temperature,
+but stay inside the ranges. E and F cannot be brought onto the goal within the window: E needs a pH of
+7.7 and F a pH of 8.2 and a concentration of 8.7 umol/L, all beyond the values the experiment
+explored. The ordering, B then C and D then E and F, is the order of the late-time drift built into
+each compound, so the inversion recovers the same ranking the design was built to reveal, now as a
+set of concrete settings rather than a distance.
+
+.. figure:: ../figures/doe/colour-pls-inversion.png
+    :align: center
+    :width: 720px
+    :alt: colour-pls-inversion.py
+
+    The inverted continuous-factor settings that place each candidate on the reference goal, in coded
+    units, one row per factor. The shaded band between the dashed lines at :math:`-1` and :math:`+1`
+    is the studied range. B, C and D are reachable within the ranges; E and F need a pH (and, for F, a
+    concentration) beyond the studied window, marked with a heavy outline.
+
+The compensation figure shows the coded settings directly; a Plotly version, with the studied range
+shaded:
+
+.. code-block:: python
+
+    factors = ["concentration", "co_solvent", "pH", "temperature"]
+    coded = pd.DataFrame({c: compensate(c) for c in ["B", "C", "D", "E", "F"]}, index=factors)
+
+    fig = go.Figure()
+    fig.add_vrect(x0=-1, x1=1, fillcolor="#e8eef5", line_width=0)
+    for c in coded.columns:
+        fig.add_scatter(x=coded[c], y=factors, mode="markers", name=c)
+    fig.update_layout(xaxis_title="coded setting to match the goal (0 = nominal centre)")
+    fig.show()
+
+Inversion is non-unique, and this reports one member of the operating window, the smallest move from
+the nominal centre. A subject-matter expert might spend the free direction differently, for instance
+holding one factor fixed and solving for the rest, as the :ref:`product-development worked example
+<LVM_model_inversion_example>` does with a fixed hardness. The result is the same either way for the
+question asked here: B, C and D can be tuned to the reference colour development, and E and F cannot,
+not without moving outside the ranges the design covered.
 
 What the design and the library carried
 ---------------------------------------
@@ -984,8 +1150,9 @@ coordinate-exchange optimiser, ``pyoptex``, which powers the I-optimal and split
 and is installed on its own.
 
 The study answered its questions from a single design: the three interactions are significant
-(objectives 1 to 3), compound B develops colour most like the reference (objective 4), and the
-fitted model over the continuous factors locates settings for a target colour intensity for the
-chosen compound (objective 5). The same design supported a scalar analysis of variance on the peak
-and a multivariate model of the full curve, because the design was chosen for the model, not for a
-particular way of reducing the response.
+(objectives 1 to 3), inverting the model onto a reference goal shows that B, C and D can be tuned to
+develop colour like the reference while E and F cannot within the studied ranges (objective 4), and
+the fitted model over the continuous factors locates settings for a target colour intensity for the
+chosen compound (objective 5). The same design supported a scalar analysis of variance on the peak, a
+multivariate model of the full curve, and the inversion of that model back to factor settings,
+because the design was chosen for the model, not for a particular way of reducing the response.


### PR DESCRIPTION
Reworks the fourth-question answer in the mixed-level profile case study. It adds model diagnostics and PLS model inversion (which the chapter's product-development sibling sets up but only demonstrates for PCA), and then makes the **categorical coding** the subject: the same model, written three ways, gives three different low-rank answers, and only a full-rank reading is coding-invariant.

## What changed

- **New section "Model diagnostics: SPE and Hotelling's T2"**: per-run SPE and T2 for the 3-component interaction model, plotted against the 95% limits. Introduces the reference **goal** (chromogen A at the centre point), projects it with `diagnose`, and shows it sits well inside both limits (SPE 1.7, T2 0.05), so its prediction can be used as an inversion target. The compound-F runs that cross the limits are handed off to the coding section rather than explained away in a footnote.
- **New section "Coding the categorical factor"**: defines sum (effects), treatment (reference), and cell-means coding; shows that ordinary least squares is coding-invariant while a truncated PLS is not (a minimal three-level example: OLS prediction difference 1e-15, PLS 0.37 / 0.17 / 0.00 at one/two/three components; and cumulative R2Y of 0.88 / 0.90 / 0.91 across the three codings on the case-study model). The Hotelling's T2 leverage flag follows the *omitted* sum-coding level (F when F is dropped, A when A is dropped) and vanishes under treatment and cell-means. The interaction F-tests, the full-rank coefficients, and the goal check do not move with the coding.
- **Reworked "Which compound matches the reference"**: the score-matching inversion now reads as one coding among three, and the reachable set changes with it ({B,C,D} under sum, all five under treatment, {B,C,D,F} under cell-means). It then adds the **coding-invariant curve match** (match the predicted ten-point curve at full rank), which reaches only F and ties the binding constraint back to curve *shape*, not amplitude, reconnecting to the shape-distance ranking (B nearest the reference in shape).
- Cross-links the `product-development` inversion worked example, and cites Jaeckle and MacGregor (1998) for the inversion and Bro and Smilde (2003) for the coding/scaling sensitivity.
- Updates the closing summary's objective-4 sentence.

## Paired figures PR

Two new figures live in **kgdunn/figures#47** (`colour-coding-diagnostics.png`, `colour-coding-inversion.png`); the earlier `colour-pls-t2-spe.png` / `colour-pls-inversion.png` from the merged **kgdunn/figures#46** are unchanged and still used for the sum-coding worked example. Merge #47 first (or together); until then this repo's CI PDF build hard-fails on the missing images, as with previous figure PRs. `make text` and `make html` succeed locally with figures symlinked in.

## Library dependency

The diagnostics code uses `PLS.diagnose(...).spe`, which returned 0 for named-column models before **process-improve 1.52.4** (fixed in kgdunn/process-improve#454, now merged). The chapter notes this version. All other code uses long-standing public API (`transform`, `hotellings_t2_limit`, `spe_limit`) plus `patsy`.

## Verification

- Every quoted number reproduces from the seeded case-study code (goal SPE 1.7 / T2 0.05; limits 8.7 / 6.5; R2Y 0.88 / 0.90 / 0.91 per coding; max T2 26 (F-drop) / 18 (A-drop); reachable sets {B,C,D} / all five / {B,C,D,F}; curve match reaches only F, coding-invariant to 1e-13).
- `make text`: build succeeded, no warnings; both new `:ref:` targets resolve.
- `make html`: build succeeded; `grep -r goatcounter _build/html/contents` returns zero hits; both new figures copied into `_build/html/_images`.