### PR TITLE
PLS model inversion: the null space, the orthogonal space, and a specification region

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.07.24"
-date-released: 2026-07-24
+version: "2026.07.25"
+date-released: 2026-07-25
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.07.25"
-date-released: 2026-07-25
+version: "2026.07.26"
+date-released: 2026-07-26
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/docs/blog/orthogonal-space-and-model-inversion.md
+++ b/docs/blog/orthogonal-space-and-model-inversion.md
@@ -110,10 +110,10 @@ For the cheese model, that orthogonal piece carries **18.3% of the sum of square
 exactly zero. So nearly a fifth of the systematic variation in these three measurements does nothing
 whatsoever to taste. That is not noise, and it is not a rounding error.
 
-Here is the part that took twenty-five years to write down. **That orthogonal space and the null
-space from the inversion are the same space.** García-Carrión and co-authors proved it, for a single
-response, in the *Journal of Chemometrics* last year. Written as unit vectors in the original three
-measurements, both come out as (0.948, -0.238, 0.211), and the cosine between them is 1.0.
+**That orthogonal space and the null space from the inversion are the same space.** García-Carrión
+and co-authors proved it, for a single response, in the *Journal of Chemometrics* last year. Written
+as unit vectors in the original three measurements, both come out as (0.948, -0.238, 0.211), and the
+cosine between them is 1.0.
 
 Two communities, solving two unrelated problems, with two different algorithms, named the same
 geometry twice. One called it the space to filter away; the other called it the freedom to design

--- a/docs/blog/orthogonal-space-and-model-inversion.md
+++ b/docs/blog/orthogonal-space-and-model-inversion.md
@@ -1,0 +1,223 @@
+> **Working draft, not part of the book. Delete this file once the post is published.**
+> It lives here only so the draft travels with the material it describes. Nothing in the Sphinx
+> build references it, and it is not meant to ship with the book.
+
+# The orthogonal space is as useful as the predictive space
+
+We build a model to predict an outcome from measurements. A latent variable model like PLS does that
+by compressing many correlated inputs into a few components, and the usual write-up spends all its
+attention on the component that tracks the response. The rest of the model, the systematic variation
+that has nothing to do with the response, gets filtered out and described as a nuisance.
+
+That leftover space has a use, and a name, and it turns out to have been discovered twice under two
+different names by two groups of people solving two different problems. This post is about what it
+is good for.
+
+## Running the model backwards
+
+Start with a small, old, well-worn data set: 30 cheddar cheeses, each with three measurements
+(acetic acid, hydrogen sulfide, lactic acid) and a taste score from a panel. The forward question is
+the ordinary one: given the three measurements, what taste do we predict?
+
+Many design problems ask the reverse. We fix the taste we want, and solve for the measurements that
+would produce it. That is called **model inversion**, and it is the basis of latent variable product
+and process design, going back to Jaeckle and MacGregor (2000).
+
+I hold out four cheeses, fit a two-component PLS model on the other 26, and invert it toward a taste
+of 20.9, which is what one of the held-out cheeses actually scored.
+
+```python
+pls = PLS(n_components=2).fit(X, Y)
+result = pls.invert(y_desired=20.9)
+
+print(result.x_new.round(2).to_dict())
+# {'Acetic': 5.52, 'H2S': 5.56, 'Lactic': 1.40}
+print(result.null_space_dimension)        # 1
+```
+
+A recipe comes back. So far this is unremarkable.
+
+The interesting part is the second line of output. The null space has dimension 1, which is the
+model telling us that this is not *the* answer. It is one point on a whole line of answers.
+
+## Many recipes, one target
+
+Two components, one response. The target fixes one direction in the score space and leaves the other
+free. Anything we do along that free direction changes the recipe without moving the prediction.
+
+Stepping one unit either way along it:
+
+| Row | Target taste | Acetic | H2S | Lactic | T² | SPE |
+|---|---|---|---|---|---|---|
+| Predicted at step -1 | 20.9 | 4.95 | 6.10 | 1.33 | 1.63 | 0.00 |
+| Predicted at step 0 | 20.9 | 5.52 | 5.56 | 1.40 | 0.06 | 0.00 |
+| Predicted at step +1 | 20.9 | 6.09 | 5.02 | 1.46 | 2.44 | 0.00 |
+
+Read down the rows and the inputs move substantially. Acetic acid goes from about 5 to 6, hydrogen
+sulfide falls from 6.10 to 5.02, lactic acid rises slightly. Every one of them still predicts a
+taste of 20.9. This set of equally-good recipes is the **null space** of the inversion.
+
+That is a practical result on its own. If three recipes all hit the target, we are free to choose
+among them on something the model never saw: cost, supplier availability, energy, shelf life,
+whichever raw material lot happens to be in the yard this week.
+
+*Figure: the score plot, with the calibration cheeses, the direct-inversion solution, and the null
+space drawn as a line through it. Parallel lines for other target tastes.*
+(`pls/pls-model-inversion-null-space.png`)
+
+## Why it is a line, and not a point
+
+The geometry is worth a moment, because it makes everything that follows easier to see.
+
+With two components the prediction is just a weighted sum of the two scores, ŷ = q₁t₁ + q₂t₂. So the
+vector **q** of y-loadings is the *gradient* of the prediction in the score plot: the direction in
+which predicted taste climbs fastest.
+
+Think of the prediction as a hill over the score plot. **q** points straight uphill. Asking for a
+specific taste is asking to stand at a specific height, and the set of points at one height on a
+hill is a contour line. The null space is that contour: walk along it and your coordinates change
+while your altitude does not.
+
+Which gives the whole thing in one line. If a step Δt leaves the prediction unchanged, then
+
+**q**ᵀΔt = 0
+
+The free directions are exactly those perpendicular to the gradient. For these cheeses **q** =
+(0.546, -0.262), so the contour has a slope of 2.08 in the score plot, and every design on that line
+predicts the same taste.
+
+*Figure: contours of predicted taste, perpendicular to the gradient q, drawn on equal axes so the
+right angle is visible.* (`pls/pls-null-space-geometry.png`)
+
+## The same space, arrived at from the other direction
+
+Now forget inversion completely.
+
+O-PLS (orthogonal projections to latent structures, Trygg and Wold, 2002) was invented for an
+unrelated reason: to make a model easier to interpret. It takes the one X matrix and writes it as
+two additive pieces plus a residual:
+
+X = **t**ₚ**p**ₚᵀ + **T**ₒ**P**ₒᵀ + E
+
+y = qₚ**t**ₚ + f
+
+The first piece is *predictive*, the second is *Y-orthogonal*. The important line is the second one:
+**T**ₒ does not appear in it. The orthogonal piece can be as large as it likes and the prediction
+does not move.
+
+For the cheese model, that orthogonal piece carries **18.3% of the sum of squares in X**, against
+68.7% for the predictive piece and 13.0% left in the residual. Its score correlates with taste at
+exactly zero. So nearly a fifth of the systematic variation in these three measurements does nothing
+whatsoever to taste. That is not noise, and it is not a rounding error.
+
+Here is the part that took twenty-five years to write down. **That orthogonal space and the null
+space from the inversion are the same space.** García-Carrión and co-authors proved it, for a single
+response, in the *Journal of Chemometrics* last year. Written as unit vectors in the original three
+measurements, both come out as (0.948, -0.238, 0.211), and the cosine between them is 1.0.
+
+Two communities, solving two unrelated problems, with two different algorithms, named the same
+geometry twice. One called it the space to filter away; the other called it the freedom to design
+with.
+
+## What the orthogonal space is for
+
+This is the part I want to argue for, because the orthogonal space is usually presented as the part
+you discard.
+
+**It tells you what you do not have to control.** Variation along these directions is, by
+construction, variation the response does not feel. If a plant is fighting to hold a measurement
+steady and that measurement moves mostly along the orthogonal space, that effort is buying very
+little. The predictive space tells you what to control. The orthogonal space tells you where you can
+stop.
+
+**It gives you alternatives at no cost to the target.** Every point along it hits the same number.
+The freedom is real and it is free, in terms of the response. It is not free in every sense, and
+that is the caveat to state plainly: in the table above, stepping away from the middle raised T²
+from 0.06 to 1.63 and 2.44. The prediction does not change, but the support the data give that
+design does. So the freedom is bounded, and T² is how we bound it.
+
+**It is a robustness statement about incoming material.** Two lots of raw material that differ a lot
+on paper may differ almost entirely along the orthogonal space, in which case they are
+interchangeable for this product. Two others that look similar may differ along the predictive
+direction and not be interchangeable at all. The distance that matters is not the distance in the
+raw measurements.
+
+## From points to regions
+
+Everything above aimed at one target number. Real products are specified over a range, and that is
+where this gets useful rather than merely elegant.
+
+Each acceptable taste has its own null space, and those null spaces are parallel. Sweeping the
+target across the acceptable range sweeps its line across the score plot, and the swept lines fill
+out a region. Bound it in the other direction with the T² limit so we do not wander outside the
+data, and the result is a **multivariate specification region**: the set of inputs we are prepared
+to accept.
+
+```python
+t2_limit = pls.hotellings_t2_limit(0.95)   # 7.36
+
+region = []
+for target in np.linspace(20.0, 40.0, 5):        # the range of taste we accept
+    for step in np.linspace(-6, 6, 2001):        # walk along that target's null space
+        candidate = pls.invert(target, null_space_coordinates=[step])
+        if candidate.hotellings_t2 <= t2_limit:
+            region.append(candidate.x_new)
+```
+
+One warning that costs people real money: the min and max of that region are the *enclosing box*,
+not the region. The region is a slanted band. A lot can sit inside all three individual ranges and
+still fall outside the band, because what makes it acceptable is the combination, not each
+measurement separately.
+
+This shape of answer covers a lot of ground:
+
+- **Incoming raw materials.** Which lots can I accept, and how do I use the ones I have?
+- **Product and process transfer, and scale-up.** Which conditions on the new line reproduce the
+  product from the old one?
+- **Design space, in the QbD sense.** A defensible region rather than a single set point.
+- **Choosing among equivalent recipes** on cost, availability, or environmental impact.
+
+Jaeckle and MacGregor called this a *window of process operating conditions* in 2000, and moved
+along the null space over a range that kept conditions within past experience, then applied
+engineering judgement to pick a point in that window. Bounding by T² makes "within past experience"
+a single testable number. Paris, Duchesne and Poulin (2021) compare model inversion against direct
+mapping for exactly this and find neither wins in every case: inversion accepted more of the good
+lots in their study, while direct mapping is simpler and leaves more freedom in the region's shape.
+
+## The caveats worth stating
+
+The equivalence is proved for a **single response**. With more than one response, inversion still
+works, but the O-PLS shortcut does not carry over, since O-PLS separates one predictive component.
+The null space then has dimension A - rank(Y): with three components and two responses, a line. The
+multi-response equivalence is open work, noted as such by the authors.
+
+And a moderate model is fine for this. The cheese model explains about 67% of the variation in
+taste, which is unremarkable. The null space is a property of the model's geometry, not of how
+accurately it predicts. A design far from the cheese that actually had that taste is not a failed
+inversion: the inversion returns the smallest-norm solution, nature returned whatever it returned,
+and the null space is precisely the reason both can carry the same predicted taste while sitting
+some distance apart.
+
+## Try it
+
+Everything above runs. `PLS.invert()` and an `OPLS` estimator are in the open-source
+`process_improve` library, and every number and figure in this post regenerates from public code on
+a public data set.
+
+The fully worked version, with the algebra, the geometry, the specification region, and a
+multiple-response example on a solvents data set, is the "Using a PLS model backwards: model
+inversion and the null space" section of my free textbook.
+
+## References
+
+- C. M. Jaeckle and J. F. MacGregor, "Industrial applications of product design through the
+  inversion of latent variable models", *Chemometrics and Intelligent Laboratory Systems*, **50**
+  (2000): 199-210.
+- J. Trygg and S. Wold, "Orthogonal projections to latent structures (O-PLS)", *Journal of
+  Chemometrics*, **16** (2002): 119-128, doi:10.1002/cem.695.
+- A. Paris, C. Duchesne, and É. Poulin, "Establishing multivariate specification regions for
+  incoming raw materials using projection to latent structure models", *Frontiers in Analytical
+  Science*, **1** (2021): 729732.
+- S. García-Carrión, F. Sartori, J. Borràs-Ferrís, P. Facco, M. Barolo, and A. Ferrer, "On the
+  equivalence between null space and orthogonal space in latent variable regression modeling",
+  *Journal of Chemometrics*, **39** (2025): e70057, doi:10.1002/cem.70057.

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -11,9 +11,9 @@ MacGregor, 2000
 <https://literature.learnche.org/item/180/industrial-applications-of-product-design-through-the-inversion-of-latent-variable-models>`_).
 
 We will use the same :ref:`cheddar-cheese data <LVM-cheddar-cheese-example>` as before: the taste of a
-cheese predicted from three chemical measurements, acetic acid, hydrogen sulfide, and lactic acid. The
-forward question was "what taste does this chemistry give?" The inversion question is "which chemistry
-gives a target taste?"
+cheese predicted from three inputs, acetic acid, hydrogen sulfide, and lactic acid. The forward
+question was "what taste do these inputs give?" The inversion question is "which inputs give a
+target taste?"
 
 .. figure:: ../../figures/examples/cheese/cheese-plots-no-random.png
 	:alt: Scatterplot matrix of the cheddar-cheese data: acetic acid, hydrogen sulfide, lactic acid and taste
