### PR TITLE
Rule out off-plane relaxation of the inversion, and rename "shape floor"

### DIFF
--- a/product-development-product-improvement/mixed-level-profile-case-study.rst
+++ b/product-development-product-improvement/mixed-level-profile-case-study.rst
@@ -1420,6 +1420,43 @@ the reference as that candidate's shape allows, and the closed-loop check confir
 known truth. The ordering it recovers, B then F then C then D then E, is the late-time-drift ordering,
 the shape difference the fourth question was built around.
 
+One variant of the inversion is worth ruling out. The inversions above hold each candidate on the
+goal's projection, matching its three-component score or its predicted curve, so each solution sits
+close to the model plane. Muteki and MacGregor (2007) instead pose the inversion as an optimization
+that minimizes the distance to the target while keeping Hotelling's :math:`T^2` and the SPE below
+their limits, letting the solution float off the plane rather than lie on it. Allowing that here,
+with :math:`T^2` and SPE free to rise to their 95% limits, does not bring any candidate below its
+shape floor:
+
+.. code-block:: python
+
+    from scipy.optimize import minimize
+
+    t2_lim, spe_lim = pls_full.hotellings_t2_limit(), pls_full.spe_limit()
+
+    def t2_spe(compound, coded):                     # 3-component diagnostics of an inverted point
+        d = pls_full.diagnose(encode(compound, *coded))
+        return float(d.hotellings_t2.iloc[0]), float(d.spe.iloc[0])
+
+    def relaxed_inversion(compound):                 # Muteki and MacGregor (2007), their equation 5
+        objective = lambda c: float(np.sum((y_goal - curve_of(compound, c)) ** 2))
+        limits = [{"type": "ineq", "fun": lambda c: t2_lim - t2_spe(compound, c)[0]},
+                  {"type": "ineq", "fun": lambda c: spe_lim - t2_spe(compound, c)[1]}]
+        return minimize(objective, np.zeros(4), method="SLSQP", constraints=limits).x
+
+    for c in ["B", "C", "D", "E", "F"]:
+        settings = relaxed_inversion(c)
+        rmse = np.sqrt(np.mean((true_curve(c, settings) - goal_curve) ** 2))
+        print(c, round(float(rmse), 3))              # 0.016  0.058  0.094  0.100  0.043
+
+Each relaxed solution lands at or above its candidate's shape floor (B at 0.016 and D at 0.094,
+against floors of 0.015 and 0.079), while its SPE rises to the 6.5 limit and its settings leave the
+studied ranges. Pinning the two hard-to-change factors, temperature and co-solvent, at the centre and
+re-optimizing over concentration and pH alone gives the same result. The off-plane freedom the
+continuous factors can reach is amplitude, not shape, so it cannot close a compound's late-time drift:
+the closest attainable curve stays the projection of the target, which is Muteki and MacGregor's
+feasibility condition.
+
 Read together, the answer to which compound matches the reference is not one candidate but a graded
 ranking, and it depends on how the question is posed. The score match returns a binary reachable set
 that changes with the coding and with where the studied box is drawn, a statement about a low-rank

--- a/product-development-product-improvement/mixed-level-profile-case-study.rst
+++ b/product-development-product-improvement/mixed-level-profile-case-study.rst
@@ -1360,8 +1360,9 @@ reference profile.
         print(c, round(rmse, 3), round(rmse / noise, 1))
 
 The continuous factors move only the amplitude, so the closest any setting can bring a candidate to
-the reference is set by that candidate's fixed shape, its late-time drift. That floor, the smallest
-root-mean-square deviation from the reference at the best amplitude, orders the candidates by drift:
+the reference is set by that candidate's fixed shape, its late-time drift. The best attainable
+match, the smallest root-mean-square deviation from the reference reachable at any amplitude, orders
+the candidates by drift:
 
 .. list-table:: How close each candidate can be brought to the reference, limited by its fixed shape
     :widths: 20 20 22 26
@@ -1396,8 +1397,8 @@ root-mean-square deviation from the reference at the best amplitude, orders the 
         - 0.090
         - 3.0
 
-Running the curve-match settings through the ground truth reaches those floors for the near
-candidates: B lands at 0.016, F at 0.043, and C at 0.060, all within about two measurement-noise
+Running the curve-match settings through the ground truth reaches that best attainable match for the
+near candidates: B lands at 0.016, F at 0.043, and C at 0.060, all within about two measurement-noise
 standard deviations of the reference (and the in-range cell-means score match reaches them too, at B
 0.018, C 0.056, F 0.031). D and E stay at 2.6 times the noise or worse whatever the factors are set
 to, inside the box or outside it, because their shape gap is too large for amplitude to close.
@@ -1410,10 +1411,11 @@ to, inside the box or outside it, because their shape gap is too large for ampli
     Left: the reference curve (chromogen A at the centre point) with the closest emulation each
     candidate can reach, the best amplitude for its fixed shape. The candidates track the reference
     early and separate at the tail, by their late-time drift. Right: the emulation error against the
