### PR TITLE
Box plots: stop text wrapping around the boards figure

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.07.16"
-date-released: 2026-07-16
+version: "2026.07.17"
+date-released: 2026-07-17
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/data-visualization/box-plots.rst
+++ b/data-visualization/box-plots.rst
@@ -47,7 +47,7 @@ respectively):
 The following box plot is a graphical summary of these numbers.
 
 .. image:: ../figures/visualization/boxplot-for-two-by-six-100-boards.png
-	:align: right
+	:align: center
 	:scale: 40
 	:width: 900px
 	:alt: fake width

--- a/uv.lock
+++ b/uv.lock
@@ -282,7 +282,7 @@ wheels = [
 
 [[package]]
 name = "pid-book"
-version = "0.2.5"
+version = "0.2.7"
 source = { virtual = "." }
 dependencies = [
     { name = "sphinx" },


### PR DESCRIPTION
## What changed

Follow-up to #243. The boards box plot in `data-visualization/box-plots.rst` was `:align: right`, so the paragraph after it flowed around the image; on narrow (mobile) screens that side column collapses to one word per line ("A / box / plot / is"). The image is now `:align: center`, so it sits on its own line and the paragraph starts cleanly below it.

`CITATION.cff` version and release date bumped to 2026.07.17, per the repository rules.

## Build verification

`make text` succeeds with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gbucEbmko1QaQPZDrjLhx

---
_Generated by [Claude Code](https://claude.ai/code/session_013gbucEbmko1QaQPZDrjLhx)_