@@ -21,24 +21,24 @@ gives a target taste?"
 	:align: center
 
 	The 30 cheeses in the raw data. The diagonal shows each variable's distribution; the off-diagonal
-	panels are the pairwise scatter plots with a least-squares line. The three chemical measurements
-	rise together, and each rises with Taste. It is these correlations that give the inverted model
-	room to return more than one chemistry for a target taste.
+	panels are the pairwise scatter plots with a least-squares line. The three inputs rise together,
+	and each rises with Taste. It is these correlations that give the inverted model room to return
+	more than one set of inputs for a target taste.
 
 .. _LVM-PLS-inversion-components:
 
 Why inversion needs more than the predictive number of components
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When we chose the number of components for prediction in
-:ref:`the section above <LVM-PLS-number-of-components>`, cross-validation kept a single component: one
-component is enough to predict Taste. Inversion places a second demand on the model. To reconstruct an
-input vector from a target output, the model must describe the |X|-space well enough to map a score
-back to a full set of chemistry values, not only the |Y|-space. A one-component model spans only a line
-in the input space, so it can return just one chemistry for a target taste. Keeping a second component
-lets the model describe the plane on which the calibration cheeses actually lie, and, as we will see, it
-opens up a whole set of equivalent designs. We therefore fit a two-component model here, even though the
-second component did not improve prediction.
+When we chose the number of components for prediction in :ref:`the section above
+<LVM-PLS-number-of-components>`, cross-validation kept a single component: one component is enough
+to predict Taste. Inversion places a second demand on the model. To reconstruct an input vector from
+a target output, the model must describe the |X|-space well enough to map a score back to a full set
+of input values, not only the |Y|-space. A one-component model spans only a line in the input space,
+so it can return just one set of inputs for a target taste. Keeping a second component lets the
+model describe the plane on which the calibration cheeses actually lie, and, as we will see, it
+opens up a whole set of equivalent designs. We therefore fit a two-component model here, even though
+the second component did not improve prediction.
 
 Following the request to design toward cheeses the model has not seen, we hold out the first four cheeses
 and fit the model on the remaining twenty-six.
@@ -70,8 +70,8 @@ predicts.
 The null space: many recipes, one target
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Held-out cheese 2 has a taste of 20.9. We invert the model to find a chemistry that the model predicts
-will give that taste.
+Held-out cheese 2 has a taste of 20.9. We invert the model to find the inputs that the model
+predicts will give that taste.
 
 .. code-block:: python
 
@@ -81,20 +81,20 @@ will give that taste.
 	# {'Acetic': 5.52, 'H2S': 5.56, 'Lactic': 1.40}
 	print(result.null_space_dimension)        # 1
 
-	# Compare the designed chemistry with what cheese 2 actually was.
+	# Compare the designed inputs with what cheese 2 actually was.
 	actual = holdout[x_columns].iloc[1]
-	for label, chemistry in [("Actual", actual), ("Predicted", result.x_new)]:
-	    d = pls.diagnose(chemistry.to_frame().T)
+	for label, inputs in [("Actual", actual), ("Predicted", result.x_new)]:
+	    d = pls.diagnose(inputs.to_frame().T)
 	    print(f"{label}: T2 = {float(d.hotellings_t2.iloc[0]):.2f}, "
 	          f"SPE = {float(d.spe.iloc[0]):.2f}")
 	# Actual: T2 = 0.21, SPE = 0.68
 	# Predicted: T2 = 0.06, SPE = 0.00
 
-The prediction at the designed chemistry is exactly 20.9, by construction. To judge whether that design
+The prediction at the designed inputs is exactly 20.9, by construction. To judge whether that design
 is a reasonable one, compare it with the cheese we held out. For this model the 99% limits are
 :math:`T^2 = 12.14` and :math:`\text{SPE} = 1.60`.
 
-.. list-table:: Cheese 2: its measured chemistry, and the chemistry the inversion returns for a taste of 20.9.
+.. list-table:: Cheese 2: its measured inputs, and the inputs the inversion returns for taste 20.9.
 	:header-rows: 1
 	:widths: 20 16 16 16 16 16
 
@@ -117,9 +117,9 @@ is a reasonable one, compare it with the cheese we held out. For this model the 
 		- 0.06
 		- 0.00
 
-Both rows sit well inside the two limits, so neither is an extrapolation. The predicted chemistry has an
-SPE of exactly zero, because the inversion rebuilds the inputs from their scores: the result lies on the
-model plane by construction, leaving no residual.
+Both rows sit well inside the two limits, so neither is an extrapolation. The predicted inputs have
+an SPE of exactly zero, because the inversion rebuilds the inputs from their scores: the result
+lies on the model plane by construction, leaving no residual.
 
 The two rows are close, but "close" in the raw units is hard to read: a gap of 0.5 in hydrogen sulfide
 does not mean the same thing as a gap of 0.5 in lactic acid, because the three measurements are on
@@ -150,19 +150,18 @@ Writing the three terms out, with acetic acid first, then hydrogen sulfide, then
 	\end{aligned}
 
 The square root of 0.66 is 0.81, so the cheese we held out sits about 0.8 standard deviations away from
-the chemistry the inversion proposed, counting all three measurements together. Acetic acid accounts for
-most of that gap.
+the inputs the inversion proposed, counting all three measurements together. Acetic acid accounts
+for most of that gap.
 
 The null space is the reason ``null_space_dimension`` is not zero. A two-component model has two score
 directions, but a single taste value pins down only one of them. The other direction is free: we can move
 along it and the predicted taste does not change at all. That free direction is the *null space*. Its
 dimension is the number of components minus the rank of the response, here :math:`2 - 1 = 1`, so it is a
-line. Every chemistry on that line gives the same predicted taste.
+line. Every set of inputs on that line gives the same predicted taste.
 
 We can walk along the null space by passing coordinates along its basis. In the code and figure we take a
 step of -1 and +1 along the basis. The predicted taste stays the same along this basis line. Hence the
-name the null space. Only the input variables change, i.e. the chemistry, while the predicted output
-remains fixed.
+name the null space. Only the input variables change, while the predicted output remains fixed.
 
 .. code-block:: python
 
@@ -173,11 +172,12 @@ remains fixed.
 	# [4.95, 6.10, 1.33] -> 20.9
 	# [6.09, 5.02, 1.46] -> 20.9
 
-Both of these chemistries, and the whole line between and beyond them, predict a taste of 20.9. The
-freedom to choose among them is what makes inversion useful in practice: it can be spent on a secondary
-goal such as cost, safety, or keeping within a supplier's specification, without moving the predicted
-quality. As a check on the held-out cheese, its actual chemistry (Acetic 5.16, H2S 5.04, Lactic 1.53)
-predicts a taste of 20.7, close to its measured 20.9, and it lies near the null-space line we just traced.
+Both of these sets of inputs, and the whole line between and beyond them, predict a taste of 20.9.
+The freedom to choose among them is what makes inversion useful in practice: it can be spent on a
+secondary goal such as cost, safety, or keeping within a supplier's specification, without moving
+the predicted quality. As a check on the held-out cheese, its actual inputs (Acetic 5.16, H2S 5.04,
+Lactic 1.53) predict a taste of 20.7, close to its measured 20.9, and it lies near the null-space
+line just traced.
 
 A score plot shows the picture directly. The calibration cheeses are the points, the black square is the
 direct-inversion solution, and the orange line is the null space: the set of scores that all predict a
@@ -308,7 +308,7 @@ singular vector points along :math:`\mathbf{q}`, and the remaining :math:`A-1` s
 perpendicular to it. With two components that leaves a single perpendicular direction, a line; with three
 components it leaves a plane, and so on.
 
-Finally, it is worth asking what that direction means in the chemistry, rather than in the scores.
+Finally, it is worth asking what that direction means for the inputs, rather than in the scores.
 Multiplying the direction by the |X|-loadings maps it back to the three measurements, and a step of
 :math:`+1` moves acetic acid by :math:`+0.57`, hydrogen sulfide by :math:`-0.54`, and lactic acid by only
 :math:`+0.06`, in the original units. Moving along the null space therefore trades acetic acid up against
@@ -330,8 +330,8 @@ variation gathered into a single component.
 
 It is worth being concrete about how that split is built, because it explains everything that follows.
 O-PLS keeps the same two-dimensional plane the PLS model already found; what it changes is the pair of
-axes drawn within that plane. The first axis is chosen to point along the variation in the chemistry that
-tracks taste. For these cheeses that direction, the predictive weight, is
+axes drawn within that plane. The first axis is chosen to point along the variation in the inputs
+that tracks taste. For these cheeses that direction, the predictive weight, is
 
 .. math::
 
@@ -339,7 +339,7 @@ tracks taste. For these cheeses that direction, the predictive weight, is
 	\qquad \text{for (acetic, hydrogen sulfide, lactic)}
 
 All three entries are positive and of similar size, which is the raw-data picture restated: the three
-chemical measurements rise together, and each rises with taste. The second axis takes what is left of the
+inputs rise together, and each rises with taste. The second axis takes what is left of the
 plane once that predictive direction has been removed, giving the orthogonal weight
 
 .. math::
@@ -374,7 +374,7 @@ The orthogonal score does not appear. In the language of the previous section, t
 prediction in O-PLS coordinates is :math:`(0.571, 0)`: it points exactly along the predictive axis. The
 contours of predicted taste are therefore perpendicular to that axis, which now means parallel to the
 orthogonal axis. The diagonal line of the PLS score plot becomes a line running along a coordinate axis.
-It is the same set of chemistries either way; only the axes used to describe it have moved.
+The same combinations of inputs are described either way; only the axes describing them have moved.
 
 This is also why inverting an O-PLS model needs no linear algebra. Fixing the taste gives one equation
 with one unknown, since the orthogonal score is absent from it, so the predictive score follows by
@@ -408,7 +408,7 @@ its inversion is one division rather than the solution of an underdetermined sys
 	print(opls_result.x_new.round(2).to_list())   # [5.46, 5.62, 1.39]
 	print(round(opls_result.y_hat, 2))            # 20.9
 
-The O-PLS design, (Acetic 5.46, H2S 5.62, Lactic 1.39), is a different chemistry from the PLS
+The O-PLS design, (Acetic 5.46, H2S 5.62, Lactic 1.39), is a different set of inputs from the PLS
 direct-inversion design, but it lies on the same null-space line and gives the same predicted taste. The
 two methods return different representative points: PLS reports the point of smallest score norm, while
 O-PLS reports the point whose orthogonal score is zero. The set of solutions, the line itself, is
@@ -428,7 +428,7 @@ comparing their directions.
 	)
 	print(round(cosine, 6))    # 1.0
 
-Written as unit vectors in the chemistry, both come out as
+Written as unit vectors in the inputs, both come out as
 :math:`(0.948,\ -0.238,\ 0.211)`, the same numbers to three decimals, and the cosine between them is 1.0.
 Two methods, developed for different purposes and computed by different algorithms, describe the same
 line: raise acetic acid, lower hydrogen sulfide, adjust lactic acid slightly, and the predicted taste
@@ -443,8 +443,9 @@ back as a coordinate axis.
 Reading the result: how far is the design from the data?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Inversion always returns a chemistry, whatever taste we ask for, so we need a way to judge whether that
-chemistry is a reasonable one. Hotelling's :math:`T^2` of the solution answers this: it measures how far
+Inversion always returns a set of inputs, whatever taste we ask for, so we need a way to judge
+whether those inputs are reasonable. Hotelling's :math:`T^2` of the solution answers this: it
+measures how far
 the design sits from the centre of the calibration data, in the same units as the
 :ref:`score diagnostics <LVM-Hotellings-T2>` used elsewhere. Designing toward each of the four
 held-out cheeses in turn shows the pattern.
@@ -514,7 +515,7 @@ largest :math:`T^2` of the four cheeses, 4.08, so it is an unusual cheese to beg
 from the centre of the calibration data while the design does not.
 
 A large deviation is not a failure of the inversion. The model returns the solution of smallest score
-norm, whereas nature produced whichever chemistry it produced, and the null space means both can carry
+norm, whereas nature produced whichever inputs it produced, and the null space means both can carry
 the same predicted taste while sitting some distance apart. The deviation measures how far apart the two
 recipes are, not how wrong either of them is.
 
@@ -531,8 +532,8 @@ Turning the inversion around: a specification region
 
 Everything so far has aimed at a single target taste. In practice a product is rarely specified by one
 number: it is accepted over a range. Once we ask for a range instead of a point, the inversion answers a
-different and often more useful question. Rather than "which chemistry gives a taste of 20.9?", we ask
-"which chemistries give a taste we would accept?" The set of inputs that answer it is called a
+different and often more useful question. Rather than "which inputs give a taste of 20.9?", we ask
+"which inputs give a taste we would accept?" The set of inputs that answer it is called a
 :index:`multivariate specification region <single: multivariate specification region>`, and for incoming
 raw materials it is a statement of what we are prepared to buy.
 
@@ -575,9 +576,9 @@ Suppose a taste between 20 and 40 is acceptable.
 	# min    4.35  4.44    1.25
 	# max    6.99  9.47    1.86
 
-A cheese whose chemistry falls in this region is predicted to have an acceptable taste. Note that these
+A cheese whose inputs fall in this region is predicted to have an acceptable taste. Note that these
 minima and maxima are the box that encloses the region, not the region itself: the region is a slanted
