### PR TITLE
Adaptive sub-chapter: link the flotation callback and stress memory efficiency

### DIFF
--- a/product-development-product-improvement/adaptive-soft-sensor.rst
+++ b/product-development-product-improvement/adaptive-soft-sensor.rst
@@ -10,8 +10,9 @@ of step with it. A prediction or monitoring statistic from such a model then
 develops a systematic offset: its limits, set on earlier data, no longer match
 where the process now sits, and normal operation starts to look abnormal.
 
-The flotation example built one model on a phase-1 stretch and left it fixed,
-which is fine for a short demonstration. A process moves over months and years,
+The :ref:`flotation example <APPS_multivariate_monitoring_flotation>` built one
+model on a phase-1 stretch and left it fixed, which is fine for a short
+demonstration. A process moves over months and years,
 though, so here we keep the model current instead.
 
 This section works through that problem on a longer dataset. It uses a
@@ -277,8 +278,14 @@ matrices** (also called kernels): :math:`\mathbf{X}'\mathbf{X}`, the sum of
 cross-products of the process tags, and :math:`\mathbf{X}'\mathbf{Y}`, the
 cross-products of tags with the response. A PLS model's weights and regression
 coefficients can be recomputed from these two matrices alone, without the
-original rows, using a kernel algorithm. Alongside the kernels the model keeps
-the **centring** and **scaling** vectors, :math:`\mathbf{m}` and
+original rows, using a kernel algorithm. The size of these kernels is fixed by
+the number of *variables*, not the number of *observations*:
+:math:`\mathbf{X}'\mathbf{X}` is :math:`K \times K` and
+:math:`\mathbf{X}'\mathbf{Y}` is :math:`K \times M`. However long the process
+runs, none of the :math:`N` rows are ever kept, so the memory footprint stays
+small and constant, which makes the approach extremely memory-efficient for a
+sensor that must run continuously for months or years. Alongside the kernels the
+model keeps the **centring** and **scaling** vectors, :math:`\mathbf{m}` and
 :math:`\mathbf{s}`, that standardise each incoming row.
 
 When observation :math:`i` arrives as a raw row :math:`\mathbf{x}_i^0`, the


### PR DESCRIPTION
## What changed

Two small prose improvements to the 7.5 "Keeping a model current: an adaptive soft sensor" sub-chapter:

1. **Link the flotation callback.** The opening line "The flotation example built one model on a phase-1 stretch and left it fixed" now uses an explicit `:ref:` cross-reference to the flotation worked example in 7.3 (`APPS_multivariate_monitoring_flotation`). Since the adaptive material is now a separate sub-chapter, the reference cannot be positional; it renders as a hyperlink to the flotation section.

2. **Stress the memory efficiency.** In "How the recursive update works", the paragraph on the association-matrix kernels now makes explicit that their size is set by the number of *variables*, not the number of *observations*: `X'X` is K x K and `X'Y` is K x M. However long the process runs, none of the N rows are ever kept, so the memory footprint stays small and constant, which matters for a sensor that runs continuously for months or years.

## Verification

- `make text` and `make html` build successfully with zero new warnings (only the unrelated `colour-*` image warnings remain).
- The flotation `:ref:` resolves to a hyperlink (`multivariate-process-monitoring#apps-multivariate-monitoring-flotation`).
- `grep -r goatcounter _build/html/contents` returns zero hits.
- `CITATION.cff` `date-released` is today's date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQ4kBqpph4HgRfbDS3t3fJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQ4kBqpph4HgRfbDS3t3fJ)_