### PR TITLE
Adjust two image scales for the modernized chapter figures

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.07.13"
-date-released: 2026-07-13
+version: "2026.07.16"
+date-released: 2026-07-16
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/data-visualization/relational-graphs-scatter-plots.rst
+++ b/data-visualization/relational-graphs-scatter-plots.rst
@@ -54,7 +54,7 @@ You will see this in industrial settings as well. The next time you go into an i
 Further improvements can be made to your scatter plots. For example, extend the frames only as far as your data, and add a :index:`regression line <pair: regression line; scatter plot>` where appropriate:
 
 	.. image:: ../figures/visualization/scatterplot-figures-with-regression-lines.png
-		:scale: 75
+		:scale: 30
 
 You can add box plots and histograms to the side of the axes to aid interpretation:
 

--- a/univariate-review/some-terminology.rst
+++ b/univariate-review/some-terminology.rst
@@ -22,7 +22,7 @@ We review a couple of concepts that you should have seen in a prior statistical 
 		single: sample
 
 	.. image:: ../figures/univariate/batch-yields.png
-		:scale: 80
+		:scale: 40
 		:align: center
 
 	In engineering applications where we have plenty of data, we can characterize the population from all available data. The figure here shows the viscosity of a motor oil, from all batches produced in the last 5 years (about 1 batch per day). These 1825 data points, though technically a *sample* are an excellent surrogate for the *population* viscosity because they come from such a long duration. Once we have characterized these samples, future viscosity values will likely follow that same distribution, provided the process continues to operate in a similar manner.


### PR DESCRIPTION
## What changed

Companion to kgdunn/figures#55, which replaces the base-R figures in the data-visualization and univariate-review chapters with matplotlib versions generated by committed, seeded Python scripts.

Two of the replacement PNGs have larger pixel dimensions than the files they replace, so their `:scale:` values shrink to keep the same displayed size:

- `univariate-review/some-terminology.rst`: `batch-yields.png` scale 80 to 40 (the image went from 768x288 to 1600x600, so it now also renders crisply on high-DPI screens).
- `data-visualization/relational-graphs-scatter-plots.rst`: `scatterplot-figures-with-regression-lines.png` scale 75 to 30 (previously a 1399x679 screenshot of R output; now a 3600x1800 generated figure).

`CITATION.cff` version and release date bumped to 2026.07.16, per the repository rules. The README attribution year range already ends in 2026.

## What did not change

All other replacement figures keep their original pixel dimensions, so no other RST changes are needed. No prose changes: the chapter text (including the quoted numbers 3.04 and "31 out of 281, about 11%") was verified against the regenerated figures and still holds exactly.

## Build verification

- `make text`: succeeds with zero warnings.
- `make html`: succeeds; `grep -r goatcounter _build/html/contents` returns zero hits; the extensionless entry page `_build/html/contents` is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gbucEbmko1QaQPZDrjLhx

---
_Generated by [Claude Code](https://claude.ai/code/session_013gbucEbmko1QaQPZDrjLhx)_