-band in the three chemical measurements, and a lot may sit inside every one of the three ranges while
+band in the three inputs, and a lot may sit inside every one of the three ranges while
 still lying outside the band. Note also that the enclosing box reaches slightly past the observed range
 of acetic acid in the training cheeses (4.48 to 6.46). The :math:`T^2` limit bounds the joint distance
 from the centre of the model, not each measurement separately, so a corner of the region can sit a little

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -419,15 +419,24 @@ comparing their directions.
 
 	ns_input = result.null_space_basis.to_numpy().T @ pls.x_loadings_.to_numpy().T
 	os_input = opls_result.orthogonal_space_basis.to_numpy().T
-	cosine = np.abs(ns_input @ os_input.T) / (
+
+	print((ns_input / np.linalg.norm(ns_input)).round(3))    # [[ 0.948 -0.238  0.211]]
+	print((os_input / np.linalg.norm(os_input)).round(3))    # [[ 0.948 -0.238  0.211]]
+
+	cosine = np.abs(ns_input @ os_input.T).item() / (
 	    np.linalg.norm(ns_input) * np.linalg.norm(os_input)
 	)
-	print(float(cosine))    # 1.0
+	print(round(cosine, 6))    # 1.0
 
-The cosine between the two directions is 1.0: the PLS null space and the O-PLS orthogonal space point the
-same way and span the same line. This is what the green circles in the
-:ref:`score plot <LVM-PLS-null-space-figure>` show: they are the orthogonal space projected into the PLS
-score plot, and they lie on the orange null-space line.
+Written as unit vectors in the chemistry, both come out as
+:math:`(0.948,\ -0.238,\ 0.211)`, the same numbers to three decimals, and the cosine between them is 1.0.
+Two methods, developed for different purposes and computed by different algorithms, describe the same
+line: raise acetic acid, lower hydrogen sulfide, adjust lactic acid slightly, and the predicted taste
+does not move. This is what the green circles in the :ref:`score plot <LVM-PLS-null-space-figure>` show:
+they are the orthogonal space projected into the PLS score plot, and they lie on the orange null-space
+line. The two approaches differ in bookkeeping rather than in what they find. PLS solves for the freedom
+after the fact and hands it back as a null-space basis; O-PLS sets it aside during fitting and hands it
+back as a coordinate axis.
 
 .. _LVM-PLS-inversion-in-practice:
 
@@ -552,7 +561,7 @@ properties give a solvent with a chosen :math:`\log P` and solubility.
 	print(design.null_space_dimension)          # 1
 	print(round(design.hotellings_t2, 2))       # 2.46
 	print(model.predict(design.x_new.to_frame().T).round(2).to_dict("records")[0])
-	# {'logP': 0.5, 'Solubility': -0.0}
+	# {'logP': 0.5, 'Solubility': 0.0}
 
 Two things change with two responses. First, the target now pins down two score directions instead of
 one, so the null space has dimension :math:`A - \text{rank}(\mathbf{Y})`. Here that is

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -363,7 +363,7 @@ the figure do not converge.
 	:width: 620px
 	:align: center
 
-	The same score plot, with both axes drawn to the same scale so that angles are true. The purple
+	The same score plot, with both axes drawn to the same scale so that angles are true. The maroon
 	arrow is the gradient :math:`\mathbf{q}`, the direction in which the predicted taste rises fastest.
 	The orange line is the null space for a taste of 20.9, at right angles to it, and the grey dotted
 	lines are the contours for tastes of 10, 30 and 40. The orange square is the direct-inversion

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -363,12 +363,13 @@ the figure do not converge.
 	:width: 620px
 	:align: center
 
-	The same score plot, with both axes drawn to the same scale so that angles are true. The teal arrow
-	is the gradient :math:`\mathbf{q}`, the direction in which the predicted taste rises fastest. The
-	orange line is the null space for a taste of 20.9, at right angles to it, and the grey dotted lines
-	are the contours for tastes of 10, 30 and 40. The orange square is the direct-inversion solution,
-	which sits where a perpendicular dropped from the origin meets the orange contour, and so is the
-	solution of smallest score norm.
+	The same score plot, with both axes drawn to the same scale so that angles are true. The dark green
+	arrow is the gradient :math:`\mathbf{q}`, the direction in which the predicted taste rises fastest.
+	The orange line is the null space for a taste of 20.9, at right angles to it, and the grey dotted
+	lines are the contours for tastes of 10, 30 and 40. The orange square is the direct-inversion
+	solution, which sits where a perpendicular dropped from the origin meets the orange contour, and so
+	is the solution of smallest score norm. The two orange triangles are the -1 and +1 steps, the same
+	points marked in the score plot above, so the two figures can be read against each other.
 
 We can confirm both statements from the fitted model.
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -540,9 +540,10 @@ Two methods, developed for different purposes and computed by different algorith
 line: raise acetic acid, lower hydrogen sulfide, adjust lactic acid slightly, and the predicted taste
 does not move. This is what the green circles in the :ref:`score plot <LVM-PLS-null-space-figure>` show:
 they are the orthogonal space projected into the PLS score plot, and they lie on the orange null-space
-line. The two approaches differ in bookkeeping rather than in what they find. PLS solves for the freedom
-after the fact and hands it back as a null-space basis; O-PLS sets it aside during fitting and hands it
-back as a coordinate axis.
+line. The two approaches differ in bookkeeping rather than in what they find. Both describe the same
+freedom: the directions the inputs can move in without changing the predicted taste. PLS solves for that
+freedom after the fact and hands it back as a null-space basis; O-PLS sets the same freedom aside during
+fitting and hands it back as a coordinate axis.
 
 .. _LVM-PLS-inversion-in-practice:
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -449,21 +449,74 @@ the design sits from the centre of the calibration data, in the same units as th
 :ref:`score diagnostics <LVM-Hotellings-T2>` used elsewhere. Designing toward each of the four
 held-out cheeses in turn shows the pattern.
 
+We can repeat for all four held-out cheeses what we did for cheese 2: invert toward its taste, then
+record how far the design sits from the data, how far the cheese itself sits from the data, and the
+normalized deviation between the two.
+
 .. code-block:: python
 
-	for i in range(4):
+	rows = []
+	for i in range(len(holdout)):
 	    target = float(holdout["Taste"].iloc[i])
-	    t2 = pls.invert(target).hotellings_t2
-	    print(f"taste {target:5.1f} -> T2 {t2:.2f}")
-	# taste  12.3 -> T2 1.07
-	# taste  20.9 -> T2 0.06
-	# taste  39.0 -> T2 1.93
-	# taste  47.9 -> T2 4.82
+	    design = pls.invert(target)
+	    measured = holdout[x_columns].iloc[i]
+	    a = scaler.transform(measured.to_frame().T).iloc[0]
+	    p = scaler.transform(design.x_new.to_frame().T).iloc[0]
+	    rows.append({
+	        "Taste": target,
+	        "T2 design": design.hotellings_t2,
+	        "T2 cheese": float(pls.diagnose(measured.to_frame().T).hotellings_t2.iloc[0]),
+	        "Deviation": float(((a - p) ** 2).sum()),
+	    })
 
-The moderate tastes near the middle of the calibration range give designs with small :math:`T^2`; the
-more extreme tastes push the design further from the data, and :math:`T^2` grows. A large :math:`T^2` does
-not make a design wrong, but it flags that the model is extrapolating and that the predicted taste rests
-on less support from the data.
+	print(pd.DataFrame(rows).round(2))
+
+.. list-table:: The four held-out cheeses: how far each design and each cheese sits from the calibration data, and the normalized deviation between them. The 99% limit on :math:`T^2` is 12.14.
+	:header-rows: 1
+	:widths: 14 16 22 22 26
+
+	*	- Cheese
+		- Taste
+		- :math:`T^2` of the design
+		- :math:`T^2` of the cheese
+		- Normalized deviation
+	*	- 1
+		- 12.3
+		- 1.07
+		- 4.08
+		- 4.50
+	*	- 2
+		- 20.9
+		- 0.06
+		- 0.21
+		- 0.66
+	*	- 3
+		- 39.0
+		- 1.93
+		- 0.02
+		- 2.65
+	*	- 4
+		- 47.9
+		- 4.82
+		- 0.94
+		- 1.57
+
+Reading down the third column, the moderate tastes near the middle of the calibration range give designs
+with small :math:`T^2`, while the more extreme tastes push the design further from the data: asking for a
+taste of 47.9 gives the largest value, 4.82. A large :math:`T^2` does not make a design wrong, but it
+flags that the model is extrapolating and that the predicted taste rests on less support from the data.
+All four are well inside the 99% limit of 12.14.
+
+The last column compares each design with the cheese that actually had that taste. Cheese 2 is the
+closest match, at 0.66, which is the case we worked through. Cheese 1 is the furthest, at 4.50, or
+:math:`\sqrt{4.50} = 2.1` standard deviations. The fourth column explains part of that: cheese 1 has the
+largest :math:`T^2` of the four cheeses, 4.08, so it is an unusual cheese to begin with, sitting well away
+from the centre of the calibration data while the design does not.
+
+A large deviation is not a failure of the inversion. The model returns the solution of smallest score
+norm, whereas nature produced whichever chemistry it produced, and the null space means both can carry
+the same predicted taste while sitting some distance apart. The deviation measures how far apart the two
+recipes are, not how wrong either of them is.
 
 For a single response, then, PLS model inversion and O-PLS model inversion lead to the same set of
 designs. They differ in how they reach it: PLS inversion solves an underdetermined system and returns the

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -14,6 +14,16 @@ cheese predicted from three chemical measurements, acetic acid, hydrogen sulfide
 forward question was "what taste does this chemistry give?" The inversion question is "which chemistry
 gives a target taste?"
 
+.. figure:: ../../figures/examples/cheese/cheese-plots-no-random.png
+	:alt: Scatterplot matrix of the cheddar-cheese data: acetic acid, hydrogen sulfide, lactic acid and taste
+	:width: 600px
+	:align: center
+
+	The 30 cheeses in the raw data. The diagonal shows each variable's distribution; the off-diagonal
+	panels are the pairwise scatter plots with a least-squares line. The three chemical measurements
+	rise together, and each rises with Taste. It is these correlations that give the inverted model
+	room to return more than one chemistry for a target taste.
+
 .. _LVM-PLS-inversion-components:
 
 Why inversion needs more than the predictive number of components
@@ -221,6 +231,70 @@ minimum-norm point, while O-PLS inversion is a single division once the orthogon
 separated during fitting. The equivalence has been proved for one response; the multiple-response case
 remains open (García-Carrión et al., 2025).
 
+.. _LVM-PLS-specification-regions:
+
+Turning the inversion around: a specification region
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Everything so far has aimed at a single target taste. In practice a product is rarely specified by one
+number: it is accepted over a range. Once we ask for a range instead of a point, the inversion answers a
+different and often more useful question. Rather than "which chemistry gives a taste of 20.9?", we ask
+"which chemistries give a taste we would accept?" The set of inputs that answer it is called a
+:index:`multivariate specification region <single: multivariate specification region>`, and for incoming
+raw materials it is a statement of what we are prepared to buy.
+
+Building it needs nothing new. Each acceptable taste has its own null space, and those null spaces are
+parallel, as shown in the score plot in :ref:`the section on O-PLS <LVM-PLS-orthogonal-space>`. Sweeping
+the target across the acceptable range sweeps its null space across the score plot, and the swept lines
+fill out a region.
+
+Two boundaries close the region off. The acceptable range of taste bounds it in one direction. In the
+other direction, along each null space, the region would run on without limit, so we bound it by the
+Hotelling's :math:`T^2` limit: solutions beyond it are extrapolations, as
+:ref:`the previous section <LVM-PLS-inversion-in-practice>` described. Paris and co-workers (2021) do
+exactly this, constraining the region by the 95% :math:`T^2` limit so it stays inside the space the data
+support.
+
+Suppose a taste between 20 and 40 is acceptable.
+
+.. code-block:: python
+
+	t2_limit = pls.hotellings_t2_limit(0.95)
+
+	region = []
+	for target in np.linspace(20.0, 40.0, 5):        # the range of taste we accept
+	    for step in np.linspace(-6, 6, 2001):        # walk along that target's null space
+	        candidate = pls.invert(target, null_space_coordinates=[step])
+	        if candidate.hotellings_t2 <= t2_limit:
+	            region.append(candidate.x_new)
+
+	region = pd.DataFrame(region)
+	print(round(t2_limit, 2))                        # 7.36
+	print(region.agg(["min", "max"]).round(2))
+	#      Acetic   H2S  Lactic
+	# min    4.35  4.44    1.25
+	# max    6.99  9.47    1.86
+
+A cheese whose chemistry falls in this region is predicted to have an acceptable taste. Note that these
+minima and maxima are the box that encloses the region, not the region itself: the region is a slanted
+band in the three chemical measurements, and a lot may sit inside every one of the three ranges while
+still lying outside the band. Note also that the enclosing box reaches slightly past the observed range
+of acetic acid in the training cheeses (4.48 to 6.46). The :math:`T^2` limit bounds the joint distance
+from the centre of the model, not each measurement separately, so a corner of the region can sit a little
+outside the range of any one measurement.
+
+When a candidate lot falls outside the region, the natural follow-up is to ask which measurement put it
+there. That is what a :ref:`contribution plot <APPS_multivariate_monitoring_contribution>` answers, by
+breaking the :math:`T^2` value into the part each variable contributes (Miller, Swanson and Heckler,
+1998).
+
+Inversion is not the only route to a specification region. The inputs can also be mapped directly into a
+region without inverting a model, an approach known as direct mapping. Paris and co-workers (2021)
+compare the two on simulated data and find neither is better in every case: model inversion accepted more
+of the genuinely good lots in their study, while direct mapping is simpler to compute and leaves more
+freedom in the shape of the region. Which suits a given problem depends on the relative cost of accepting
+a lot that turns out to be bad and rejecting one that would have been fine.
+
 .. _LVM-PLS-inversion-multiple-responses:
 
 More than one response
@@ -265,6 +339,15 @@ García-Carrión et al. (2025).
 
 * J. Trygg and S. Wold, "Orthogonal projections to latent structures (O-PLS)", *Journal of Chemometrics*,
   16 (2002): 119-128, `doi:10.1002/cem.695 <https://doi.org/10.1002/cem.695>`_.
+
+* A. Paris, C. Duchesne, and É. Poulin, "Establishing multivariate specification regions for incoming raw
+  materials using projection to latent structure models: comparison between direct mapping and model
+  inversion", *Frontiers in Analytical Science*, 1 (2021): 729732,
+  `doi:10.3389/frans.2021.729732 <https://doi.org/10.3389/frans.2021.729732>`_.
+
+* P. Miller, R. E. Swanson, and C. E. Heckler, "`Contribution plots: a missing link in multivariate
+  quality control <https://literature.learnche.org/item/78/contribution-plots-a-missing-link-in-multivariate-quality-control>`_",
+  *Applied Mathematics and Computer Science*, **8** (1998): 775-792.
 
 * S. García-Carrión, F. Sartori, J. Borràs-Ferrís, P. Facco, M. Barolo, and A. Ferrer, "On the equivalence
   between null space and orthogonal space in latent variable regression modeling", *Journal of

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -292,7 +292,9 @@ predict a taste of 20.9.
 	:width: 700px
 	:align: center
 
-	Score plot of the two-component model (cheeses 5 to 30). The orange line is the null space for a
+	Score plot of the two-component model (cheeses 5 to 30). Each cheese is drawn with an area
+	proportional to its measured taste, the legend marker being the size for a taste of 20. The orange
+	line is the null space for a
 	target taste of 20.9, and the orange square is the direct-inversion solution. The two triangles are
 	the -1 step (pointing down) and the +1 step (pointing up) from the code above; both predict a
 	taste of 20.9. The red dashed and purple dotted lines are the null spaces for two other target
@@ -363,7 +365,8 @@ the figure do not converge.
 	:width: 620px
 	:align: center
 
-	The same score plot, with both axes drawn to the same scale so that angles are true. The maroon
+	The same score plot, with the areas again proportional to taste and both axes drawn to the same
+	scale so that angles are true. The maroon
 	arrow is the gradient :math:`\mathbf{q}`, the direction in which the predicted taste rises fastest.
 	The orange line is the null space for a taste of 20.9, at right angles to it, and the grey dotted
 	lines are the contours for tastes of 10, 30 and 40. The orange square is the direct-inversion

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -363,7 +363,7 @@ the figure do not converge.
 	:width: 620px
 	:align: center
 
-	The same score plot, with both axes drawn to the same scale so that angles are true. The dark green
+	The same score plot, with both axes drawn to the same scale so that angles are true. The purple
 	arrow is the gradient :math:`\mathbf{q}`, the direction in which the predicted taste rises fastest.
 	The orange line is the null space for a taste of 20.9, at right angles to it, and the grey dotted
 	lines are the contours for tastes of 10, 30 and 40. The orange square is the direct-inversion

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -80,12 +80,46 @@ will give that taste.
 	print(result.x_new.round(2).to_dict())
 	# {'Acetic': 5.52, 'H2S': 5.56, 'Lactic': 1.40}
 	print(result.null_space_dimension)        # 1
-	print(round(result.hotellings_t2, 2))     # 0.06
 
-The model returns a chemistry of about (Acetic 5.52, H2S 5.56, Lactic 1.40). The prediction at this point
-is exactly 20.9, by construction. Two other quantities are reported. The ``null_space_dimension`` is 1,
-and the Hotelling's :math:`T^2` of the solution is 0.06, far inside the 99% limit of 12.1, so this design
-sits comfortably among the calibration cheeses rather than being an extrapolation.
+	# Compare the designed chemistry with what cheese 2 actually was.
+	actual = holdout[x_columns].iloc[1]
+	for label, chemistry in [("Actual", actual), ("Predicted", result.x_new)]:
+	    d = pls.diagnose(chemistry.to_frame().T)
+	    print(f"{label}: T2 = {float(d.hotellings_t2.iloc[0]):.2f}, "
+	          f"SPE = {float(d.spe.iloc[0]):.2f}")
+	# Actual: T2 = 0.21, SPE = 0.68
+	# Predicted: T2 = 0.06, SPE = 0.00
+
+The prediction at the designed chemistry is exactly 20.9, by construction. To judge whether that design
+is a reasonable one, compare it with the cheese we held out. For this model the 99% limits are
+:math:`T^2 = 12.14` and :math:`\text{SPE} = 1.60`.
+
+.. list-table:: Cheese 2: its measured chemistry, and the chemistry the inversion returns for a taste of 20.9.
+	:header-rows: 1
+	:widths: 20 16 16 16 16 16
+
+	*	- Row
+		- Acetic
+		- H2S
+		- Lactic
+		- :math:`T^2`
+		- SPE
+	*	- Actual
+		- 5.16
+		- 5.04
+		- 1.53
+		- 0.21
+		- 0.68
+	*	- Predicted
+		- 5.52
+		- 5.56
+		- 1.40
+		- 0.06
+		- 0.00
+
+Both rows sit well inside the two limits, so neither is an extrapolation. The predicted chemistry has an
+SPE of exactly zero, because the inversion rebuilds the inputs from their scores: the result lies on the
+model plane by construction, leaving no residual.
 
 The null space is the reason ``null_space_dimension`` is not zero. A two-component model has two score
 directions, but a single taste value pins down only one of them. The other direction is free: we can move

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -195,12 +195,14 @@ the null space does and does not change.
 	}
 	for label, inputs in designs.items():
 	    d = pls.diagnose(inputs.to_frame().T)
