### PR TITLE
Drop the unresolved-slopes caveat from the peak comparison

### DIFF
--- a/product-development-product-improvement/mixed-level-profile-case-study.rst
+++ b/product-development-product-improvement/mixed-level-profile-case-study.rst
@@ -662,10 +662,7 @@ are omitted):
 
 The PLS point falls inside the :math:`\pm` one-standard-error band for all but two of the 24 terms
 (the largest gap is 1.4 standard errors), so the low-rank shrinkage is small next to the estimation
-uncertainty. On this single peak response least squares and PLS are interchangeable. Among the terms
-not shown, four compound-specific temperature and co-solvent slopes are not resolved individually at
-this run count (p-values from 0.07 to 0.37), though the joint F-test found the interaction present for
-the set.
+uncertainty. On this single peak response least squares and PLS are interchangeable.
 
 The interaction model on the full curve
 ---------------------------------------


### PR DESCRIPTION
## What changed

Removed one sentence from the peak least-squares-vs-PLS comparison in
`product-development-product-improvement/mixed-level-profile-case-study.rst`: the note that four
compound-specific temperature and co-solvent slopes are not individually resolved at this run count
(p-values 0.07 to 0.37). The joint F-test result already stands on its own and the caveat added
little.

## What did not change

No analysis, code, figures, or quoted numbers change; this removes one prose sentence.

## Verification

- `make text` succeeds with zero warnings.
- `make html` succeeds; `grep -r goatcounter _build/html/contents` returns zero hits.
- RST source is ASCII-clean.
- `CITATION.cff` `version:`/`date-released:` already at 2026.07.13 (today).


---
_Generated by [Claude Code](https://claude.ai/code/session_01TvUM1DPgi2S3JFLjRJTJWj)_