-    measurement-noise scale, each candidate's shape floor (open marker) and what the coding-invariant
-    curve-match inversion reaches when its real-unit settings are put through the ground truth (filled
-    marker), ordered by drift. B and F land within about one noise standard deviation of the reference,
-    C within two; D and E cannot be brought closer than 2.6 times the noise.
+    measurement-noise scale, each candidate's best attainable match (open marker) and what the
+    coding-invariant curve-match inversion reaches when its real-unit settings are put through the
+    ground truth (filled marker), ordered by drift. B and F land within about one noise standard
+    deviation of the reference, C within two; D and E cannot be brought closer than 2.6 times the
+    noise.
 
 So the inversion does its job: for each candidate it finds settings that bring the curve as close to
 the reference as that candidate's shape allows, and the closed-loop check confirms this against the
@@ -1426,7 +1428,7 @@ close to the model plane. Muteki and MacGregor (2007) instead pose the inversion
 that minimizes the distance to the target while keeping Hotelling's :math:`T^2` and the SPE below
 their limits, letting the solution float off the plane rather than lie on it. Allowing that here,
 with :math:`T^2` and SPE free to rise to their 95% limits, does not bring any candidate below its
-shape floor:
+best attainable match:
 
 .. code-block:: python
 
@@ -1449,11 +1451,12 @@ shape floor:
         rmse = np.sqrt(np.mean((true_curve(c, settings) - goal_curve) ** 2))
         print(c, round(float(rmse), 3))              # 0.016  0.058  0.094  0.100  0.043
 
-Each relaxed solution lands at or above its candidate's shape floor (B at 0.016 and D at 0.094,
-against floors of 0.015 and 0.079), while its SPE rises to the 6.5 limit and its settings leave the
-studied ranges. Pinning the two hard-to-change factors, temperature and co-solvent, at the centre and
-re-optimizing over concentration and pH alone gives the same result. The off-plane freedom the
-continuous factors can reach is amplitude, not shape, so it cannot close a compound's late-time drift:
+Each relaxed solution lands at or above its candidate's best attainable match (B at 0.016 and D at
+0.094, whose best matches are 0.015 and 0.079), while its SPE rises to the 6.5 limit and its
+settings leave the studied ranges. Pinning the two hard-to-change factors, temperature and co-solvent, at the
+centre and re-optimizing over concentration and pH alone gives the same result. The off-plane
+freedom the continuous factors can reach is amplitude, not shape, so it cannot close a compound's
+late-time drift:
 the closest attainable curve stays the projection of the target, which is Muteki and MacGregor's
 feasibility condition.
 


### PR DESCRIPTION
Two changes to the "Checking the inversion against the known ground truth" subsection of the mixed-level profile case study. Text only (no new figure) for the first; the second is a paired terminology rename.

## 1. Rule out a relaxed (off-plane) inversion

The score- and curve-matching inversions hold each candidate near the model plane. Following **Muteki and MacGregor (2007)**, the inversion can instead be posed as an optimization that minimizes the distance to the target while keeping Hotelling's T2 and the SPE below their 95% limits, letting the solution float off the plane. Applying that here does **not** bring any candidate below its best attainable match: the relaxed solutions land at or above it (B 0.016, C 0.058, D 0.094, E 0.100, F 0.043 against 0.015 / 0.055 / 0.079 / 0.090 / 0.031), while riding the SPE limit (6.5) and leaving the studied ranges. Pinning the two hard-to-change split-plot factors (temperature and co-solvent) at the centre and re-optimizing over concentration and pH alone gives the same result. The off-plane freedom the continuous factors reach is amplitude, not shape, so it cannot close a compound's late-time drift, which is the paper's feasibility condition. Includes the `scipy.optimize` check code, reusing the chapter's existing `pls_full`, `encode`, `curve_of`, `y_goal`, `true_curve`, and `goal_curve`.

## 2. Rename "shape floor" to "best attainable match"

Replaces the coined term "shape floor" with the plainer "best attainable match" throughout the section, with a one-line definition at first use (the smallest RMSE to the reference reachable at any amplitude, limited by the compound's fixed shape). No number or result changes. The paired figure legend is renamed in **kgdunn/figures** (`colour-inversion-validation.png`).

## Placement note

The relaxed-inversion paragraph sits at the end of the ground-truth validation subsection (before the closing synthesis), because the check reuses that subsection's ground-truth helpers; happy to move it earlier with a model-only framing if preferred.

## Verification

- The relaxed-inversion RMSE values reproduce from the seeded model.
- `make text` and `make html` succeed with no warnings; `grep -r goatcounter _build/html/contents` returns zero hits.
- Text only, all added text ASCII, so the LaTeX PDF build has no missing-image or Unicode dependency.