+	    v = scaler.transform(inputs.to_frame().T).iloc[0]
 	    print(f"{label:<22}{inputs.round(2).to_list()}  "
-	          f"T2 = {float(d.hotellings_t2.iloc[0]):.2f}, SPE = {float(d.spe.iloc[0]):.2f}")
+	          f"T2 = {float(d.hotellings_t2.iloc[0]):.2f}, SPE = {float(d.spe.iloc[0]):.2f}, "
+	          f"deviation = {float(((a - v) ** 2).sum()):.2f}")
 
 .. list-table:: Cheese 2 and three points along its null space, all reaching the same target taste.
 	:header-rows: 1
-	:widths: 24 14 12 12 12 12 12
+	:widths: 22 12 10 10 10 10 10 16
 
 	*	- Row
 		- Target taste
@@ -209,6 +211,7 @@ the null space does and does not change.
 		- Lactic
 		- :math:`T^2`
 		- SPE
+		- Deviation from target
 	*	- Actual
 		- 20.9
 		- 5.16
@@ -216,6 +219,7 @@ the null space does and does not change.
 		- 1.53
 		- 0.21
 		- 0.68
+		- 0.00
 	*	- Predicted at step -1
 		- 20.9
 		- 4.95
@@ -223,6 +227,7 @@ the null space does and does not change.
 		- 1.33
 		- 1.63
 		- 0.00
+		- 0.82
 	*	- Predicted at step 0
 		- 20.9
 		- 5.52
@@ -230,6 +235,7 @@ the null space does and does not change.
 		- 1.40
 		- 0.06
 		- 0.00
+		- 0.66
 	*	- Predicted at step +1
 		- 20.9
 		- 6.09
@@ -237,6 +243,7 @@ the null space does and does not change.
 		- 1.46
 		- 2.44
 		- 0.00
+		- 2.66
 
 Read across the three predicted rows and the inputs change substantially: acetic acid runs from 4.95
 to 6.09 while hydrogen sulfide falls from 6.10 to 5.02. Every one of them still reaches a taste of
@@ -247,9 +254,18 @@ either side moves the design away from the centre of the calibration data, to 1.
 freedom along the null space is therefore free in terms of the predicted taste, but not in terms of
 how much support the data give the design.
 
-A score plot shows the picture directly. The calibration cheeses are the points, the black square is the
-direct-inversion solution, and the orange line is the null space: the set of scores that all predict a
-taste of 20.9.
+The last column is the normalized deviation of each row from the cheese we are designing toward,
+computed the same way as before: centre and scale each input, then sum the squared differences. The
+Actual row is 0.00 because it is the target. Reading down the column, the step 0 design is the
+closest of the three at 0.66, the -1 step is a little further at 0.82, and the +1 step is furthest
+at 2.66. Since every one of those rows reaches the same predicted taste, the column says which of
+the equally valid designs comes nearest to a real cheese, which is a choice the null space leaves
+open. Sliding a little further in the -1 direction would do better still: the closest point on the
+line to this cheese sits near a step of -0.43, at a deviation of 0.46.
+
+A score plot shows the picture directly. The calibration cheeses are the points, the orange square
+is the direct-inversion solution, and the orange line is the null space: the set of scores that all
+predict a taste of 20.9.
 
 .. code-block:: python
 
@@ -264,7 +280,8 @@ taste of 20.9.
 	fig.add_scatter(x=line[:, 0], y=line[:, 1], mode="lines", name="null space",
 	                line={"color": "orange"})
 	fig.add_scatter(x=[tau[0]], y=[tau[1]], mode="markers", name="direct inversion",
-	                marker={"color": "black", "symbol": "square", "size": 10})
+	                marker={"color": "orange", "symbol": "square", "size": 12,
+	                        "line": {"color": "black", "width": 1}})
 	fig.update_layout(xaxis_title="t_1", yaxis_title="t_2")
 	fig.show()
 
@@ -276,8 +293,8 @@ taste of 20.9.
 	:align: center
 
 	Score plot of the two-component model (cheeses 5 to 30). The orange line is the null space for a
-	target taste of 20.9, and the black square is the direct-inversion solution. The two orange triangles
-	are the -1 step (pointing down) and the +1 step (pointing up) from the code above; both predict a
+	target taste of 20.9, and the orange square is the direct-inversion solution. The two triangles are
+	the -1 step (pointing down) and the +1 step (pointing up) from the code above; both predict a
 	taste of 20.9. The red dashed and purple dotted lines are the null spaces for two other target
 	tastes, 47.9 and 12.3. All three are parallel: a single-response model has one null-space direction,
 	and only the position shifts with the target. The green circles are the O-PLS orthogonal space,
@@ -346,7 +363,7 @@ another target taste, which is why the three lines in the figure do not converge
 	The same score plot, with both axes drawn to the same scale so that angles are true. The teal arrow
 	is the gradient :math:`\mathbf{q}`, the direction in which the predicted taste rises fastest. The
 	orange line is the null space for a taste of 20.9, at right angles to it, and the grey dotted lines
-	are the contours for tastes of 10, 30 and 40. The black square is the direct-inversion solution,
+	are the contours for tastes of 10, 30 and 40. The orange square is the direct-inversion solution,
 	which sits where a perpendicular dropped from the origin meets the orange contour, and so is the
 	solution of smallest score norm.
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -424,9 +424,33 @@ The same space, reached a different way: O-PLS
 Orthogonal projections to latent structures (O-PLS) was developed in a separate line of work, for a
 different reason: to make a model easier to interpret. O-PLS splits the systematic variation in |X| into
 two parts. One *predictive* component carries the variation that is related to |Y|; the remaining
-*Y-orthogonal* components carry systematic variation in |X| that has no bearing on |Y|. Filtering out the
-orthogonal part leaves a model with the same predictions as ordinary PLS, but with the response-relevant
-variation gathered into a single component.
+*Y-orthogonal* components carry systematic variation in |X| that has no bearing on |Y|.
+
+It is worth writing that split out, because there is a single |X| matrix here, not two blocks of data
+sitting side by side. O-PLS writes that one matrix as a predictive piece plus an orthogonal piece plus a
+residual, and the three pieces add back up to |X|:
+
+.. math::
+
+	\begin{aligned}
+	\mathbf{X} &= \underbrace{\mathbf{t}_\text{p} \mathbf{p}_\text{p}^T}_{\text{predictive}}
+	  \,+\, \underbrace{\mathbf{T}_\text{o} \mathbf{P}_\text{o}^T}_{Y\text{-orthogonal}}
+	  \,+\, \underbrace{\mathbf{E}}_{\text{residual}} \\
+	\mathbf{y} &= q_\text{p}\, \mathbf{t}_\text{p} + \mathbf{f}
+	\end{aligned}
+
+The vector :math:`\mathbf{t}_\text{p}` is the single predictive score, one value per observation, and
+:math:`\mathbf{p}_\text{p}` is its loading, one value per input. :math:`\mathbf{T}_\text{o}` and
+:math:`\mathbf{P}_\text{o}` are the matching orthogonal scores and loadings, carrying one column for
+each orthogonal component asked for, while :math:`\mathbf{E}` and :math:`\mathbf{f}` hold what no
+component explains. For these cheeses, in the scaled units the model works in, the predictive piece
+carries 68.7% of the sum of squares in |X|, the orthogonal piece 18.3%, and the residual 13.0%.
+
+The second line is where O-PLS parts company with PLS. Only :math:`\mathbf{t}_\text{p}` appears in it:
+the orthogonal scores :math:`\mathbf{T}_\text{o}` are absent, so movement in the orthogonal piece
+cannot change the predicted taste, however large that piece is. Filtering out the orthogonal part
+leaves a model with the same predictions as ordinary PLS, but with the response-relevant variation
+gathered into a single component.
 
 It is worth being concrete about how that split is built, because it explains everything that follows.
 O-PLS keeps the same two-dimensional plane the PLS model already found; what it changes is the pair of

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -127,8 +127,10 @@ along it and the predicted taste does not change at all. That free direction is 
 dimension is the number of components minus the rank of the response, here :math:`2 - 1 = 1`, so it is a
 line. Every chemistry on that line gives the same predicted taste.
 
-We can walk along the null space by passing coordinates along its basis. The prediction stays fixed while
-the chemistry changes.
+We can walk along the null space by passing coordinates along its basis. In the code and figure we take a
+step of -1 and +1 along the basis. The predicted taste stays the same along this basis line. Hence the
+name the null space. Only the input variables change, i.e. the chemistry, while the predicted output
+remains fixed.
 
 .. code-block:: python
 
@@ -166,8 +168,20 @@ taste of 20.9.
 	fig.update_layout(xaxis_title="t_1", yaxis_title="t_2")
 	fig.show()
 
-Every score on the orange line predicts a taste of 20.9. When we overlay the O-PLS orthogonal space
-(below), it falls exactly on this line, as the figure at the end of the next section shows.
+.. _LVM-PLS-null-space-figure:
+
+.. figure:: ../../figures/pls/pls-model-inversion-null-space.png
+	:alt: Score plot showing the null space and the O-PLS orthogonal space overlapping
+	:width: 700px
+	:align: center
+
+	Score plot of the two-component model (cheeses 5 to 30). The orange line is the null space for a
+	target taste of 20.9, and the black square is the direct-inversion solution. The two orange triangles
+	are the -1 step (pointing down) and the +1 step (pointing up) from the code above; both predict a
+	taste of 20.9. The red dashed and purple dotted lines are the null spaces for two other target
+	tastes, 47.9 and 12.3. All three are parallel: a single-response model has one null-space direction,
+	and only the position shifts with the target. The green circles are the O-PLS orthogonal space,
+	described in the section that follows.
 
 .. _LVM-PLS-orthogonal-space:
 
@@ -218,20 +232,9 @@ comparing their directions.
 	print(float(cosine))    # 1.0
 
 The cosine between the two directions is 1.0: the PLS null space and the O-PLS orthogonal space point the
-same way and span the same line.
-
-.. figure:: ../../figures/pls/pls-model-inversion-null-space.png
-	:alt: Score plot showing the null space and the O-PLS orthogonal space overlapping
-	:width: 700px
-	:align: center
-
-	Score plot of the two-component model (cheeses 5 to 30). The orange line is the null space for a
-	target taste of 20.9; the green circles are the O-PLS orthogonal space for that target, projected
-	into the plot, and they fall on the orange line. The black square is the direct-inversion solution,
-	and the two orange triangles mark a -1 step (pointing down) and a +1 step (pointing up) along the
-	null space; both predict the same taste of 20.9. The red dashed and purple dotted lines are the null
-	spaces for two other target tastes, 47.9 and 12.3. All three are parallel: a single-response model
-	has one null-space direction, and only the position shifts with the target.
+same way and span the same line. This is what the green circles in the
+:ref:`score plot <LVM-PLS-null-space-figure>` show: they are the orthogonal space projected into the PLS
+score plot, and they lie on the orange null-space line.
 
 .. _LVM-PLS-inversion-in-practice:
 
@@ -279,7 +282,7 @@ different and often more useful question. Rather than "which chemistry gives a t
 raw materials it is a statement of what we are prepared to buy.
 
 Building it needs nothing new. Each acceptable taste has its own null space, and those null spaces are
-parallel, as shown in the score plot in :ref:`the section on O-PLS <LVM-PLS-orthogonal-space>`. Sweeping
+parallel, as the :ref:`score plot <LVM-PLS-null-space-figure>` shows. Sweeping
 the target across the acceptable range sweeps its null space across the score plot, and the swept lines
 fill out a region.
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -424,16 +424,19 @@ variation gathered into a single component.
 It is worth being concrete about how that split is built, because it explains everything that follows.
 O-PLS keeps the same two-dimensional plane the PLS model already found; what it changes is the pair of
 axes drawn within that plane. The first axis is chosen to point along the variation in the inputs
-that tracks taste. For these cheeses that direction, the predictive weight, is
+that tracks taste. The fitted model reports it as ``opls.predictive_weights_``, one entry per input,
+and for these cheeses that direction is
 
 .. math::
 
 	\mathbf{w}_\text{p} = (0.474,\ 0.657,\ 0.586)
 	\qquad \text{for (acetic, hydrogen sulfide, lactic)}
 
-All three entries are positive and of similar size, which is the raw-data picture restated: the three
-inputs rise together, and each rises with taste. The second axis takes what is left of the
-plane once that predictive direction has been removed, giving the orthogonal weight
+The entries are in the mean-centred, unit-variance units the model works in, so they can be compared
+with each other directly. All three are positive and of similar size, which is the raw-data picture
+restated: the three inputs rise together, and each rises with taste. The second axis takes what is left
+of the plane once that predictive direction has been removed, reported as ``opls.orthogonal_weights_``,
+one column per orthogonal component. Here there is one column, the orthogonal weight
 
 .. math::
 
@@ -447,6 +450,10 @@ uncorrelated with the response, exactly, while the predictive score is strongly 
 .. code-block:: python
 
 	opls = OPLS(n_orthogonal_components=1).fit(X, Y)
+
+	print(opls.predictive_weights_.round(3).to_numpy())           # [0.474 0.657 0.586]
+	print(opls.orthogonal_weights_.round(3).to_numpy().ravel())   # [ 0.808 -0.59   0.008]
+
 	y_centred = (Y - Y.mean()).to_numpy().ravel()
 
 	print(round(float(np.corrcoef(opls.orthogonal_scores_.to_numpy().ravel(), y_centred)[0, 1]), 12))

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -554,8 +554,8 @@ Inversion always returns a set of inputs, whatever taste we ask for, so we need 
 whether those inputs are reasonable. Hotelling's :math:`T^2` of the solution answers this: it
 measures how far
 the design sits from the centre of the calibration data, in the same units as the
-:ref:`score diagnostics <LVM-Hotellings-T2>` used elsewhere. Designing toward each of the four
-held-out cheeses in turn shows the pattern.
+:ref:`score diagnostics <LVM-Hotellings-T2>` used elsewhere. Let's take a look with all four held-out
+cheeses.
 
 We can repeat for all four held-out cheeses what we did for cheese 2: invert toward its taste, then
 record how far the design sits from the data, how far the cheese itself sits from the data, and the

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -252,9 +252,10 @@ fill out a region.
 Two boundaries close the region off. The acceptable range of taste bounds it in one direction. In the
 other direction, along each null space, the region would run on without limit, so we bound it by the
 Hotelling's :math:`T^2` limit: solutions beyond it are extrapolations, as
-:ref:`the previous section <LVM-PLS-inversion-in-practice>` described. Paris and co-workers (2021) do
-exactly this, constraining the region by the 95% :math:`T^2` limit so it stays inside the space the data
-support.
+:ref:`the previous section <LVM-PLS-inversion-in-practice>` described. `Paris and co-workers (2021)
+<https://literature.learnche.org/item/181/establishing-multivariate-specification-regions-for-incoming-raw-materials-using-projection-to-latent-structure-models-comparison-between-direct-mapping-and-model-inversion>`_
+do exactly this, constraining the region by the 95% :math:`T^2` limit so it stays inside the space the
+data support.
 
 The idea is as old as the method. Jaeckle and MacGregor called the result a *window of process operating
 conditions*: they moved along the null space over a range that kept the conditions within those seen in
@@ -343,10 +344,11 @@ García-Carrión et al. (2025).
 * J. Trygg and S. Wold, "Orthogonal projections to latent structures (O-PLS)", *Journal of Chemometrics*,
   16 (2002): 119-128, `doi:10.1002/cem.695 <https://doi.org/10.1002/cem.695>`_.
 
-* A. Paris, C. Duchesne, and É. Poulin, "Establishing multivariate specification regions for incoming raw
-  materials using projection to latent structure models: comparison between direct mapping and model
-  inversion", *Frontiers in Analytical Science*, 1 (2021): 729732,
-  `doi:10.3389/frans.2021.729732 <https://doi.org/10.3389/frans.2021.729732>`_.
+* A. Paris, C. Duchesne, and É. Poulin, "`Establishing multivariate specification regions for incoming
+  raw materials using projection to latent structure models: comparison between direct mapping and model
+  inversion
+  <https://literature.learnche.org/item/181/establishing-multivariate-specification-regions-for-incoming-raw-materials-using-projection-to-latent-structure-models-comparison-between-direct-mapping-and-model-inversion>`_",
+  *Frontiers in Analytical Science*, **1** (2021): 729732.
 
 * S. García-Carrión, F. Sartori, J. Borràs-Ferrís, P. Facco, M. Barolo, and A. Ferrer, "On the equivalence
   between null space and orthogonal space in latent variable regression modeling", *Journal of

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -346,12 +346,15 @@ The constant cancels, leaving
 	\qquad \text{or} \qquad
 	\mathbf{q}^T \Delta \mathbf{t} = 0
 
-Any step along the line is therefore perpendicular to the vector :math:`\mathbf{q} = (q_1, q_2)`. That
-vector has a meaning: since :math:`\hat{y} = \mathbf{q}^T \mathbf{t}`, it is the gradient of the
-prediction, the direction in the score plot along which the predicted taste changes fastest. Moving at
-right angles to a gradient is what keeps a quantity constant, so the null space is a contour line of the
-predicted taste drawn over the score plot. Every parallel line in the score plot is another contour, for
-another target taste, which is why the three lines in the figure do not converge.
+Any step along the line is therefore perpendicular to the vector :math:`\mathbf{q} = (q_1, q_2)`.
+That vector has a meaning: since :math:`\hat{y} = \mathbf{q}^T \mathbf{t}`, it is the gradient of
+the prediction, the direction in the score plot along which the predicted taste changes fastest.
+Moving at right angles to a gradient is what keeps a quantity constant. It is like walking a path on
+a hill where you stay at exactly the same elevation (the output value) while your latitude and
+longitude change (a different set of inputs). So the null space is that contour line: the predicted
+taste stays the same even though you are at different coordinates in the score plot. Every parallel
+line in the score plot is another contour, for another target taste, which is why the three lines in
+the figure do not converge.
 
 .. _LVM-PLS-null-space-geometry-figure:
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -200,6 +200,8 @@ the null space does and does not change.
 	          f"T2 = {float(d.hotellings_t2.iloc[0]):.2f}, SPE = {float(d.spe.iloc[0]):.2f}, "
 	          f"deviation = {float(((a - v) ** 2).sum()):.2f}")
 
+.. _LVM-PLS-null-space-steps-table:
+
 .. list-table:: Cheese 2 and three points along its null space, all reaching the same target taste.
 	:header-rows: 1
 	:widths: 22 12 10 10 10 10 10 16
@@ -247,8 +249,10 @@ the null space does and does not change.
 
 Read down the three predicted rows and the inputs change substantially in order to keep the taste
 constant. Acetic acid increases from about 5 to 6, while that is compensated by hydrogen sulfide
-falling from 6.10 to 5.02, and lactic acid increases slightly, from 1.33 to 1.46. Every one of the
-three still reaches a taste of 20.9, and every one has an SPE of zero, since all three are rebuilt
+falling from 6.10 to 5.02, and lactic acid increases slightly, from 1.33 to 1.46. This same trade-off
+comes back when we reach :ref:`O-PLS <LVM-PLS-orthogonal-space>` below, where it appears directly as
+one of the model's axes. Every one of the three still reaches a taste of 20.9, and every one has an
+SPE of zero, since all three are rebuilt
 from scores and so lie on the model plane. What does change is :math:`T^2`. The step 0 row is the
 direct-inversion solution, the one of smallest score norm, and it has the smallest :math:`T^2` of
 the three, 0.06. Stepping out to either side moves the design away from the centre of the
@@ -443,7 +447,9 @@ one column per orthogonal component. Here there is one column, the orthogonal we
 	\mathbf{w}_\text{o} = (0.808,\ -0.590,\ 0.008)
 
 Read that as a recipe: raise acetic acid, lower hydrogen sulfide, and leave lactic acid essentially
-untouched. It is the same trade-off the null space described, arrived at without ever inverting anything.
+untouched. It is the same trade-off the null space described, arrived at without ever inverting anything,
+and the same one the :ref:`table of null-space steps <LVM-PLS-null-space-steps-table>` set out in the
+original units.
 The defining property is that this second axis carries no taste information at all. Its score is
 uncorrelated with the response, exactly, while the predictive score is strongly correlated with it.
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -96,30 +96,33 @@ is a reasonable one, compare it with the cheese we held out. For this model the 
 
 .. list-table:: Cheese 2: its measured inputs, and the inputs the inversion returns for taste 20.9.
 	:header-rows: 1
-	:widths: 20 16 16 16 16 16
+	:widths: 16 18 14 14 14 12 12
 
 	*	- Row
+		- Target taste
 		- Acetic
 		- H2S
 		- Lactic
 		- :math:`T^2`
 		- SPE
 	*	- Actual
+		- 20.9
 		- 5.16
 		- 5.04
 		- 1.53
 		- 0.21
 		- 0.68
 	*	- Predicted
+		- 20.9
 		- 5.52
 		- 5.56
 		- 1.40
 		- 0.06
 		- 0.00
 
-Both rows sit well inside the two limits, so neither is an extrapolation. The predicted inputs have
-an SPE of exactly zero, because the inversion rebuilds the inputs from their scores: the result
-lies on the model plane by construction, leaving no residual.
+Both rows sit well inside the SPE and :math:`T^2` limits, so neither is an extrapolation. The
+predicted inputs have an SPE of exactly zero, because the inversion rebuilds the inputs from their
+scores: the result lies on the model plane by construction, leaving no residual.
 
 The two rows are close, but "close" in the raw units is hard to read: a gap of 0.5 in hydrogen sulfide
 does not mean the same thing as a gap of 0.5 in lactic acid, because the three measurements are on

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -215,6 +215,91 @@ taste of 20.9.
 	and only the position shifts with the target. The green circles are the O-PLS orthogonal space,
 	described in the section that follows.
 
+.. _LVM-PLS-null-space-direction:
+
+Where the null-space line comes from
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The line has to run somewhere, and its direction is not arbitrary. It is fixed entirely by the
+:math:`y`-loadings, the two numbers that convert scores into a predicted taste.
+
+Start from how the model predicts. For a two-component model the prediction is a weighted sum of the two
+scores, with the :math:`y`-loadings :math:`q_1` and :math:`q_2` as the weights:
+
+.. math::
+
+	\hat{y} = q_1 t_1 + q_2 t_2
+
+For this model :math:`q_1 = 0.546` and :math:`q_2 = -0.262`, both on the centred and scaled taste scale.
+Asking for a particular taste sets that expression equal to a constant. Cheese 2's taste of 20.9 is
+:math:`(20.9 - 23.69) / 16.4 = -0.17` in scaled units, so the inversion is asking for every pair
+:math:`(t_1, t_2)` that satisfies:
+
+.. math::
+
+	0.546\, t_1 - 0.262\, t_2 = -0.17
+
+That is one linear equation in two unknowns, which is the whole reason a line appears. One equation
+cannot pin down two coordinates: it removes one degree of freedom and leaves the other free. Rearranged
+into the familiar form, the free coordinate traces out
+
+.. math::
+
+	t_2 = -\frac{q_1}{q_2} t_1 + \frac{-0.17}{q_2}
+	    = 2.08\, t_1 + 0.65
+
+so the line climbs 2.08 units of :math:`t_2` for every unit of :math:`t_1`. That is the diagonal in the
+score plot, and it comes from the ratio of the two :math:`y`-loadings alone, :math:`-q_1/q_2`. Their
+absolute sizes do not matter, only their ratio: doubling both would give the same line.
+
+There is a matching geometric statement. Take any two points on the line and subtract their equations.
+The constant cancels, leaving
+
+.. math::
+
+	q_1 \Delta t_1 + q_2 \Delta t_2 = 0
+	\qquad \text{or} \qquad
+	\mathbf{q}^T \Delta \mathbf{t} = 0
+
+Any step along the line is therefore perpendicular to the vector :math:`\mathbf{q} = (q_1, q_2)`. That
+vector has a meaning: since :math:`\hat{y} = \mathbf{q}^T \mathbf{t}`, it is the gradient of the
+prediction, the direction in the score plot along which the predicted taste changes fastest. Moving at
+right angles to a gradient is what keeps a quantity constant, so the null space is a contour line of the
+predicted taste drawn over the score plot. Every parallel line in the score plot is another contour, for
+another target taste, which is why the three lines in the figure do not converge.
+
+We can confirm both statements from the fitted model.
+
+.. code-block:: python
+
+	q = pls.y_loadings_.to_numpy().ravel()
+	print(q.round(3))                      # [ 0.546 -0.262]
+	print(round(-q[0] / q[1], 2))          # 2.08, the slope of the line
+	print(round(float(g @ q), 12))         # 0.0, the direction is perpendicular to q
+
+The direct-inversion solution fits the same picture. It is
+:math:`\boldsymbol{\tau}_\text{DI} = y_\text{des}\, \mathbf{q} / (\mathbf{q}^T\mathbf{q})`, which points
+along :math:`\mathbf{q}` itself, so it is the point where a perpendicular dropped from the origin meets
+the line. That is what makes it the solution of smallest score norm. Here it is
+:math:`(-0.253, 0.121)`, pointing opposite to :math:`\mathbf{q}` because the requested taste of 20.9
+sits below the training average of 23.7.
+
+Two further points are worth making. First, the perpendicularity is a statement about the score
+coordinates, so it looks like a right angle on the page only when both axes are drawn to the same scale.
+Second, the same reasoning is what the code performs in general. For one response,
+``null_space_basis`` comes from a singular value decomposition of the :math:`y`-loadings: the first left
+singular vector points along :math:`\mathbf{q}`, and the remaining :math:`A-1` span everything
+perpendicular to it. With two components that leaves a single perpendicular direction, a line; with three
+components it leaves a plane, and so on.
+
+Finally, it is worth asking what that direction means in the chemistry, rather than in the scores.
+Multiplying the direction by the |X|-loadings maps it back to the three measurements, and a step of
+:math:`+1` moves acetic acid by :math:`+0.57`, hydrogen sulfide by :math:`-0.54`, and lactic acid by only
+:math:`+0.06`, in the original units. Moving along the null space therefore trades acetic acid up against
+hydrogen sulfide down, leaving lactic acid nearly alone. Both of those measurements rise with taste in
+this data set, with correlations of 0.56 and 0.77, so raising one while lowering the other leaves the
+predicted taste where it was. That trade-off is what the diagonal line is recording.
+
 .. _LVM-PLS-orthogonal-space:
 
 The same space, reached a different way: O-PLS

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -268,6 +268,20 @@ right angles to a gradient is what keeps a quantity constant, so the null space 
 predicted taste drawn over the score plot. Every parallel line in the score plot is another contour, for
 another target taste, which is why the three lines in the figure do not converge.
 
+.. _LVM-PLS-null-space-geometry-figure:
+
+.. figure:: ../../figures/pls/pls-null-space-geometry.png
+	:alt: The gradient vector q with the null space and further contours drawn perpendicular to it
+	:width: 620px
+	:align: center
+
+	The same score plot, with both axes drawn to the same scale so that angles are true. The teal arrow
+	is the gradient :math:`\mathbf{q}`, the direction in which the predicted taste rises fastest. The
+	orange line is the null space for a taste of 20.9, at right angles to it, and the grey dotted lines
+	are the contours for tastes of 10, 30 and 40. The black square is the direct-inversion solution,
+	which sits where a perpendicular dropped from the origin meets the orange contour, and so is the
+	solution of smallest score norm.
+
 We can confirm both statements from the fitted model.
 
 .. code-block:: python
@@ -285,7 +299,9 @@ the line. That is what makes it the solution of smallest score norm. Here it is
 sits below the training average of 23.7.
 
 Two further points are worth making. First, the perpendicularity is a statement about the score
-coordinates, so it looks like a right angle on the page only when both axes are drawn to the same scale.
+coordinates, so it reads as a right angle on the page only when both axes are drawn to the same scale, as
+they are in the figure above but not in the earlier
+:ref:`score plot <LVM-PLS-null-space-figure>`, where the two scores have different spreads.
 Second, the same reasoning is what the code performs in general. For one response,
 ``null_space_basis`` comes from a singular value decomposition of the :math:`y`-loadings: the first left
 singular vector points along :math:`\mathbf{q}`, and the remaining :math:`A-1` span everything
@@ -311,6 +327,66 @@ two parts. One *predictive* component carries the variation that is related to |
 *Y-orthogonal* components carry systematic variation in |X| that has no bearing on |Y|. Filtering out the
 orthogonal part leaves a model with the same predictions as ordinary PLS, but with the response-relevant
 variation gathered into a single component.
+
+It is worth being concrete about how that split is built, because it explains everything that follows.
+O-PLS keeps the same two-dimensional plane the PLS model already found; what it changes is the pair of
+axes drawn within that plane. The first axis is chosen to point along the variation in the chemistry that
+tracks taste. For these cheeses that direction, the predictive weight, is
+
+.. math::
+
+	\mathbf{w}_\text{p} = (0.474,\ 0.657,\ 0.586)
+	\qquad \text{for (acetic, hydrogen sulfide, lactic)}
+
+All three entries are positive and of similar size, which is the raw-data picture restated: the three
+chemical measurements rise together, and each rises with taste. The second axis takes what is left of the
+plane once that predictive direction has been removed, giving the orthogonal weight
+
+.. math::
+
+	\mathbf{w}_\text{o} = (0.808,\ -0.590,\ 0.008)
+
+Read that as a recipe: raise acetic acid, lower hydrogen sulfide, and leave lactic acid essentially
+untouched. It is the same trade-off the null space described, arrived at without ever inverting anything.
+The defining property is that this second axis carries no taste information at all. Its score is
+uncorrelated with the response, exactly, while the predictive score is strongly correlated with it.
+
+.. code-block:: python
+
+	opls = OPLS(n_orthogonal_components=1).fit(X, Y)
+	y_centred = (Y - Y.mean()).to_numpy().ravel()
+
+	print(round(float(np.corrcoef(opls.orthogonal_scores_.to_numpy().ravel(), y_centred)[0, 1]), 12))
+	print(round(float(np.corrcoef(opls.predictive_scores_.to_numpy().ravel(), y_centred)[0, 1]), 4))
+	# -0.0
+	# 0.8198
+
+That is the whole difference between the two models, and it shows up in the :math:`y`-loadings. The PLS
+model spread the response across both of its components, :math:`\mathbf{q} = (0.546, -0.262)`, so
+predicting taste needed both scores. The O-PLS model puts all of it on the first component and none on
+the second:
+
+.. math::
+
+	\hat{y} = q_\text{p}\, t_\text{p} = 0.571\, t_\text{p}
+
+The orthogonal score does not appear. In the language of the previous section, the gradient of the
+prediction in O-PLS coordinates is :math:`(0.571, 0)`: it points exactly along the predictive axis. The
+contours of predicted taste are therefore perpendicular to that axis, which now means parallel to the
+orthogonal axis. The diagonal line of the PLS score plot becomes a line running along a coordinate axis.
+It is the same set of chemistries either way; only the axes used to describe it have moved.
+
+This is also why inverting an O-PLS model needs no linear algebra. Fixing the taste gives one equation
+with one unknown, since the orthogonal score is absent from it, so the predictive score follows by
+division:
+
+.. math::
+
+	t_\text{p} = \frac{y_\text{des}}{q_\text{p}} = \frac{-0.17}{0.571} = -0.298
+
+and the orthogonal score is left free, to be chosen on any grounds we like. The PLS inversion had to
+solve one equation in two unknowns and then describe the leftover freedom with a null-space basis. O-PLS
+separates that freedom in advance, during fitting, and hands it over as a coordinate axis.
 
 The subspace holding the orthogonal components is called the *orthogonal space*. By construction, moving
 an input along the orthogonal space changes |X| but not the predicted |Y|. That description should sound

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -124,11 +124,14 @@ Both rows sit well inside the SPE and :math:`T^2` limits, so neither is an extra
 predicted inputs have an SPE of exactly zero, because the inversion rebuilds the inputs from their
 scores: the result lies on the model plane by construction, leaving no residual.
 
+.. _LVM-PLS-input-space-deviation:
+
 The two rows are close, but "close" in the raw units is hard to read: a gap of 0.5 in hydrogen sulfide
 does not mean the same thing as a gap of 0.5 in lactic acid, because the three measurements are on
 different scales. Centring and scaling each column puts them on a common footing, where one unit is one
-standard deviation of that measurement. The *normalized deviation* is then the sum of the squared
-differences between the two rows, in those units.
+standard deviation of that measurement. The *input-space deviation* is then the sum of the squared
+differences between the two rows, in those units. It is a distance between two recipes, measured across
+the three inputs, and normalized so that every input counts on the same scale.
 
 .. code-block:: python
 
@@ -145,7 +148,7 @@ Writing the three terms out, with acetic acid first, then hydrogen sulfide, then
 .. math::
 
 	\begin{aligned}
-	\text{normalized deviation} &= \left(-0.67 - (-0.04)\right)^2 + \left(-0.46 - (-0.22)\right)^2
+	\text{input-space deviation} &= \left(-0.67 - (-0.04)\right)^2 + \left(-0.46 - (-0.22)\right)^2
 	  + \left(0.30 - (-0.15)\right)^2 \\
 	&= (-0.63)^2 + (-0.24)^2 + (0.45)^2 \\
 	&= 0.39 + 0.06 + 0.21 \\
@@ -259,7 +262,7 @@ the three, 0.06. Stepping out to either side moves the design away from the cent
 calibration data, to 1.63 and 2.44. The freedom along the null space is therefore free in terms of
 the predicted taste, but not in terms of how much support the data give the design.
 
-The last column is the normalized deviation of each row from the cheese we are designing toward,
+The last column is the input-space deviation of each row from the cheese we are designing toward,
 computed the same way as before: centre and scale each input, then sum the squared differences. The
 Actual row is 0.00 because it is the target. Reading down the column, the step 0 design is the
 closest of the three at 0.66, the -1 step is a little further at 0.82, and the +1 step is furthest
@@ -551,15 +554,27 @@ Reading the result: how far is the design from the data?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Inversion always returns a set of inputs, whatever taste we ask for, so we need a way to judge
-whether those inputs are reasonable. Hotelling's :math:`T^2` of the solution answers this: it
-measures how far
-the design sits from the centre of the calibration data, in the same units as the
+whether those inputs are reasonable. Hotelling's :math:`T^2` answers this: it measures how far a point
+sits from the centre of the calibration data, in the same units as the
 :ref:`score diagnostics <LVM-Hotellings-T2>` used elsewhere. Let's take a look with all four held-out
-cheeses.
+cheeses, repeating for each of them what we did for cheese 2.
 
-We can repeat for all four held-out cheeses what we did for cheese 2: invert toward its taste, then
-record how far the design sits from the data, how far the cheese itself sits from the data, and the
-normalized deviation between the two.
+Two different :math:`T^2` values appear once we do that, and they are worth keeping apart. Each
+held-out cheese was really made and really measured, so its three measurements can be projected onto
+the model to give scores, and a :math:`T^2` from those scores. Call that the :math:`T^2` of the cheese:
+it says how unusual that cheese is compared with the 26 cheeses the model was calibrated on. Inverting
+toward the same target taste produces a different set of three inputs, the recipe the model proposes,
+which has its own scores and its own :math:`T^2`. Call that the :math:`T^2` of the design: it says how
+far the proposed recipe sits from the centre of the calibration data. The two are computed from
+different points in the input space, so there is no reason for them to agree, and the table below shows
+that they often do not.
+
+A third quantity compares those two points with each other. It is the
+:ref:`input-space deviation <LVM-PLS-input-space-deviation>` defined earlier: centre and scale the
+three measurements, then sum the squared differences between the measured cheese and the proposed
+recipe. Note that it is not a comparison of the two :math:`T^2` values. The two :math:`T^2` values are
+distances in the score space, each measured from the centre of the calibration data; the input-space
+deviation is a distance in the input space, measured between the two recipes themselves.
 
 .. code-block:: python
 
@@ -572,22 +587,22 @@ normalized deviation between the two.
 	    p = scaler.transform(design.x_new.to_frame().T).iloc[0]
 	    rows.append({
 	        "Taste": target,
-	        "T2 design": design.hotellings_t2,
+	        "T2 design": design.hotellings_t2,          # the proposed recipe
 	        "T2 cheese": float(pls.diagnose(measured.to_frame().T).hotellings_t2.iloc[0]),
-	        "Deviation": float(((a - p) ** 2).sum()),
+	        "Input dev": float(((a - p) ** 2).sum()),   # between the two recipes
 	    })
 
 	print(pd.DataFrame(rows).round(2))
 
-.. list-table:: The four held-out cheeses: how far each design and each cheese sits from the calibration data, and the normalized deviation between them. The 99% limit on :math:`T^2` is 12.14.
+.. list-table:: The four held-out cheeses. Each row compares the recipe the inversion proposes for that cheese's taste against the cheese as it was actually measured. The two :math:`T^2` columns are distances from the centre of the calibration data, one for each of those two points; the last column is the distance between the two points. The 99% limit on :math:`T^2` is 12.14.
 	:header-rows: 1
-	:widths: 14 16 22 22 26
+	:widths: 12 14 22 22 30
 
 	*	- Cheese
 		- Taste
 		- :math:`T^2` of the design
-		- :math:`T^2` of the cheese
-		- Normalized deviation
+		- :math:`T^2` of the measured cheese
+		- Input-space deviation
 	*	- 1
 		- 12.3
 		- 1.07
@@ -609,22 +624,23 @@ normalized deviation between the two.
 		- 0.94
 		- 1.57
 
-Reading down the third column, the moderate tastes near the middle of the calibration range give designs
-with small :math:`T^2`, while the more extreme tastes push the design further from the data: asking for a
+Reading down the :math:`T^2` of the design, the moderate tastes near the middle of the calibration range
+give designs with small :math:`T^2`, while the more extreme tastes push the design further from the data:
+asking for a
 taste of 47.9 gives the largest value, 4.82. A large :math:`T^2` does not make a design wrong, but it
 flags that the model is extrapolating and that the predicted taste rests on less support from the data.
 All four are well inside the 99% limit of 12.14.
 
-The last column compares each design with the cheese that actually had that taste. Cheese 2 is the
-closest match, at 0.66, which is the case we worked through. Cheese 1 is the furthest, at 4.50, or
-:math:`\sqrt{4.50} = 2.1` standard deviations. The fourth column explains part of that: cheese 1 has the
-largest :math:`T^2` of the four cheeses, 4.08, so it is an unusual cheese to begin with, sitting well away
-from the centre of the calibration data while the design does not.
+The input-space deviation compares each design with the cheese that actually had that taste. Cheese 2 is
+the closest match, at 0.66, which is the case we worked through. Cheese 1 is the furthest, at 4.50, or
+:math:`\sqrt{4.50} = 2.1` standard deviations. The :math:`T^2` of the measured cheese explains part of
+that: cheese 1 has the largest :math:`T^2` of the four cheeses, 4.08, so it is an unusual cheese to begin
+with, sitting well away from the centre of the calibration data while the design does not.
 
-A large deviation is not a failure of the inversion. The model returns the solution of smallest score
-norm, whereas nature produced whichever inputs it produced, and the null space means both can carry
-the same predicted taste while sitting some distance apart. The deviation measures how far apart the two
-recipes are, not how wrong either of them is.
+A large input-space deviation is not a failure of the inversion. The model returns the solution of
+smallest score norm, whereas nature produced whichever inputs it produced, and the null space means both
+can carry the same predicted taste while sitting some distance apart. The input-space deviation measures
+how far apart the two recipes are, not how wrong either of them is.
 
 For a single response, then, PLS model inversion and O-PLS model inversion lead to the same set of
 designs. They differ in how they reach it: PLS inversion solves an underdetermined system and returns the

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -245,14 +245,15 @@ the null space does and does not change.
 		- 0.00
 		- 2.66
 
-Read across the three predicted rows and the inputs change substantially: acetic acid runs from 4.95
-to 6.09 while hydrogen sulfide falls from 6.10 to 5.02. Every one of them still reaches a taste of
-20.9, and every one has an SPE of zero, since all three are rebuilt from scores and so lie on the
-model plane. What does change is :math:`T^2`. The step 0 row is the direct-inversion solution, the
-one of smallest score norm, and it has the smallest :math:`T^2` of the three, 0.06. Stepping out to
-either side moves the design away from the centre of the calibration data, to 1.63 and 2.44. The
-freedom along the null space is therefore free in terms of the predicted taste, but not in terms of
-how much support the data give the design.
+Read down the three predicted rows and the inputs change substantially in order to keep the taste
+constant. Acetic acid increases from about 5 to 6, while that is compensated by hydrogen sulfide
+falling from about 6 to 5. Every one of the three still reaches a taste of 20.9, and every one has
+an SPE of zero, since all three are rebuilt from scores and so lie on the model plane. What does
+change is :math:`T^2`. The step 0 row is the direct-inversion solution, the one of smallest score
+norm, and it has the smallest :math:`T^2` of the three, 0.06. Stepping out to either side moves the
+design away from the centre of the calibration data, to 1.63 and 2.44. The freedom along the null
+space is therefore free in terms of the predicted taste, but not in terms of how much support the
+data give the design.
 
 The last column is the normalized deviation of each row from the cheese we are designing toward,
 computed the same way as before: centre and scale each input, then sum the squared differences. The

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -182,6 +182,71 @@ the predicted quality. As a check on the held-out cheese, its actual inputs (Ace
 Lactic 1.53) predict a taste of 20.7, close to its measured 20.9, and it lies near the null-space
 line just traced.
 
+Collecting the three points on the line, together with the cheese itself, shows what moving along
+the null space does and does not change.
+
+.. code-block:: python
+
+	designs = {
+	    "Actual": actual,
+	    "Predicted at step -1": pls.invert(20.9, null_space_coordinates=[-1.0]).x_new,
+	    "Predicted at step 0": result.x_new,
+	    "Predicted at step +1": pls.invert(20.9, null_space_coordinates=[+1.0]).x_new,
+	}
+	for label, inputs in designs.items():
+	    d = pls.diagnose(inputs.to_frame().T)
+	    print(f"{label:<22}{inputs.round(2).to_list()}  "
+	          f"T2 = {float(d.hotellings_t2.iloc[0]):.2f}, SPE = {float(d.spe.iloc[0]):.2f}")
+
+.. list-table:: Cheese 2 and three points along its null space, all reaching the same target taste.
+	:header-rows: 1
+	:widths: 24 14 12 12 12 12 12
+
+	*	- Row
+		- Target taste
+		- Acetic
+		- H2S
+		- Lactic
+		- :math:`T^2`
+		- SPE
+	*	- Actual
+		- 20.9
+		- 5.16
+		- 5.04
+		- 1.53
+		- 0.21
+		- 0.68
+	*	- Predicted at step -1
+		- 20.9
+		- 4.95
+		- 6.10
+		- 1.33
+		- 1.63
+		- 0.00
+	*	- Predicted at step 0
+		- 20.9
+		- 5.52
+		- 5.56
+		- 1.40
+		- 0.06
+		- 0.00
+	*	- Predicted at step +1
+		- 20.9
+		- 6.09
+		- 5.02
+		- 1.46
+		- 2.44
+		- 0.00
+
+Read across the three predicted rows and the inputs change substantially: acetic acid runs from 4.95
+to 6.09 while hydrogen sulfide falls from 6.10 to 5.02. Every one of them still reaches a taste of
+20.9, and every one has an SPE of zero, since all three are rebuilt from scores and so lie on the
+model plane. What does change is :math:`T^2`. The step 0 row is the direct-inversion solution, the
+one of smallest score norm, and it has the smallest :math:`T^2` of the three, 0.06. Stepping out to
+either side moves the design away from the centre of the calibration data, to 1.63 and 2.44. The
+freedom along the null space is therefore free in terms of the predicted taste, but not in terms of
+how much support the data give the design.
+
 A score plot shows the picture directly. The calibration cheeses are the points, the black square is the
 direct-inversion solution, and the orange line is the null space: the set of scores that all predict a
 taste of 20.9.

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -78,7 +78,7 @@ predicts will give that taste.
 	result = pls.invert(y_desired=20.9)
 
 	print(result.x_new.round(2).to_dict())
-	# {'Acetic': 5.52, 'H2S': 5.56, 'Lactic': 1.40}
+	# {'Acetic': 5.52, 'H2S': 5.56, 'Lactic': 1.4}
 	print(result.null_space_dimension)        # 1
 
 	# Compare the designed inputs with what cheese 2 actually was.
@@ -139,7 +139,7 @@ the three inputs, and normalized so that every input counts on the same scale.
 	a = scaler.transform(actual.to_frame().T).iloc[0]           # actual, in std deviations
 	p = scaler.transform(result.x_new.to_frame().T).iloc[0]     # predicted, in std deviations
 
-	print(a.round(2).to_list())                      # [-0.67, -0.46, 0.30]
+	print(a.round(2).to_list())                      # [-0.67, -0.46, 0.3]
 	print(p.round(2).to_list())                      # [-0.04, -0.22, -0.15]
 	print(round(float(((a - p) ** 2).sum()), 2))     # 0.66
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -48,7 +48,7 @@ and fit the model on the remaining twenty-six.
 	import numpy as np
 	import pandas as pd
 	import plotly.graph_objects as go
-	from process_improve.multivariate import PLS, OPLS
+	from process_improve.multivariate import PLS, OPLS, MCUVScaler
 
 	cheese = pd.read_csv("https://openmv.net/file/cheddar-cheese.csv")
 	x_columns = ["Acetic", "H2S", "Lactic"]
@@ -120,6 +120,38 @@ is a reasonable one, compare it with the cheese we held out. For this model the 
 Both rows sit well inside the two limits, so neither is an extrapolation. The predicted chemistry has an
 SPE of exactly zero, because the inversion rebuilds the inputs from their scores: the result lies on the
 model plane by construction, leaving no residual.
+
+The two rows are close, but "close" in the raw units is hard to read: a gap of 0.5 in hydrogen sulfide
+does not mean the same thing as a gap of 0.5 in lactic acid, because the three measurements are on
+different scales. Centring and scaling each column puts them on a common footing, where one unit is one
+standard deviation of that measurement. The *normalized deviation* is then the sum of the squared
+differences between the two rows, in those units.
+
+.. code-block:: python
+
+	scaler = MCUVScaler().fit(X)
+	a = scaler.transform(actual.to_frame().T).iloc[0]           # actual, in std deviations
+	p = scaler.transform(result.x_new.to_frame().T).iloc[0]     # predicted, in std deviations
+
+	print(a.round(2).to_list())                      # [-0.67, -0.46, 0.30]
+	print(p.round(2).to_list())                      # [-0.04, -0.22, -0.15]
+	print(round(float(((a - p) ** 2).sum()), 2))     # 0.66
+
+Writing the three terms out, with acetic acid first, then hydrogen sulfide, then lactic acid:
+
+.. math::
+
+	\begin{aligned}
+	\text{normalized deviation} &= \left(-0.67 - (-0.04)\right)^2 + \left(-0.46 - (-0.22)\right)^2
+	  + \left(0.30 - (-0.15)\right)^2 \\
+	&= (-0.63)^2 + (-0.24)^2 + (0.45)^2 \\
+	&= 0.39 + 0.06 + 0.21 \\
+	&= 0.66
+	\end{aligned}
+
+The square root of 0.66 is 0.81, so the cheese we held out sits about 0.8 standard deviations away from
+the chemistry the inversion proposed, counting all three measurements together. Acetic acid accounts for
+most of that gap.
 
 The null space is the reason ``null_space_dimension`` is not zero. A two-component model has two score
 directions, but a single taste value pins down only one of them. The other direction is free: we can move

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -6,8 +6,9 @@ Using a PLS model backwards: model inversion and the null space
 So far we have used a PLS model in the forward direction: given the inputs in |X|, predict the
 outputs in |Y|. Many design problems ask the reverse question. We fix the quality we want and
 solve for the inputs that would achieve it. Finding the inputs that give a chosen output is called
-*model inversion*, and it is the basis of latent-variable product and process design
-(Jaeckle and MacGregor, 2000).
+*model inversion*, and it is the basis of latent-variable product and process design (`Jaeckle and
+MacGregor, 2000
+<https://literature.learnche.org/item/180/industrial-applications-of-product-design-through-the-inversion-of-latent-variable-models>`_).
 
 We will use the same :ref:`cheddar-cheese data <LVM-cheddar-cheese-example>` as before: the taste of a
 cheese predicted from three chemical measurements, acetic acid, hydrogen sulfide, and lactic acid. The
@@ -255,6 +256,12 @@ Hotelling's :math:`T^2` limit: solutions beyond it are extrapolations, as
 exactly this, constraining the region by the 95% :math:`T^2` limit so it stays inside the space the data
 support.
 
+The idea is as old as the method. Jaeckle and MacGregor called the result a *window of process operating
+conditions*: they moved along the null space over a range that kept the conditions within those seen in
+the past, then applied engineering judgement to pick a point in that window, such as the most economical
+or most energy-efficient one. Bounding by :math:`T^2` is a way of making "within the range of past
+operating conditions" a single, testable number.
+
 Suppose a taste between 20 and 40 is acceptable.
 
 .. code-block:: python
@@ -282,11 +289,6 @@ still lying outside the band. Note also that the enclosing box reaches slightly 
 of acetic acid in the training cheeses (4.48 to 6.46). The :math:`T^2` limit bounds the joint distance
 from the centre of the model, not each measurement separately, so a corner of the region can sit a little
 outside the range of any one measurement.
-
-When a candidate lot falls outside the region, the natural follow-up is to ask which measurement put it
-there. That is what a :ref:`contribution plot <APPS_multivariate_monitoring_contribution>` answers, by
-breaking the :math:`T^2` value into the part each variable contributes (Miller, Swanson and Heckler,
-1998).
 
 Inversion is not the only route to a specification region. The inputs can also be mapped directly into a
 region without inverting a model, an approach known as direct mapping. Paris and co-workers (2021)
@@ -333,9 +335,10 @@ García-Carrión et al. (2025).
 
 .. rubric:: References
 
-* C. M. Jaeckle and J. F. MacGregor, "Industrial applications of product design through the inversion of
-  latent variable models", *Chemometrics and Intelligent Laboratory Systems*, 50 (2000): 199-210,
-  `doi:10.1016/S0169-7439(99)00058-1 <https://doi.org/10.1016/S0169-7439(99)00058-1>`_.
+* C. M. Jaeckle and J. F. MacGregor, "`Industrial applications of product design through the inversion of
+  latent variable models
+  <https://literature.learnche.org/item/180/industrial-applications-of-product-design-through-the-inversion-of-latent-variable-models>`_",
+  *Chemometrics and Intelligent Laboratory Systems*, **50** (2000): 199-210.
 
 * J. Trygg and S. Wold, "Orthogonal projections to latent structures (O-PLS)", *Journal of Chemometrics*,
   16 (2002): 119-128, `doi:10.1002/cem.695 <https://doi.org/10.1002/cem.695>`_.
@@ -344,10 +347,6 @@ García-Carrión et al. (2025).
   materials using projection to latent structure models: comparison between direct mapping and model
   inversion", *Frontiers in Analytical Science*, 1 (2021): 729732,
   `doi:10.3389/frans.2021.729732 <https://doi.org/10.3389/frans.2021.729732>`_.
-
-* P. Miller, R. E. Swanson, and C. E. Heckler, "`Contribution plots: a missing link in multivariate
-  quality control <https://literature.learnche.org/item/78/contribution-plots-a-missing-link-in-multivariate-quality-control>`_",
-  *Applied Mathematics and Computer Science*, **8** (1998): 775-792.
 
 * S. García-Carrión, F. Sartori, J. Borràs-Ferrís, P. Facco, M. Barolo, and A. Ferrer, "On the equivalence
   between null space and orthogonal space in latent variable regression modeling", *Journal of

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -247,13 +247,13 @@ the null space does and does not change.
 
 Read down the three predicted rows and the inputs change substantially in order to keep the taste
 constant. Acetic acid increases from about 5 to 6, while that is compensated by hydrogen sulfide
-falling from about 6 to 5. Every one of the three still reaches a taste of 20.9, and every one has
-an SPE of zero, since all three are rebuilt from scores and so lie on the model plane. What does
-change is :math:`T^2`. The step 0 row is the direct-inversion solution, the one of smallest score
-norm, and it has the smallest :math:`T^2` of the three, 0.06. Stepping out to either side moves the
-design away from the centre of the calibration data, to 1.63 and 2.44. The freedom along the null
-space is therefore free in terms of the predicted taste, but not in terms of how much support the
-data give the design.
+falling from 6.10 to 5.02, and lactic acid increases slightly, from 1.33 to 1.46. Every one of the
+three still reaches a taste of 20.9, and every one has an SPE of zero, since all three are rebuilt
+from scores and so lie on the model plane. What does change is :math:`T^2`. The step 0 row is the
+direct-inversion solution, the one of smallest score norm, and it has the smallest :math:`T^2` of
+the three, 0.06. Stepping out to either side moves the design away from the centre of the
+calibration data, to 1.63 and 2.44. The freedom along the null space is therefore free in terms of
+the predicted taste, but not in terms of how much support the data give the design.
 
 The last column is the normalized deviation of each row from the cheese we are designing toward,
 computed the same way as before: centre and scale each input, then sum the squared differences. The

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -371,7 +371,7 @@ the figure do not converge.
 	is the solution of smallest score norm. The two orange triangles are the -1 and +1 steps, the same
 	points marked in the score plot above, so the two figures can be read against each other.
 
-We can confirm both statements from the fitted model.
+We can confirm both the slope and the perpendicularity from the fitted model.
 
 .. code-block:: python
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -494,6 +494,50 @@ uncorrelated with the response, exactly, while the predictive score is strongly 
 	# -0.0
 	# 0.8198
 
+.. _LVM-PLS-opls-construction:
+
+That first correlation is exactly zero rather than merely small, and it is worth seeing why, because
+the orthogonality is built by construction rather than arrived at by fitting. O-PLS finds the two
+directions in three steps (Trygg and Wold, 2002).
+
+The predictive weight is read straight off the response,
+:math:`\mathbf{w}_\text{p} = \mathbf{X}^T \mathbf{y}` scaled to unit length. Each entry is the
+covariance between one input and taste. This direction is settled before anything else happens, and
+it is never revised.
+
+The orthogonal weight is then built to be perpendicular to it. Projecting the data onto
+:math:`\mathbf{w}_\text{p}` gives a score :math:`\mathbf{t}`, and regressing |X| back onto that score
+gives a loading :math:`\mathbf{p}`. The loading is not the same vector as the weight: it collects
+everything that varies together with :math:`\mathbf{t}`, including variation that has no bearing on
+taste. That difference is what O-PLS separates out, by subtracting from the loading its component
+along the predictive weight:
+
+.. math::
+
+	\mathbf{w}_\text{o} = \mathbf{p} - \left(\mathbf{w}_\text{p}^T \mathbf{p}\right) \mathbf{w}_\text{p}
+
+Finally the component this new weight defines is removed from |X|, and the previous step repeats for
+as many orthogonal components as were requested. The predictive component is computed last, on what
+is left.
+
+Nothing there searches for orthogonality. The subtraction removes the predictive part of the loading,
+so :math:`\mathbf{w}_\text{o}` is perpendicular to :math:`\mathbf{w}_\text{p}` as a matter of algebra.
+The zero correlation then follows in one line, because the predictive weight was defined from the
+response in the first place:
+
+.. math::
+
+	\mathbf{t}_\text{o}^T \mathbf{y} = \left(\mathbf{X} \mathbf{w}_\text{o}\right)^T \mathbf{y}
+	  = \mathbf{w}_\text{o}^T \left(\mathbf{X}^T \mathbf{y}\right)
+	  = \left\|\mathbf{X}^T \mathbf{y}\right\| \, \mathbf{w}_\text{o}^T \mathbf{w}_\text{p} = 0
+
+So perpendicular in the space of the inputs means uncorrelated with the response in the space of the
+observations. The argument survives the removal step as well: what is taken out of |X| is
+:math:`\mathbf{t}_\text{o} \mathbf{p}_\text{o}^T`, which changes :math:`\mathbf{X}^T\mathbf{y}` by
+:math:`\mathbf{p}_\text{o}\left(\mathbf{t}_\text{o}^T \mathbf{y}\right)`, and that is zero by the line
+just given. The quantity the predictive weight was built from is therefore untouched, so the same
+reasoning applies at every subsequent orthogonal component.
+
 That is the whole difference between the two models, and it shows up in the :math:`y`-loadings. The PLS
 model spread the response across both of its components, :math:`\mathbf{q} = (0.546, -0.262)`, so
 predicting taste needed both scores. The O-PLS model puts all of it on the first component and none on


### PR DESCRIPTION
Follow-up to #249 (merged), on the PLS model-inversion page. The page now runs from
"what does inversion return" through to "why the two spaces coincide", with every figure
reproducible and every quoted number verified.

Net diff against the merge base is three files: the page, `CITATION.cff`, and a blog draft.

## The page

Sections, in order:

1. Using a PLS model backwards (intro, plus the raw cheddar-cheese scatterplot matrix)
2. Why inversion needs more than the predictive number of components
3. The null space: many recipes, one target
4. Where the null-space line comes from
5. The same space, reached a different way: O-PLS
6. Reading the result: how far is the design from the data?
7. Turning the inversion around: a specification region
8. More than one response

### What changed in this round

**The two Hotelling's T² values are now distinguished.** The four-cheese table put two
different T² values side by side under terse headers without saying that one comes from
projecting the measured cheese onto the model and the other from the recipe the inversion
proposes. They are computed at two different points in the input space, so they need not
agree, and the table bears that out: cheese 1 is an unusual cheese (T² 4.08) with an
unremarkable design (1.07), while cheese 3 is a typical cheese (0.02) whose design sits
further out (1.93).

**"Normalized deviation" is renamed to "input-space deviation"** throughout, because the
old name read as though it compared those two T² values. It does not: T² is a score-space
distance from the centre of the data, the deviation is an input-space distance between two
recipes. The definition is now labelled so the later use links back to it.

**The O-PLS decomposition is written out** rather than only described, since the prose left
it unclear whether the predictive and orthogonal parts are separate blocks of data. They are
not: one X matrix, two additive pieces plus a residual, with only the predictive piece
appearing in the equation for y. For the cheese model the split is 68.7% predictive, 18.3%
orthogonal, 13.0% residual, and those are exactly additive because the score sets are
mutually orthogonal.

**How O-PLS constructs its two directions** is now explained, which the page previously
asserted without support. The predictive weight is `X'y` scaled to unit length and never
revised; the orthogonal weight is built by subtracting from the loading its component along
the predictive weight. The exact zero correlation then follows in one line, and because the
removal step changes `X'y` by `p_o(t_o'y)`, which is zero, the argument carries to every
further orthogonal component.

**Smaller edits.** The O-PLS weights now name the attributes they are read from
(`predictive_weights_`, `orthogonal_weights_`). The acetic-up / hydrogen-sulfide-down
trade-off is cross-linked in both directions between the null-space step table and the
O-PLS axis. A sentence carrying three uses of "it" with a distant antecedent now names the
shared freedom. The step rows say which inputs compensate, with exact values.

## Verification

The chapter's thirteen code blocks were extracted and run end to end as a single script
against the vendored CSVs. Every quoted number reproduces: R² 0.672, the inverted recipe,
the step table, `q = (0.546, -0.262)` and slope 2.08, the O-PLS weights and `q_p = 0.571`,
both spaces as `(0.948, -0.238, 0.211)` with cosine 1.0, the four-cheese table, the
specification region box, and the solvents multi-response inversion.

That pass also turned up two comments quoting output with a trailing zero Python does not
print (`1.40` and `0.30`, which print as `1.4` and `0.3`). Fixed. The prose tables keep two
decimals, which is a separate convention and is unchanged.

- `make text`: exit 0, zero warnings.
- `make html`: exit 0, zero warnings, `grep -r goatcounter _build/html/contents` returns zero.
- Both figure PNGs regenerate byte-identical from their committed generators, so the figures
  repo needs no companion PR this time.
- `CITATION.cff` `version` and `date-released` set to 2026-07-26.

## One thing to action before merge

`docs/blog/orthogonal-space-and-model-inversion.md` is a **working draft, not part of the
book**, added alongside the existing `docs/blog/judging-and-comparing-designs.md`. It is not
referenced by the Sphinx build. **Delete it once the post is published**; the note is
repeated at the top of the file itself. Say the word if you would rather it not land in the
repo at all and I will drop the commit.

## Related

- Code: kgdunn/process-improve#470 (`PLS.invert`, `OPLS`).
- Figure: kgdunn/figures#71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsTypY4FcRbrXRxorb9raz