### PR TITLE
PLS inversion: how the null space is derived, how O-PLS reaches it, and how well it is determined

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.07.26"
-date-released: 2026-07-26
+version: "2026.07.27"
+date-released: 2026-07-27
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.07.27"
-date-released: 2026-07-27
+version: "2026.07.28"
+date-released: 2026-07-28
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -98,6 +98,7 @@ toward a middling one.
 	import numpy as np
 	import pandas as pd
 	import plotly.graph_objects as go
+	from plotly.subplots import make_subplots
 	from process_improve.multivariate import PLS, OPLS, MCUVScaler
 
 	cheese = pd.read_csv("https://openmv.net/file/cheddar-cheese.csv")
@@ -682,27 +683,7 @@ mixed into the first component, it removes that direction from |X| first, and co
 component afterwards, on what is left.
 
 The fitted model reports the two directions as ``opls.predictive_weights_`` and
-``opls.orthogonal_weights_``, the second carrying one column per orthogonal component asked for. Here
-that is one column, and the two directions are
-
-.. math::
-
-	\mathbf{w}_\text{p} = (0.474,\ 0.657,\ 0.586)
-	\qquad
-	\mathbf{w}_\text{o} = (0.808,\ -0.590,\ 0.008)
-
-for (acetic, hydrogen sulfide, lactic). The predictive weight is the first PLS weight, unchanged, and
-the orthogonal weight is the difference just computed. All three entries of
-:math:`\mathbf{w}_\text{p}` are positive and of similar size, which is the raw-data picture restated:
-the three inputs rise together, and each rises with taste.
-
-Read :math:`\mathbf{w}_\text{o}` as a recipe: raise acetic acid, lower hydrogen sulfide, and leave
-lactic acid essentially untouched. It is the same trade-off the null space described, arrived at
-without ever inverting anything, and the same one the
-:ref:`table of null-space steps <LVM-PLS-null-space-steps-table>` set out in the original units.
-The defining property of this second direction is that it carries no taste information at all. Its
-score is uncorrelated with the response, exactly, while the predictive score is strongly correlated
-with it.
+``opls.orthogonal_weights_``, the second carrying one column per orthogonal component asked for.
 
 .. code-block:: python
 
@@ -710,43 +691,66 @@ with it.
 
 	print(opls.predictive_weights_.round(3).to_numpy())           # [0.474 0.657 0.586]
 	print(opls.orthogonal_weights_.round(3).to_numpy().ravel())   # [ 0.808 -0.59   0.008]
-
-	print(opls.predictive_loadings_.round(3).to_numpy())           # [0.472 0.654 0.591]
-	print(opls.orthogonal_loadings_.round(3).to_numpy().ravel())   # [ 1.044 -0.263  0.232]
+	print(opls.predictive_loadings_.round(3).to_numpy())          # [0.472 0.654 0.591]
 
 	print(pls.x_weights_.to_numpy().round(3))    # the PLS weights, side by side
 	# [[ 0.474  0.808]
 	#  [ 0.657 -0.59 ]
 	#  [ 0.586  0.008]]
 
+The predictive weight :math:`\mathbf{w}_\text{p} = (0.474, 0.657, 0.586)` has three positive entries of
+similar size, which restates the raw-data picture: the three inputs rise together, and each rises with
+taste. The orthogonal weight :math:`\mathbf{w}_\text{o} = (0.808, -0.590, 0.008)` reads as a recipe:
+raise acetic acid, lower hydrogen sulfide, leave lactic acid alone. That is the same trade-off the
+:ref:`table of null-space steps <LVM-PLS-null-space-steps-table>` set out in the original units, arrived
+at here without inverting anything.
+
+The two methods are less different than they appear. The columns of ``pls.x_weights_`` *are* the two
+O-PLS weights, in the same order and to the same digits, and both models return regression coefficients
+agreeing to :math:`1.4 \times 10^{-13}`, so they predict a new cheese identically. What differs is the
+order the directions are peeled off |X|: PLS removes the predictive component first, O-PLS the
+orthogonal one, computing the predictive score on what is left. That score therefore absorbs all of the
+taste information.
+
+The consequence shows up in the scores, not the weights.
+
+.. code-block:: python
+
 	y_centred = (Y - Y.mean()).to_numpy().ravel()
+	t_p = opls.predictive_scores_.to_numpy().ravel()
+	t_o = opls.orthogonal_scores_.to_numpy().ravel()
 
-	print(round(float(np.corrcoef(opls.orthogonal_scores_.to_numpy().ravel(), y_centred)[0, 1]), 12))
-	print(round(float(np.corrcoef(opls.predictive_scores_.to_numpy().ravel(), y_centred)[0, 1]), 4))
-	# -0.0
-	# 0.8198
+	for name, score in [("PLS 1", scores.iloc[:, 0]), ("PLS 2", scores.iloc[:, 1]),
+	                    ("O-PLS predictive", t_p), ("O-PLS orthogonal", t_o)]:
+	    print(name, round(float(np.corrcoef(score, y_centred)[0, 1]), 3))
+	# PLS 1 0.802
+	# PLS 2 -0.172
+	# O-PLS predictive 0.82
+	# O-PLS orthogonal -0.0
 
-Those two weight vectors are worth comparing with the PLS model, since the two methods are easy to
-imagine as more different than they are. The two columns of ``pls.x_weights_`` are the two O-PLS
-weights, in the same order: the predictive weight is the first PLS weight, and the orthogonal weight is
-the second. They are not merely similar directions, they are the same numbers. The two models also return the same regression coefficients, agreeing here to
-:math:`1.4 \times 10^{-13}`, so they would predict a new cheese identically.
+	print(round(float(np.corrcoef(t_p, scores.iloc[:, 0])[0, 1]), 3))   # 0.978
 
-What differs is the order in which the two directions are peeled off |X|. PLS removes the predictive
-component first and the orthogonal one second. O-PLS reverses that: it removes the orthogonal component
-first, then computes the predictive score on what is left. Because the orthogonal variation has already
-gone by the time the predictive score is formed, that score absorbs all of the taste information.
+.. _LVM-PLS-score-correlation-table:
 
-The consequence is visible in the scores rather than in the weights. The two predictive scores are
-close but not identical, correlating at 0.978. More to the point, the PLS second score still carries a
-little taste information, correlating with taste at :math:`-0.172`, while the O-PLS orthogonal score
-correlates with it at exactly zero. The PLS first score correlates with taste at 0.802, and the O-PLS
-predictive score at 0.820: the taste information that PLS left on its second component has been
-gathered onto the first.
+.. list-table:: How each score correlates with taste. The two predictive scores are close, correlating
+	with each other at 0.978, but only O-PLS drives the second correlation to zero.
+	:header-rows: 1
+	:widths: 40 30
 
-Written out, what O-PLS ends up with is a single |X| matrix split into a predictive piece, an
-orthogonal piece and a residual, the three adding back up to |X|. There is one |X| matrix here, not
-two blocks of data sitting side by side:
+	*	- Score
+		- Correlation with taste
+	*	- PLS, first component
+		- 0.802
+	*	- PLS, second component
+		- -0.172
+	*	- O-PLS, predictive
+		- 0.820
+	*	- O-PLS, orthogonal
+		- 0.000
+
+The taste information PLS left on its second component has been gathered onto the first. What O-PLS ends
+up with is a single |X| matrix split three ways, the pieces adding back up to |X|. There is one |X| here,
+not two blocks of data side by side:
 
 .. math::
 
@@ -757,46 +761,29 @@ two blocks of data sitting side by side:
 	\mathbf{y} &= q_\text{p}\, \mathbf{t}_\text{p} + \mathbf{f}
 	\end{aligned}
 
-The vector :math:`\mathbf{t}_\text{p}` is the single predictive score, one value per observation, and
-:math:`\mathbf{p}_\text{p}` is its loading, one value per input. :math:`\mathbf{T}_\text{o}` and
-:math:`\mathbf{P}_\text{o}` are the matching orthogonal scores and loadings, carrying one column for
-each orthogonal component asked for, while :math:`\mathbf{E}` and :math:`\mathbf{f}` hold what no
-component explains. For these cheeses, in the scaled units the model works in, the predictive piece
-carries 68.7% of the sum of squares in |X|, the orthogonal piece 18.3%, and the residual 13.0%.
+Here :math:`\mathbf{T}_\text{o}` and :math:`\mathbf{P}_\text{o}` carry one column per orthogonal
+component, and :math:`\mathbf{E}` and :math:`\mathbf{f}` hold what no component explains. In the scaled
+units the model works in, the predictive piece carries 68.7% of the sum of squares in |X|, the
+orthogonal piece 18.3%, and the residual 13.0%. Those percentages describe |X| alone. The first is not
+the share of the input variation that is about taste: most of it is the joint spread of three correlated
+measurements, which would be there whether or not taste had been recorded. How much of taste the model
+accounts for is the separate :math:`R^2` of 0.672.
 
-Those three percentages describe |X| alone. It would be a misreading to take the first as the share of
-the input variation that is about taste. The predictive component is the one that carries all of the
-taste information, but most of what it explains in |X| is simply the joint spread of three correlated
-measurements, which would be there whether or not taste had ever been recorded. How much of taste the
-model accounts for is a separate number, the :math:`R^2` of 0.672 quoted earlier.
-
-The predictive loading repays a second look, because it closes the loop on where this section started.
-In the PLS model the first weight and its loading sat 5.49 degrees apart, and that gap was the whole
-starting point. In the O-PLS model the corresponding pair,
+The predictive loading closes the loop. In the PLS model the first weight and its loading sat 5.49
+degrees apart, and that gap was the starting point. The O-PLS pair,
 :math:`\mathbf{w}_\text{p} = (0.474, 0.657, 0.586)` and
-:math:`\mathbf{p}_\text{p} = (0.472, 0.654, 0.591)`, sit 0.31 degrees apart. Once the orthogonal
-variation has been taken out of |X| there is almost nothing left for the loading to drift towards, so
-the direction we look along and the direction we find have very nearly converged. That is the
+:math:`\mathbf{p}_\text{p} = (0.472, 0.654, 0.591)`, sit 0.31 degrees apart: with the orthogonal
+variation already out of |X|, there is almost nothing left for the loading to drift towards. That is the
 interpretability O-PLS was built to deliver.
-
-The equation for |Y|, the second of the two lines just given, is where O-PLS parts company with PLS.
-Only :math:`\mathbf{t}_\text{p}` appears in it: the orthogonal scores :math:`\mathbf{T}_\text{o}` are
-absent, so movement in the orthogonal piece cannot change the predicted taste, however large that
-piece is. Filtering out the orthogonal part leaves a model with the same predictions as ordinary PLS,
-but with the response-relevant variation gathered into a single component.
 
 .. _LVM-PLS-opls-construction:
 
-That first correlation is exactly zero rather than merely small, and it is worth seeing why, because
-the orthogonality holds by algebra rather than by fitting. One more fact about the construction is
-needed. The predictive weight is read straight off the response,
-:math:`\mathbf{w}_\text{p} = \mathbf{X}^T \mathbf{y}` scaled to unit length, so each entry is the
-covariance between one input and taste (Trygg and Wold, 2002). That direction is settled before
-anything else happens, and it is never revised.
-
-The subtraction that produced :math:`\mathbf{w}_\text{o}` already guarantees it is perpendicular to
-:math:`\mathbf{w}_\text{p}`. The zero correlation then follows in one line, because the predictive
-weight was defined from the response in the first place:
+The zero in the table is exact rather than merely small, and it holds by algebra rather than by fitting.
+The predictive weight is read straight off the response, :math:`\mathbf{w}_\text{p} = \mathbf{X}^T
+\mathbf{y}` scaled to unit length, so each entry is the covariance between one input and taste (Trygg
+and Wold, 2002); that direction is settled first and never revised. The subtraction that produced
+:math:`\mathbf{w}_\text{o}` already makes it perpendicular to :math:`\mathbf{w}_\text{p}`, and the zero
+correlation then follows in one line:
 
 .. math::
 
@@ -804,71 +791,64 @@ weight was defined from the response in the first place:
 	  = \mathbf{w}_\text{o}^T \left(\mathbf{X}^T \mathbf{y}\right)
 	  = \left\|\mathbf{X}^T \mathbf{y}\right\| \, \mathbf{w}_\text{o}^T \mathbf{w}_\text{p} = 0
 
-So perpendicular in the space of the inputs means uncorrelated with the response in the space of the
-observations. The argument survives the removal step as well: what is taken out of |X| is
-:math:`\mathbf{t}_\text{o} \mathbf{p}_\text{o}^T`, which changes :math:`\mathbf{X}^T\mathbf{y}` by
-:math:`\mathbf{p}_\text{o}\left(\mathbf{t}_\text{o}^T \mathbf{y}\right)`, and that is zero by the line
-just given. The quantity the predictive weight was built from is therefore untouched, so the same
-reasoning applies at every subsequent orthogonal component. The plain subtraction carries over too:
-the score at each round is formed as :math:`\mathbf{X}\mathbf{w}_\text{p}` on whatever is left of
-|X|, so :math:`\mathbf{w}_\text{p}^T \mathbf{p} = 1` holds every time, and the orthogonal weight is
-always the amount by which that round's loading misses :math:`\mathbf{w}_\text{p}`.
+Perpendicular in the space of the inputs therefore means uncorrelated with the response in the space of
+the observations. The argument survives the removal step: what is taken out of |X| changes
+:math:`\mathbf{X}^T\mathbf{y}` by :math:`\mathbf{p}_\text{o}(\mathbf{t}_\text{o}^T \mathbf{y})`, which
+the line above makes zero, so the same reasoning applies at every further orthogonal component.
 
-That is the whole difference between the two models, and it shows up in the :math:`y`-loadings. The PLS
-model spread the response across both of its components, :math:`\mathbf{q} = (0.546, -0.262)`, so
-predicting taste needed both scores. The O-PLS model puts all of it on the first component and none on
-the second:
+That difference between the two models is visible in the :math:`y`-loadings. PLS spread the response
+across both components, :math:`\mathbf{q} = (0.546, -0.262)`, so predicting taste needed both scores.
+O-PLS puts all of it on the first and none on the second, :math:`\hat{y} = 0.571\, t_\text{p}`, so the
+gradient of the prediction points exactly along the predictive axis. Plotting the same cheeses in each
+set of coordinates shows what that does to the geometry.
 
-.. math::
+.. code-block:: python
 
-	\hat{y} = q_\text{p}\, t_\text{p} = 0.571\, t_\text{p}
+	opls_result = opls.invert(y_desired=20.9)
 
-The orthogonal score does not appear. In the language of the previous section, the gradient of the
-prediction in O-PLS coordinates is :math:`(0.571, 0)`: it points exactly along the predictive axis. The
-contours of predicted taste are therefore perpendicular to that axis, which now means parallel to the
-orthogonal axis. The diagonal line of the PLS score plot becomes a line running along a coordinate axis.
-The same combinations of inputs are described either way; only the axes describing them have moved.
+	fig = make_subplots(rows=1, cols=2, subplot_titles=(
+	    "PLS: response spread over both components",
+	    "O-PLS: response all on one component"))
+	fig.add_scatter(x=scores.iloc[:, 0], y=scores.iloc[:, 1], mode="markers", row=1, col=1)
+	fig.add_scatter(x=line[:, 0], y=line[:, 1], mode="lines", row=1, col=1,
+	                line={"color": "orange"})
+	fig.add_scatter(x=t_p, y=t_o, mode="markers", row=1, col=2)
+	fig.add_vline(x=opls_result.predictive_score, line={"color": "orange"}, row=1, col=2)
+	fig.update_yaxes(scaleanchor="x", scaleratio=1)     # equal axes, so angles are true
+	fig.show()
 
-This is also why inverting an O-PLS model needs no linear algebra. Fixing the taste gives one equation
-with one unknown, since the orthogonal score is absent from it, so the predictive score follows by
-division:
+.. _LVM-PLS-opls-rotation-figure:
+
+.. figure:: ../../figures/pls/pls-opls-rotation.png
+	:alt: The same set of solutions drawn in PLS score coordinates and in O-PLS score coordinates
+	:width: 700px
+	:align: center
+
+	The same 26 cheeses and the same set of designs reaching a taste of 20.9, drawn in each model's
+	coordinates. Left: PLS spreads the response over both components, the gradient :math:`\mathbf{q}`
+	points diagonally, and the solutions form a diagonal line, so inversion solves one equation in two
+	unknowns. Right: O-PLS puts the whole response on the predictive component, so the gradient points
+	along that axis and the same solutions become a line at a fixed predictive score. Only the axes have
+	moved; the set of designs described is identical.
+
+Fixing the taste in O-PLS coordinates therefore leaves one equation with one unknown, since the
+orthogonal score does not appear in it, and the predictive score follows by division:
 
 .. math::
 
 	t_\text{p} = \frac{y_\text{des}}{q_\text{p}} = \frac{-0.17}{0.571} = -0.298
 
-and the orthogonal score is left free, to be chosen on any grounds we like. The PLS inversion had to
-solve one equation in two unknowns and then describe the leftover freedom with a null-space basis. O-PLS
-separates that freedom in advance, during fitting, and hands it over as a coordinate axis.
-
-The subspace holding the orthogonal components is called the *orthogonal space*. By construction, moving
-an input along the orthogonal space changes |X| but not the predicted |Y|. That description should sound
-familiar: it is the same property that defines the null space of the inverted PLS model. García-Carrión
-and co-authors (2025) proved that, for a single response, the two subspaces are the same linear space.
-The null space that arises when a PLS model is inverted and the orthogonal space that O-PLS isolates while
-fitting are one and the same. The reason is short: both are exactly the set of score directions the model
-maps to no change in the response.
-
-The ``process_improve`` package fits O-PLS with the same total number of components, here one predictive
-and one orthogonal, and inverts it. Because O-PLS has already separated the single predictive direction,
-its inversion is one division rather than the solution of an underdetermined system.
+The orthogonal score is left free, to be chosen on any grounds we like. The subspace holding the
+orthogonal components is called the *orthogonal space*, and by construction, moving along it changes |X|
+but not the predicted |Y|. That is the same property that defines the null space of the inverted PLS
+model. García-Carrión and co-authors (2025) proved that, for a single response, the two subspaces are
+the same linear space: both are exactly the set of score directions the model maps to no change in the
+response.
 
 .. code-block:: python
-
-	opls = OPLS(n_orthogonal_components=1).fit(X, Y)
-	opls_result = opls.invert(y_desired=20.9)
 
 	print(opls_result.x_new.round(2).to_list())   # [5.46, 5.62, 1.39]
 	print(round(opls_result.y_hat, 2))            # 20.9
-
-The O-PLS design, (Acetic 5.46, H2S 5.62, Lactic 1.39), is a different set of inputs from the PLS
-direct-inversion design, but it lies on the same null-space line and gives the same predicted taste. The
-two methods return different representative points: PLS reports the point of smallest score norm, while
-O-PLS reports the point whose orthogonal score is zero. The set of solutions, the line itself, is
-identical. We can confirm the two subspaces coincide by reconstructing each basis into the input space and
-comparing their directions.
-
-.. code-block:: python
 
 	ns_input = result.null_space_basis.to_numpy().T @ pls.x_loadings_.to_numpy().T
 	os_input = opls_result.orthogonal_space_basis.to_numpy().T
@@ -881,16 +861,15 @@ comparing their directions.
 	)
 	print(round(cosine, 6))    # 1.0
 
-Written as unit vectors in the inputs, both come out as
-:math:`(0.948,\ -0.238,\ 0.211)`, the same numbers to three decimals, and the cosine between them is 1.0.
-Two methods, developed for different purposes and computed by different algorithms, describe the same
-line: raise acetic acid, lower hydrogen sulfide, adjust lactic acid slightly, and the predicted taste
-does not move. This is what the green circles in the :ref:`score plot <LVM-PLS-null-space-figure>` show:
-they are the orthogonal space projected into the PLS score plot, and they lie on the orange null-space
-line. The two approaches differ in bookkeeping rather than in what they find. Both describe the same
-freedom: the directions the inputs can move in without changing the predicted taste. PLS solves for that
-freedom after the fact and hands it back as a null-space basis; O-PLS sets the same freedom aside during
-fitting and hands it back as a coordinate axis.
+The O-PLS design, (Acetic 5.46, H2S 5.62, Lactic 1.39), differs from the PLS direct-inversion design,
+but lies on the same line and gives the same predicted taste. The two methods simply report different
+representative points on it: PLS the point of smallest score norm, O-PLS the point whose orthogonal
+score is zero. Written as unit vectors in the inputs both bases come out as
+:math:`(0.948,\ -0.238,\ 0.211)`, with a cosine of 1.0 between them. This is what the green circles in
+the :ref:`score plot <LVM-PLS-null-space-figure>` show: the orthogonal space projected into the PLS
+score plot, lying on the orange null-space line. The two approaches differ in bookkeeping rather than in
+what they find. PLS solves for the freedom after the fact and hands it back as a null-space basis;
+O-PLS sets it aside during fitting and hands it back as a coordinate axis.
 
 .. _LVM-PLS-inversion-in-practice:
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -96,8 +96,9 @@ The prediction at the designed inputs is exactly 20.9, by construction. To judge
 is a reasonable one, compare it with the cheese we held out. For this model the 99% limits are
 :math:`T^2 = 12.14` and :math:`\text{SPE} = 1.60`. These are the limits for a *new* observation rather
 than for one of the 26 used to fit the model, which is the right choice here: a proposed design is
-being judged against the model, not summarised by it. The distinction is small at this sample size,
-moving the :math:`T^2` limit from 11.69 to 12.14, and it grows smaller as :math:`N` grows.
+being judged against the model, not summarised by it. Limits for the observations that built the model
+are lower, since each of those helped set the centre and spread it is then measured against, and at a
+sample size of 26 that difference is not negligible.
 
 .. list-table:: Cheese 2: its measured inputs, and the inputs the inversion returns for taste 20.9.
 	:header-rows: 1

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -385,14 +385,17 @@ the figure do not converge.
 	:width: 620px
 	:align: center
 
-	The same score plot, with the areas again proportional to taste and both axes drawn to the same
-	scale so that angles are true. The maroon
-	arrow is the gradient :math:`\mathbf{q}`, the direction in which the predicted taste rises fastest.
-	The orange line is the null space for a taste of 20.9, at right angles to it, and the grey dotted
-	lines are the contours for tastes of 10, 30 and 40. The orange square is the direct-inversion
-	solution, which sits where a perpendicular dropped from the origin meets the orange contour, and so
-	is the solution of smallest score norm. The two orange triangles are the -1 and +1 steps, the same
-	points marked in the score plot above, so the two figures can be read against each other.
+	Left: the same score plot, with the areas again proportional to taste and both axes drawn to the
+	same scale so that angles are true. The maroon arrow is the gradient :math:`\mathbf{q}`, the
+	direction in which the predicted taste rises fastest. The orange line is the null space for a taste
+	of 20.9, at right angles to it, and the grey dotted lines are the contours for tastes of 10, 30 and
+	40. The orange square is the direct-inversion solution and the two orange triangles are the -1 and
+	+1 steps, the same points marked in the score plot above, so the two figures can be read against
+	each other.
+
+	Right: the boxed region enlarged, at the scale the next argument needs. The three arrows form a
+	right triangle, from the origin to the direct-inversion solution, from there along the contour to
+	the +1 step, and back to the origin.
 
 We can confirm both the slope and the perpendicularity from the fitted model.
 
@@ -521,7 +524,7 @@ Refitting the model on bootstrap resamples of the calibration set answers that d
 	reference = np.array([0.948, -0.238, 0.211])         # the direction reported below
 	reference = reference / np.linalg.norm(reference)
 
-	q2, slopes, angles, designs = [], [], [], []
+	q2, slopes, angles, designs, boot_lines = [], [], [], [], []
 	for _ in range(2000):
 	    sample = train.iloc[rng.integers(0, len(train), len(train))]
 	    boot = PLS(n_components=2).fit(sample[x_columns], sample[["Taste"]])
@@ -531,6 +534,8 @@ Refitting the model on bootstrap resamples of the calibration set answers that d
 
 	    result_b = boot.invert(20.9)
 	    designs.append(result_b.x_new.to_numpy())
+	    boot_lines.append((result_b.scores.to_numpy(),
+	                       result_b.null_space_basis.to_numpy().ravel()))
 	    d = result_b.null_space_basis.to_numpy().ravel() @ boot.x_loadings_.to_numpy().T
 	    d = d / np.linalg.norm(d)
 	    # A direction and its negative describe the same line, so compare without sign.
@@ -557,6 +562,37 @@ acetic acid, 4.97 to 6.26 for hydrogen sulfide, and 1.30 to 1.49 for lactic acid
 the spread of the calibration cheeses. The reason for the difference is worth seeing: the solution
 depends mostly on :math:`q_1`, which is estimated well, while the null-space direction depends on the
 ratio of :math:`q_1` to :math:`q_2`.
+
+Drawing every one of those refits says the same thing without any percentiles. Each is a line, so
+plotting all 2000 of them faintly enough to overlap turns the spread into a density.
+
+.. code-block:: python
+
+	fig = go.Figure()
+	for tau_b, g_b in boot_lines:                      # one faint line per refit
+	    segment = np.array([tau_b + s * g_b for s in (-9, 9)])
+	    fig.add_scatter(x=segment[:, 0], y=segment[:, 1], mode="lines", showlegend=False,
+	                    line={"color": "rgba(230, 130, 10, 0.03)"})
+	fig.add_scatter(x=scores.iloc[:, 0], y=scores.iloc[:, 1], mode="markers",
+	                name="calibration cheeses")
+	fig.update_layout(xaxis_title="t_1", yaxis_title="t_2")
+	fig.show()
+
+.. _LVM-PLS-null-space-bootstrap-figure:
+
+.. figure:: ../../figures/pls/pls-null-space-bootstrap.png
+	:alt: A fan of bootstrap null-space lines, and a histogram of their angles
+	:width: 700px
+	:align: center
+
+	Left: one faint line for each of 2000 refits, each the null space that refit would have returned.
+	The fan pinches near the direct-inversion solution and spreads from there. Right: the same spread
+	measured as an angle from the direction the full calibration set gives, compared without sign since
+	a direction and its negative describe the same line. The shaded band holds the 15% of refits that
+	land more than 45 degrees away.
+
+That pinch is the point-and-direction asymmetry in one picture. The refits nearly agree on where the
+solution sits, and disagree widely on which way the line runs through it.
 
 So the two statements this section makes are not equally firm. That a set of inputs reaching a target
 taste exists, and roughly where it sits, is supported by these data. Which direction one may then walk

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -775,11 +775,20 @@ is one |X| here, not two blocks of data side by side:
 	\mathbf{X} &= \underbrace{\mathbf{t}_\text{p} \mathbf{p}_\text{p}^T}_{\text{predictive}}
 	  \,+\, \underbrace{\mathbf{T}_\text{o} \mathbf{P}_\text{o}^T}_{Y\text{-orthogonal}}
 	  \,+\, \underbrace{\mathbf{E}}_{\text{residual}} \\
-	\mathbf{y} &= q_\text{p}\, \mathbf{t}_\text{p} + \mathbf{f}
+	\mathbf{y} &= q_\text{p}\, \mathbf{t}_\text{p} + \mathbf{f} \\[4pt]
+	\mathbf{t}_\text{o} &= \mathbf{X}\,(0.808,\ -0.590,\ 0.008)^T
+	  \qquad\text{and then}\qquad
+	  \mathbf{t}_\text{p} = \left(\mathbf{X} - \mathbf{t}_\text{o}\mathbf{p}_\text{o}^T\right)
+	  (0.474,\ 0.657,\ 0.586)^T \\
+	\hat{\mathbf{y}} &= 0.571\, \mathbf{t}_\text{p}
 	\end{aligned}
 
-Here :math:`\mathbf{T}_\text{o}` and :math:`\mathbf{P}_\text{o}` carry one column per orthogonal
-component, and :math:`\mathbf{E}` and :math:`\mathbf{f}` hold what no component explains. In the scaled
+The last two lines are this cheese model's numbers, with |X| centred and scaled. They also show the
+order O-PLS works in: the orthogonal score is formed first, using
+:math:`\mathbf{w}_\text{o} = (0.808, -0.590, 0.008)`, and only then is the predictive score formed with
+:math:`\mathbf{w}_\text{p} = (0.474, 0.657, 0.586)`, on what is left of |X| once the orthogonal piece
+has been removed. Here :math:`\mathbf{T}_\text{o}` and :math:`\mathbf{P}_\text{o}` carry one column per
+orthogonal component, and :math:`\mathbf{E}` and :math:`\mathbf{f}` hold what no component explains. In the scaled
 units the model works in, the predictive piece carries 68.7% of the sum of squares in |X|, the
 orthogonal piece 18.3%, and the residual 13.0%. Those percentages describe |X| alone. The first is not
 the share of the input variation that is about taste: most of it is the joint spread of three correlated

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -644,10 +644,20 @@ For the first component of the cheese model those two vectors are close, but the
 		- 0.008
 		- 90
 
-Why should they differ at all? The weight was aimed at taste. The score it produces, though, carries
-along whatever else happens to vary in that same pattern across the cheeses, and the loading records
-all of it. The difference between the loading and the weight is therefore the part of the variation
-that travelled with the score without being about taste.
+Why should they differ at all? The weight was aimed at taste. But it was not aimed only at taste, and
+:ref:`the mathematical interpretation of PLS <LVM_PLS_mathematical_interpretation>` says why. Each
+component is chosen to maximise the *covariance* between the |X|-score and the |Y|-score, and
+covariance factors into three parts: the correlation between the two scores, the variation the score
+captures in |X|, and the variation it captures in |Y|. Maximising covariance is therefore not the same
+as maximising correlation. A direction that lines up slightly less well with taste, but which accounts
+for more of the spread among the cheeses, can give the larger covariance, so the weight settles
+somewhere between pointing at taste and pointing where the inputs vary most.
+
+The score that direction produces consequently carries along whatever else happens to vary in that same
+pattern across the cheeses. The loading is a plain regression of the inputs back onto that score, so it
+records all of it, the part related to taste and the part not. The difference between the loading and
+the weight is therefore the part of the variation that travelled with the score without being about
+taste.
 
 That difference is simpler to write down than it looks. For every PLS component the weight and its own
 loading satisfy :math:`\mathbf{w}_a^T \mathbf{p}_a = 1`, which follows by substituting

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -519,15 +519,16 @@ each orthogonal component asked for, while :math:`\mathbf{E}` and :math:`\mathbf
 component explains. For these cheeses, in the scaled units the model works in, the predictive piece
 carries 68.7% of the sum of squares in |X|, the orthogonal piece 18.3%, and the residual 13.0%.
 
-The second line is where O-PLS parts company with PLS. Only :math:`\mathbf{t}_\text{p}` appears in it:
+The equation for |Y|, the second of the two lines given for the decomposition, is where O-PLS parts
+company with PLS. Only :math:`\mathbf{t}_\text{p}` appears in it:
 the orthogonal scores :math:`\mathbf{T}_\text{o}` are absent, so movement in the orthogonal piece
 cannot change the predicted taste, however large that piece is. Filtering out the orthogonal part
 leaves a model with the same predictions as ordinary PLS, but with the response-relevant variation
 gathered into a single component.
 
 It is worth being concrete about how that split is built, because it explains everything that follows.
-O-PLS keeps the same two-dimensional plane the PLS model already found; what it changes is the pair of
-axes drawn within that plane. The first axis is chosen to point along the variation in the inputs
+O-PLS works in the same two-dimensional plane the PLS model already found, and, as we will see below,
+along the same two directions within it. The first of those directions points along the variation in the inputs
 that tracks taste. The fitted model reports it as ``opls.predictive_weights_``, one entry per input,
 and for these cheeses that direction is
 
@@ -538,9 +539,10 @@ and for these cheeses that direction is
 
 The entries are in the mean-centred, unit-variance units the model works in, so they can be compared
 with each other directly. All three are positive and of similar size, which is the raw-data picture
-restated: the three inputs rise together, and each rises with taste. The second axis takes what is left
-of the plane once that predictive direction has been removed, reported as ``opls.orthogonal_weights_``,
-one column per orthogonal component. Here there is one column, the orthogonal weight
+restated: the three inputs rise together, and each rises with taste. The second direction takes what is
+left of the plane once that predictive direction has been removed, reported as
+``opls.orthogonal_weights_``, one column per orthogonal component. Here there is one column, the
+orthogonal weight
 
 .. math::
 
@@ -560,12 +562,35 @@ uncorrelated with the response, exactly, while the predictive score is strongly 
 	print(opls.predictive_weights_.round(3).to_numpy())           # [0.474 0.657 0.586]
 	print(opls.orthogonal_weights_.round(3).to_numpy().ravel())   # [ 0.808 -0.59   0.008]
 
+	print(pls.x_weights_.to_numpy().round(3))    # the PLS weights, side by side
+	# [[ 0.474  0.808]
+	#  [ 0.657 -0.59 ]
+	#  [ 0.586  0.008]]
+
 	y_centred = (Y - Y.mean()).to_numpy().ravel()
 
 	print(round(float(np.corrcoef(opls.orthogonal_scores_.to_numpy().ravel(), y_centred)[0, 1]), 12))
 	print(round(float(np.corrcoef(opls.predictive_scores_.to_numpy().ravel(), y_centred)[0, 1]), 4))
 	# -0.0
 	# 0.8198
+
+Those two weight vectors are worth comparing with the PLS model, since the two methods are easy to
+imagine as more different than they are. The two columns of ``pls.x_weights_`` are the two O-PLS
+weights, in the same order: the predictive weight is the first PLS weight, and the orthogonal weight is
+the second. They are not merely similar directions, they are the same numbers. The two models also return the same regression coefficients, agreeing here to
+:math:`1.4 \times 10^{-13}`, so they would predict a new cheese identically.
+
+What differs is the order in which the two directions are peeled off |X|. PLS removes the predictive
+component first and the orthogonal one second. O-PLS reverses that: it removes the orthogonal component
+first, then computes the predictive score on what is left. Because the orthogonal variation has already
+gone by the time the predictive score is formed, that score absorbs all of the taste information.
+
+The consequence is visible in the scores rather than in the weights. The two predictive scores are
+close but not identical, correlating at 0.978. More to the point, the PLS second score still carries a
+little taste information, correlating with taste at :math:`-0.172`, while the O-PLS orthogonal score
+correlates with it at exactly zero. The PLS first score correlates with taste at 0.802, and the O-PLS
+predictive score at 0.820: the taste information that PLS left on its second component has been
+gathered onto the first.
 
 .. _LVM-PLS-opls-construction:
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -10,22 +10,18 @@ solve for the inputs that would achieve it. Finding the inputs that give a chose
 MacGregor, 2000
 <https://literature.learnche.org/item/180/industrial-applications-of-product-design-through-the-inversion-of-latent-variable-models>`_).
 
-The answer is more interesting than a single recipe. A PLS model compresses several correlated inputs
-into a few latent directions, and one target value can pin down only one of them. Everything left over
-is free, so inversion returns not *the* recipe but a flat set of them, every one of which the model
-says will hit the target. Where that freedom comes from, what it is worth, and how much of it the data
-support is the subject of this section.
+Inversion returns not a single set of inputs but a whole set of them, every one of which the model says
+will hit the target. That is possible because a model captures systematic variation in the inputs that
+turns out to have no bearing on the response, the part usually filtered out to make a model easier to
+read. For these cheeses it is 18.3% of the variation in the inputs, and moving within it changes the
+recipe while leaving the prediction exactly where it was. Those directions are the null space. Where
+that freedom comes from, what it is worth, and how much of it the data support is the subject of this
+section.
 
-That freedom lives in a part of the model few people look at: the systematic variation the model
-captures and then finds has no bearing on the response. It is usually filtered out to make a model
-easier to read. For these cheeses it is 18.3% of the variation in the inputs, none of which moves the
-taste.
-
-The running example is the same :ref:`cheddar-cheese data <LVM-cheddar-cheese-example>` as before, a
-small and well-worn data set. Thirty cheddar cheeses were each measured for three things, the
-concentrations of acetic acid, hydrogen sulfide and lactic acid, and each was given a taste score by a
-panel. The forward question was "what taste do these three measurements imply?" The inversion question
-is "which three measurements would give me a taste I have chosen?"
+The running example is the same :ref:`cheddar-cheese data <LVM-cheddar-cheese-example>` as before.
+Thirty cheeses were each measured for acetic acid, hydrogen sulfide and lactic acid, and given a taste
+score by a panel. The forward question was "what taste do these three measurements imply?" The
+inversion question is "which three measurements would give me a taste I have chosen?"
 
 .. _LVM-PLS-cheese-scatterplot:
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -394,9 +394,27 @@ We can confirm both the slope and the perpendicularity from the fitted model.
 The direct-inversion solution fits the same picture. It is
 :math:`\boldsymbol{\tau}_\text{DI} = y_\text{des}\, \mathbf{q} / (\mathbf{q}^T\mathbf{q})`, which points
 along :math:`\mathbf{q}` itself, so it is the point where a perpendicular dropped from the origin meets
-the line. That is what makes it the solution of smallest score norm. Here it is
-:math:`(-0.253, 0.121)`, pointing opposite to :math:`\mathbf{q}` because the requested taste of 20.9
-sits below the training average of 23.7.
+the line. Here it is :math:`(-0.253, 0.121)`, pointing opposite to :math:`\mathbf{q}` because the
+requested taste of 20.9 sits below the training average of 23.7.
+
+That perpendicularity is also what makes it the solution of smallest score norm, once we notice what
+the score norm measures. The norm :math:`\|\boldsymbol{\tau}\|` is the distance from the origin of the
+score plot out to the point, so asking for the smallest norm is asking which design on the null-space
+line sits closest to the origin. Writing a general solution as
+:math:`\boldsymbol{\tau}_\text{DI} + s\,\mathbf{g}`, for a step of size :math:`s` along the unit
+null-space direction :math:`\mathbf{g}`, the two parts are at right angles, so Pythagoras applies:
+
+.. math::
+
+	\left\| \boldsymbol{\tau}_\text{DI} + s\,\mathbf{g} \right\|^2
+	  = \left\| \boldsymbol{\tau}_\text{DI} \right\|^2 + s^2
+
+The step contributes :math:`s^2`, which is positive for every step other than none at all. The norm is
+therefore smallest at :math:`s = 0`, and it grows in either direction. Here
+:math:`\|\boldsymbol{\tau}_\text{DI}\| = 0.281`, while the :math:`-1` and :math:`+1` steps both sit at
+:math:`\sqrt{0.281^2 + 1^2} = 1.039`. The right angle is the reason: had the null space met the
+solution at any other angle, moving one way along it would have carried the design closer to the origin
+than :math:`\boldsymbol{\tau}_\text{DI}`.
 
 Two further points are worth making. First, the perpendicularity is a statement about the score
 coordinates, so it reads as a right angle on the page only when both axes are drawn to the same scale, as

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -416,6 +416,61 @@ therefore smallest at :math:`s = 0`, and it grows in either direction. Here
 solution at any other angle, moving one way along it would have carried the design closer to the origin
 than :math:`\boldsymbol{\tau}_\text{DI}`.
 
+The score norm is not the only way to measure how far a design sits from the centre of the model.
+Hotelling's :math:`T^2` measures the same thing, but it divides each score by that score's standard
+deviation before squaring, so a component with little spread counts for more. It is a weighted sum of
+squares rather than a plain one. Both can be plotted against the step size, which shows what the walk
+along the null space costs.
+
+.. code-block:: python
+
+	sf = pls.scaling_factor_for_scores_.to_numpy()   # one standard deviation per score
+	steps = np.linspace(-2, 2, 401)
+	points = tau + steps[:, None] * g                # every design on the null space
+
+	norm_squared = (points ** 2).sum(axis=1)
+	t2 = ((points / sf) ** 2).sum(axis=1)
+
+	fig = go.Figure()
+	fig.add_scatter(x=steps, y=norm_squared, mode="lines", name="squared score norm",
+	                line={"color": "orange"})
+	fig.add_scatter(x=steps, y=t2, mode="lines", name="Hotelling's T2",
+	                line={"color": "darkblue"})
+	fig.update_layout(xaxis_title="step s along the null space",
+	                  yaxis_title="squared distance from the model centre")
+	fig.show()
+
+	print(sf.round(3))                                        # [1.468 0.657]
+	print(round(-float((tau / sf**2) @ g) / float((g / sf**2) @ g), 3))
+	# -0.103, the step at which T2 is least
+
+.. _LVM-PLS-null-space-distance-figure:
+
+.. figure:: ../../figures/pls/pls-null-space-distance.png
+	:alt: Squared score norm and Hotelling's T2 plotted against the step along the null space
+	:width: 700px
+	:align: center
+
+	Two measures of how far a design sits from the centre of the model, as a step of size :math:`s` is
+	taken along the null space from the direct-inversion solution. The predicted taste is 20.9 at every
+	point on the horizontal axis. The orange curve is the squared score norm, least exactly at
+	:math:`s = 0`. The blue curve is Hotelling's :math:`T^2`, least at :math:`s = -0.103`. The three
+	blue markers are the rows tabulated earlier for steps of :math:`-1`, :math:`0` and :math:`+1`.
+
+Both curves are parabolas in :math:`s`, but they are not the same parabola. The orange one is
+:math:`\|\boldsymbol{\tau}_\text{DI}\|^2 + s^2` from the equation above, so its lowest point is exactly
+the direct-inversion solution. The blue one is tilted, and reaches its lowest point at
+:math:`s = -0.103` instead. The two scores have standard deviations of 1.468 and 0.657, so :math:`t_2`
+counts for more in :math:`T^2` than in the plain norm, and the null-space direction
+:math:`\mathbf{g} = (0.433, 0.902)` is mostly :math:`t_2`.
+
+The distinction is worth keeping straight, because it says what the direct-inversion solution does and
+does not give. It is the smallest-norm design, exactly. It is not quite the design of smallest
+:math:`T^2`: a step of :math:`-0.103` would reach :math:`T^2 = 0.043` rather than 0.064. The gap is
+small here and the direct-inversion solution is still the closest of the three tabulated steps, but the
+two criteria are different questions and a model with more unequal score spreads would separate them
+further.
+
 Two further points are worth making. First, the perpendicularity is a statement about the score
 coordinates, so it reads as a right angle on the page only when both axes are drawn to the same scale, as
 they are in the figure above but not in the earlier

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -344,8 +344,7 @@ into the familiar form, the free coordinate traces out
 	    = 2.08\, t_1 + 0.65
 
 so the line climbs 2.08 units of :math:`t_2` for every unit of :math:`t_1`. That is the diagonal in the
-score plot, and it comes from the ratio of the two :math:`y`-loadings alone, :math:`-q_1/q_2`. Their
-absolute sizes do not matter, only their ratio: doubling both would give the same line.
+score plot, and it comes from the ratio of the two :math:`y`-loadings alone, :math:`-q_1/q_2`.
 
 There is a matching geometric statement. Take any two points on the line and subtract their equations.
 The constant cancels, leaving

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -1113,7 +1113,8 @@ Both the region and the box it is reported as can be drawn.
 	Five points are marked in both panels with the same shape and colour, so a location in the score
 	plot can be followed to the recipe it stands for: the four corners of the region, where the outer
 	null spaces meet the :math:`T^2` limit, and its centre, the direct-inversion solution for a taste of
-	25. Each corner of the box carries the taste it is predicted to have, dark red where that taste is
+	25. Colour gives the target taste, and the triangle points down at the low end of that taste's null
+	space and up at the high end. Each corner of the box carries the taste it is predicted to have, dark red where that taste is
 	outside the window and blue where it is acceptable but the recipe lies beyond the :math:`T^2` limit.
 
 The eight corners make the difference concrete. Every one of them satisfies all three ranges, since

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -10,6 +10,12 @@ solve for the inputs that would achieve it. Finding the inputs that give a chose
 MacGregor, 2000
 <https://literature.learnche.org/item/180/industrial-applications-of-product-design-through-the-inversion-of-latent-variable-models>`_).
 
+The answer turns out not to be a single set of inputs but a whole set of them. The freedom to choose
+among them lives in a part of the model that is often set aside: the systematic variation the model
+captures and then finds has no bearing on the response. It is usually filtered out to make a model
+easier to read. For these cheeses it is 18.3% of the variation in the inputs, none of which moves the
+taste.
+
 We will use the same :ref:`cheddar-cheese data <LVM-cheddar-cheese-example>` as before: the taste of a
 cheese predicted from three inputs, acetic acid, hydrogen sulfide, and lactic acid. The forward
 question was "what taste do these inputs give?" The inversion question is "which inputs give a
@@ -407,14 +413,27 @@ We can confirm both the slope and the perpendicularity from the fitted model.
 	print(g.round(3))                      # [0.433 0.902], the null-space direction
 	print(round(float(g @ q), 12))         # 0.0, the direction is perpendicular to q
 
-The direct-inversion solution fits the same picture. It is
-:math:`\boldsymbol{\tau}_\text{DI} = y_\text{des}\, \mathbf{q} / (\mathbf{q}^T\mathbf{q})`, which points
-along :math:`\mathbf{q}` itself, so it is the point where a perpendicular dropped from the origin meets
-the line. Here it is :math:`(-0.253, 0.121)`, pointing opposite to :math:`\mathbf{q}` because the
-requested taste of 20.9 sits below the training average of 23.7.
+The particular solution the inversion returns is the shortest one, and the same picture shows where it
+comes from. Split any candidate :math:`\boldsymbol{\tau}` into a part along :math:`\mathbf{q}` and a
+part perpendicular to it. The perpendicular part contributes nothing to the prediction, since
+:math:`\hat{y} = \mathbf{q}^T \boldsymbol{\tau}` ignores it, but it does add to the length of
+:math:`\boldsymbol{\tau}`. The shortest solution therefore carries no perpendicular part at all, which
+is to say it lies along :math:`\mathbf{q}`. Writing it as
+:math:`\boldsymbol{\tau} = c\, \mathbf{q}` and requiring
+:math:`\mathbf{q}^T \boldsymbol{\tau} = y_\text{des}` gives
+:math:`c\, \mathbf{q}^T \mathbf{q} = y_\text{des}`, so that
 
-That perpendicularity is also what makes it the solution of smallest score norm, once we notice what
-the score norm measures. The norm :math:`\|\boldsymbol{\tau}\|` is the distance from the origin of the
+.. math::
+
+	\boldsymbol{\tau}_\text{DI} = \frac{y_\text{des}\, \mathbf{q}}{\mathbf{q}^T \mathbf{q}}
+
+Geometrically that is the point where a perpendicular dropped from the origin meets the line. Here
+:math:`\mathbf{q}^T \mathbf{q} = 0.367` and :math:`y_\text{des} = -0.17`, which gives
+:math:`\boldsymbol{\tau}_\text{DI} = (-0.253, 0.121)`. It points opposite to :math:`\mathbf{q}` because
+the requested taste of 20.9 sits below the training average of 23.7.
+
+Calling it the smallest-norm solution takes two further steps that are easy to skip. The norm
+:math:`\|\boldsymbol{\tau}\|` is the distance from the origin of the
 score plot out to the point, so asking for the smallest norm is asking which design on the null-space
 line sits closest to the origin. Writing a general solution as
 :math:`\boldsymbol{\tau}_\text{DI} + s\,\mathbf{g}`, for a step of size :math:`s` along the unit

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -738,6 +738,9 @@ The consequence shows up in the scores, not the weights.
 
 	print(round(float(np.corrcoef(t_p, scores.iloc[:, 0])[0, 1]), 3))   # 0.978
 
+	print(pls.r2_cumulative_.round(3).to_list())                        # [0.642, 0.672]
+	print(round(float(np.corrcoef(t_p, y_centred)[0, 1]) ** 2, 3))      # 0.672
+
 .. _LVM-PLS-score-correlation-table:
 
 .. list-table:: How each score correlates with taste. The two predictive scores are close, correlating
@@ -756,9 +759,15 @@ The consequence shows up in the scores, not the weights.
 	*	- O-PLS, orthogonal
 		- 0.000
 
-The taste information PLS left on its second component has been gathered onto the first. What O-PLS ends
-up with is a single |X| matrix split three ways, the pieces adding back up to |X|. There is one |X| here,
-not two blocks of data side by side:
+Both models explain the same amount of taste; they differ in how many components it takes. PLS reaches
+an :math:`R^2` of 0.672 only with both: the first component gets to 0.642, and the second supplies the
+remaining 0.030, which is why it still correlates with taste rather than sitting at zero. The O-PLS
+predictive score reaches the same 0.672 on its own, since :math:`0.820^2 = 0.672`. Nothing has been
+created or lost, the same explained variance is packaged into one component instead of two, and that is
+what leaves the orthogonal score at exactly zero.
+
+What O-PLS ends up with is a single |X| matrix split three ways, the pieces adding back up to |X|. There
+is one |X| here, not two blocks of data side by side:
 
 .. math::
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -388,6 +388,7 @@ We can confirm both the slope and the perpendicularity from the fitted model.
 	q = pls.y_loadings_.to_numpy().ravel()
 	print(q.round(3))                      # [ 0.546 -0.262]
 	print(round(-q[0] / q[1], 2))          # 2.08, the slope of the line
+	print(g.round(3))                      # [0.433 0.902], the null-space direction
 	print(round(float(g @ q), 12))         # 0.0, the direction is perpendicular to q
 
 The direct-inversion solution fits the same picture. It is

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -775,21 +775,37 @@ is one |X| here, not two blocks of data side by side:
 	\mathbf{X} &= \underbrace{\mathbf{t}_\text{p} \mathbf{p}_\text{p}^T}_{\text{predictive}}
 	  \,+\, \underbrace{\mathbf{T}_\text{o} \mathbf{P}_\text{o}^T}_{Y\text{-orthogonal}}
 	  \,+\, \underbrace{\mathbf{E}}_{\text{residual}} \\
-	\mathbf{y} &= q_\text{p}\, \mathbf{t}_\text{p} + \mathbf{f} \\[4pt]
-	\mathbf{t}_\text{o} &= \mathbf{X}\,(0.808,\ -0.590,\ 0.008)^T
-	  \qquad\text{and then}\qquad
-	  \mathbf{t}_\text{p} = \left(\mathbf{X} - \mathbf{t}_\text{o}\mathbf{p}_\text{o}^T\right)
+	\mathbf{y} &= q_\text{p}\, \mathbf{t}_\text{p} + \mathbf{f}
+	\end{aligned}
+
+Here :math:`\mathbf{T}_\text{o}` and :math:`\mathbf{P}_\text{o}` carry one column per orthogonal
+component, and :math:`\mathbf{E}` and :math:`\mathbf{f}` hold what no component explains.
+
+The order O-PLS works in is not visible in that split, and it matters. The orthogonal score is formed
+first, from |X| itself. The predictive score is formed second, from what is left of |X| once the
+orthogonal piece has been removed, which is what allows it to absorb all of the taste information:
+
+.. math::
+
+	\begin{aligned}
+	\mathbf{t}_\text{o} &= \mathbf{X}\, \mathbf{w}_\text{o} \\
+	\mathbf{t}_\text{p} &= \left(\mathbf{X} - \mathbf{t}_\text{o} \mathbf{p}_\text{o}^T\right)
+	  \mathbf{w}_\text{p} \\
+	\hat{\mathbf{y}} &= q_\text{p}\, \mathbf{t}_\text{p}
+	\end{aligned}
+
+Substituting this cheese model's coefficients, with |X| centred and scaled:
+
+.. math::
+
+	\begin{aligned}
+	\mathbf{t}_\text{o} &= \mathbf{X}\, (0.808,\ -0.590,\ 0.008)^T \\
+	\mathbf{t}_\text{p} &= \left(\mathbf{X} - \mathbf{t}_\text{o} \mathbf{p}_\text{o}^T\right)
 	  (0.474,\ 0.657,\ 0.586)^T \\
 	\hat{\mathbf{y}} &= 0.571\, \mathbf{t}_\text{p}
 	\end{aligned}
 
-The last two lines are this cheese model's numbers, with |X| centred and scaled. They also show the
-order O-PLS works in: the orthogonal score is formed first, using
-:math:`\mathbf{w}_\text{o} = (0.808, -0.590, 0.008)`, and only then is the predictive score formed with
-:math:`\mathbf{w}_\text{p} = (0.474, 0.657, 0.586)`, on what is left of |X| once the orthogonal piece
-has been removed. Here :math:`\mathbf{T}_\text{o}` and :math:`\mathbf{P}_\text{o}` carry one column per
-orthogonal component, and :math:`\mathbf{E}` and :math:`\mathbf{f}` hold what no component explains. In the scaled
-units the model works in, the predictive piece carries 68.7% of the sum of squares in |X|, the
+In the scaled units the model works in, the predictive piece carries 68.7% of the sum of squares in |X|, the
 orthogonal piece 18.3%, and the residual 13.0%. Those percentages describe |X| alone. The first is not
 the share of the input variation that is about taste: most of it is the joint spread of three correlated
 measurements, which would be there whether or not taste had been recorded. How much of taste the model

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -661,9 +661,17 @@ the weight is therefore the part of the variation that travelled with the score 
 taste.
 
 That difference is simpler to write down than it looks. For every PLS component the weight and its own
-loading satisfy :math:`\mathbf{w}_a^T \mathbf{p}_a = 1`, which follows by substituting
-:math:`\mathbf{p}_a = \mathbf{X}^T \mathbf{t}_a / (\mathbf{t}_a^T \mathbf{t}_a)` and
-:math:`\mathbf{t}_a = \mathbf{X} \mathbf{w}_a` and cancelling. Taking away from the loading the part
+loading satisfy :math:`\mathbf{w}_a^T \mathbf{p}_a = 1`:
+
+.. math::
+
+	\mathbf{w}_a^T \mathbf{p}_a
+	  = \mathbf{w}_a^T \left( \frac{\mathbf{X}^T \mathbf{t}_a}{\mathbf{t}_a^T \mathbf{t}_a} \right)
+	  = \frac{\left(\mathbf{X} \mathbf{w}_a\right)^T \mathbf{t}_a}{\mathbf{t}_a^T \mathbf{t}_a}
+	  = \frac{\mathbf{t}_a^T \mathbf{t}_a}{\mathbf{t}_a^T \mathbf{t}_a}
+	  = 1
+
+Taking away from the loading the part
 of it that lies along the weight therefore leaves a plain subtraction, and what is left is exactly
 perpendicular to the weight:
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -1051,8 +1051,8 @@ Suppose a taste between 20 and 30 is acceptable.
 	t2_limit = pls.hotellings_t2_limit(0.95)
 
 	region = []
-	for target in np.linspace(20.0, 30.0, 5):        # the range of taste we accept
-	    for step in np.linspace(-6, 6, 2001):        # walk along that target's null space
+	for target in np.linspace(20.0, 30.0, 41):       # the tastes we accept
+	    for step in np.linspace(-6, 6, 801):         # walk along that target's null space
 	        candidate = pls.invert(target, null_space_coordinates=[step])
 	        if candidate.hotellings_t2 <= t2_limit:
 	            region.append(candidate.x_new)

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -10,16 +10,22 @@ solve for the inputs that would achieve it. Finding the inputs that give a chose
 MacGregor, 2000
 <https://literature.learnche.org/item/180/industrial-applications-of-product-design-through-the-inversion-of-latent-variable-models>`_).
 
-The answer turns out not to be a single set of inputs but a whole set of them. The freedom to choose
-among them lives in a part of the model that is often set aside: the systematic variation the model
+The answer is more interesting than a single recipe. A PLS model compresses several correlated inputs
+into a few latent directions, and one target value can pin down only one of them. Everything left over
+is free, so inversion returns not *the* recipe but a flat set of them, every one of which the model
+says will hit the target. Where that freedom comes from, what it is worth, and how much of it the data
+support is the subject of this section.
+
+That freedom lives in a part of the model few people look at: the systematic variation the model
 captures and then finds has no bearing on the response. It is usually filtered out to make a model
 easier to read. For these cheeses it is 18.3% of the variation in the inputs, none of which moves the
 taste.
 
-We will use the same :ref:`cheddar-cheese data <LVM-cheddar-cheese-example>` as before: the taste of a
-cheese predicted from three inputs, acetic acid, hydrogen sulfide, and lactic acid. The forward
-question was "what taste do these inputs give?" The inversion question is "which inputs give a
-target taste?"
+The running example is the same :ref:`cheddar-cheese data <LVM-cheddar-cheese-example>` as before, a
+small and well-worn data set. Thirty cheddar cheeses were each measured for three things, the
+concentrations of acetic acid, hydrogen sulfide and lactic acid, and each was given a taste score by a
+panel. The forward question was "what taste do these three measurements imply?" The inversion question
+is "which three measurements would give me a taste I have chosen?"
 
 .. figure:: ../../figures/examples/cheese/cheese-plots-no-random.png
 	:alt: Scatterplot matrix of the cheddar-cheese data: acetic acid, hydrogen sulfide, lactic acid and taste
@@ -38,16 +44,54 @@ Why inversion needs more than the predictive number of components
 
 When we chose the number of components for prediction in :ref:`the section above
 <LVM-PLS-number-of-components>`, cross-validation kept a single component: one component is enough
-to predict Taste. Inversion places a second demand on the model. To reconstruct an input vector from
-a target output, the model must describe the |X|-space well enough to map a score back to a full set
-of input values, not only the |Y|-space. A one-component model spans only a line in the input space,
-so it can return just one set of inputs for a target taste. Keeping a second component lets the
-model describe the plane on which the calibration cheeses actually lie, and, as we will see, it
-opens up a whole set of equivalent designs. We therefore fit a two-component model here, even though
-the second component did not improve prediction.
+to predict Taste, and a second does not improve prediction. Inversion places a second and different
+demand on the model, though. To rebuild a complete set of three input values from one target number,
+the model has to describe the |X|-space well enough to map a score back into it, not merely describe
+the |Y|-space. A one-component model spans only a line in the input space, so it can return exactly
+one recipe, and the whole question of equivalent designs never arises.
 
-Following the request to design toward cheeses the model has not seen, we hold out the first four cheeses
-and fit the model on the remaining twenty-six.
+A second component lets the model describe the plane on which the calibration cheeses actually lie,
+and that is what opens up the set of equivalent designs. So a two-component model is fitted here even
+though the second did not earn its place on predictive grounds.
+
+So that the targets stay independent of the model, the first four cheeses are set aside and never shown
+to it. They become the targets: for each one we ask the model to design a cheese with that taste, then
+compare what it proposes against what that cheese actually was. Their tastes span most of the range,
+which matters later, because designing toward an extreme target turns out to cost more than designing
+toward a middling one.
+
+.. _LVM-PLS-holdout-table:
+
+.. list-table:: The four held-out cheeses, used only as targets. The model is fitted on the other 26,
+	whose tastes run from 0.7 to 57.2 with a mean of 23.7.
+	:header-rows: 1
+	:widths: 14 18 18 18 18
+
+	*	- Cheese
+		- Acetic
+		- H2S
+		- Lactic
+		- Taste
+	*	- 1
+		- 4.54
+		- 3.14
+		- 0.86
+		- 12.3
+	*	- 2
+		- 5.16
+		- 5.04
+		- 1.53
+		- 20.9
+	*	- 3
+		- 5.37
+		- 5.44
+		- 1.57
+		- 39.0
+	*	- 4
+		- 5.76
+		- 7.50
+		- 1.81
+		- 47.9
 
 .. code-block:: python
 
@@ -67,11 +111,10 @@ and fit the model on the remaining twenty-six.
 	pls = PLS(n_components=2).fit(X, Y)
 	print(round(float(pls.r2_cumulative_.iloc[-1]), 3))   # R2 on Taste: 0.672
 
-The two-component model explains about 67% of the variation in Taste. It is a moderate predictor, which
-is fine for what follows: the null space is a property of the model's geometry rather than of its
-predictive accuracy. That geometry is itself estimated from the same 26 cheeses, though, so it carries
-its own uncertainty. We return to
-:ref:`how well the direction is determined <LVM-PLS-null-space-uncertainty>` once it has been derived.
+It explains about 67% of the variation in Taste, which is enough for what follows: the null space is a
+property of the model's geometry rather than of its predictive accuracy. That geometry is itself
+estimated from the same 26 cheeses, though, so it carries one caveat, which we return to
+:ref:`once the geometry is on the table <LVM-PLS-null-space-uncertainty>`.
 
 .. _LVM-PLS-null-space:
 
@@ -98,95 +141,14 @@ predicts will give that taste.
 	# Actual: T2 = 0.21, SPE = 0.68
 	# Predicted: T2 = 0.06, SPE = 0.00
 
-The prediction at the designed inputs is exactly 20.9, by construction. To judge whether that design
-is a reasonable one, compare it with the cheese we held out. For this model the 99% limits are
-:math:`T^2 = 12.14` and :math:`\text{SPE} = 1.60`. These are the limits for a *new* observation rather
-than for one of the 26 used to fit the model, which is the right choice here: a proposed design is
-being judged against the model, not summarised by it. Limits for the observations that built the model
-are lower, since each of those helped set the centre and spread it is then measured against, and at a
-sample size of 26 that difference is not negligible.
+A recipe comes back, which is unremarkable. The second line is the interesting one. The null space has
+dimension 1, which is the model saying that this is not *the* answer but one point on a line of
+answers. Two score directions, one target: the target fixes one of them and leaves the other free.
+Anything we do along that free direction changes the recipe while leaving the prediction exactly where
+it was. That free direction is the *null space*, and its dimension is the number of components minus
+the rank of the response, here :math:`2 - 1 = 1`.
 
-.. list-table:: Cheese 2: its measured inputs, and the inputs the inversion returns for taste 20.9.
-	:header-rows: 1
-	:widths: 16 18 14 14 14 12 12
-
-	*	- Row
-		- Target taste
-		- Acetic
-		- H2S
-		- Lactic
-		- :math:`T^2`
-		- SPE
-	*	- Actual
-		- 20.9
-		- 5.16
-		- 5.04
-		- 1.53
-		- 0.21
-		- 0.68
-	*	- Predicted
-		- 20.9
-		- 5.52
-		- 5.56
-		- 1.40
-		- 0.06
-		- 0.00
-
-Both rows sit well inside the SPE and :math:`T^2` limits, so neither is an extrapolation. The
-predicted inputs have an SPE of exactly zero, because the inversion rebuilds the inputs from their
-scores: the result lies on the model plane by construction, leaving no residual.
-
-That zero is a statement about the arithmetic, not a claim about cheese. Every real cheese carries some
-variation the two components do not describe, which is why the measured row has an SPE of 0.68 rather
-than zero. A design returned by inversion is an idealised point on the model plane, and any cheese
-actually made to it will land near the plane rather than on it. The useful reading of a zero SPE is
-therefore that the design is internally consistent with the model, not that it is more attainable than
-the cheeses the model was built from.
-
-.. _LVM-PLS-input-space-deviation:
-
-The two rows are close, but "close" in the raw units is hard to read: a gap of 0.5 in hydrogen sulfide
-does not mean the same thing as a gap of 0.5 in lactic acid, because the three measurements are on
-different scales. Centring and scaling each column puts them on a common footing, where one unit is one
-standard deviation of that measurement. The *input-space deviation* is then the sum of the squared
-differences between the two rows, in those units. It is a distance between two recipes, measured across
-the three inputs, and normalized so that every input counts on the same scale.
-
-.. code-block:: python
-
-	scaler = MCUVScaler().fit(X)
-	a = scaler.transform(actual.to_frame().T).iloc[0]           # actual, in std deviations
-	p = scaler.transform(result.x_new.to_frame().T).iloc[0]     # predicted, in std deviations
-
-	print(a.round(2).to_list())                      # [-0.67, -0.46, 0.3]
-	print(p.round(2).to_list())                      # [-0.04, -0.22, -0.15]
-	print(round(float(((a - p) ** 2).sum()), 2))     # 0.66
-
-Writing the three terms out, with acetic acid first, then hydrogen sulfide, then lactic acid:
-
-.. math::
-
-	\begin{aligned}
-	\text{input-space deviation} &= \left(-0.67 - (-0.04)\right)^2 + \left(-0.46 - (-0.22)\right)^2
-	  + \left(0.30 - (-0.15)\right)^2 \\
-	&= (-0.63)^2 + (-0.24)^2 + (0.45)^2 \\
-	&= 0.39 + 0.06 + 0.21 \\
-	&= 0.66
-	\end{aligned}
-
-The square root of 0.66 is 0.81, so the cheese we held out sits about 0.8 standard deviations away from
-the inputs the inversion proposed, counting all three measurements together. Acetic acid accounts
-for most of that gap.
-
-The null space is the reason ``null_space_dimension`` is not zero. A two-component model has two score
-directions, but a single taste value pins down only one of them. The other direction is free: we can move
-along it and the predicted taste does not change at all. That free direction is the *null space*. Its
-dimension is the number of components minus the rank of the response, here :math:`2 - 1 = 1`, so it is a
-line. Every set of inputs on that line gives the same predicted taste.
-
-We can walk along the null space by passing coordinates along its basis. In the code and figure we take a
-step of -1 and +1 along the basis. The predicted taste stays the same along this basis line. Hence the
-name the null space. Only the input variables change, while the predicted output remains fixed.
+We can walk along it by passing coordinates along its basis. Stepping one unit either way:
 
 .. code-block:: python
 
@@ -197,17 +159,12 @@ name the null space. Only the input variables change, while the predicted output
 	# [4.95, 6.10, 1.33] -> 20.9
 	# [6.09, 5.02, 1.46] -> 20.9
 
-Both of these sets of inputs, and the whole line between and beyond them, predict a taste of 20.9.
-The freedom to choose among them is what makes inversion useful in practice: it can be spent on a
-secondary goal such as cost, safety, or keeping within a supplier's specification, without moving
-the predicted quality. As a check on the held-out cheese, its actual inputs (Acetic 5.16, H2S 5.04,
-Lactic 1.53) predict a taste of 20.7, close to its measured 20.9, and it lies near the null-space
-line just traced.
-
-Collecting the three points on the line, together with the cheese itself, shows what moving along
-the null space does and does not change.
+Collecting those points, and putting the measured cheese alongside for comparison:
 
 .. code-block:: python
+
+	scaler = MCUVScaler().fit(X)
+	a = scaler.transform(actual.to_frame().T).iloc[0]           # actual, in std deviations
 
 	designs = {
 	    "Actual": actual,
@@ -224,7 +181,7 @@ the null space does and does not change.
 
 .. _LVM-PLS-null-space-steps-table:
 
-.. list-table:: Cheese 2 and three points along its null space, all reaching the same target taste.
+.. list-table:: Cheese 2, and three points along its null space. All four rows predict a taste of 20.9.
 	:header-rows: 1
 	:widths: 22 12 10 10 10 10 10 16
 
@@ -235,8 +192,8 @@ the null space does and does not change.
 		- Lactic
 		- :math:`T^2`
 		- SPE
-		- Deviation from target
-	*	- Actual
+		- Input-space deviation
+	*	- Measured cheese
 		- 20.9
 		- 5.16
 		- 5.04
@@ -244,7 +201,7 @@ the null space does and does not change.
 		- 0.21
 		- 0.68
 		- 0.00
-	*	- Predicted at step -1
+	*	- Design, step -1
 		- 20.9
 		- 4.95
 		- 6.10
@@ -252,7 +209,7 @@ the null space does and does not change.
 		- 1.63
 		- 0.00
 		- 0.82
-	*	- Predicted at step 0
+	*	- Design, step 0
 		- 20.9
 		- 5.52
 		- 5.56
@@ -260,7 +217,7 @@ the null space does and does not change.
 		- 0.06
 		- 0.00
 		- 0.66
-	*	- Predicted at step +1
+	*	- Design, step +1
 		- 20.9
 		- 6.09
 		- 5.02
@@ -269,26 +226,36 @@ the null space does and does not change.
 		- 0.00
 		- 2.66
 
-Read down the three predicted rows and the inputs change substantially in order to keep the taste
-constant. Acetic acid increases from about 5 to 6, while that is compensated by hydrogen sulfide
-falling from 6.10 to 5.02, and lactic acid increases slightly, from 1.33 to 1.46. This same trade-off
-comes back when we reach :ref:`O-PLS <LVM-PLS-orthogonal-space>` below, where it appears directly as
-one of the model's axes. Every one of the three still reaches a taste of 20.9, and every one has an
-SPE of zero, since all three are rebuilt
-from scores and so lie on the model plane. What does change is :math:`T^2`. The step 0 row is the
-direct-inversion solution, the one of smallest score norm, and it has the smallest :math:`T^2` of
-the three, 0.06. Stepping out to either side moves the design away from the centre of the
-calibration data, to 1.63 and 2.44. The freedom along the null space is therefore free in terms of
-the predicted taste, but not in terms of how much support the data give the design.
+Read down the three designs and the inputs move substantially. Acetic acid climbs from about 5 to 6
+while hydrogen sulfide falls from 6.10 to 5.02, with lactic acid rising slightly. These are not small
+adjustments, and yet every one of the three still reaches a taste of 20.9. That is the practical
+content of the null space: if several recipes all hit the target, we are free to choose among them on
+grounds the model never saw, such as cost, supplier availability, or whichever raw material happens to
+be in the yard this week. This same trade-off comes back when we reach
+:ref:`O-PLS <LVM-PLS-orthogonal-space>` below, where it appears directly as one of the model's axes.
 
-The last column is the input-space deviation of each row from the cheese we are designing toward,
-computed the same way as before: centre and scale each input, then sum the squared differences. The
-Actual row is 0.00 because it is the target. Reading down the column, the step 0 design is the
-closest of the three at 0.66, the -1 step is a little further at 0.82, and the +1 step is furthest
-at 2.66. Since every one of those rows reaches the same predicted taste, the column says which of
-the equally valid designs comes nearest to a real cheese, which is a choice the null space leaves
-open. Sliding a little further in the -1 direction would do better still: the closest point on the
-line to this cheese sits near a step of -0.43, at a deviation of 0.46.
+Two columns need reading carefully. The SPE of exactly zero is a property of the arithmetic, not a
+claim about cheese: the inversion rebuilds the inputs from their scores, so the result lies on the
+model plane by construction. Every real cheese carries variation the two components miss, which is why
+the measured row shows 0.68. So a design is an idealised point on the plane. A cheese later made to
+that specification will land near the plane, not exactly on it, and its own SPE is what measures the
+gap.
+
+:math:`T^2` is the column that does change, and it measures how far each design sits from the centre of
+the calibration data. Step 0, the direct-inversion solution, has the smallest at 0.06; stepping either
+way moves the design outward, to 1.63 and 2.44. The freedom along the null space is free in terms of
+predicted taste, but not in terms of how much the data support the design. All rows sit well inside the
+99% limits of :math:`T^2 = 12.14` and :math:`\text{SPE} = 1.60`, which are the limits for a *new*
+observation rather than for one of the 26 that built the model: the right choice when judging a
+proposed design rather than summarising a calibration one.
+
+.. _LVM-PLS-input-space-deviation:
+
+One quantity is worth defining now, because it recurs. Comparing recipes in raw units is hard to read:
+a gap of 0.5 in hydrogen sulfide does not mean what a gap of 0.5 in lactic acid means. Centring and
+scaling each input puts them on a common footing where one unit is one standard deviation, and the sum
+of squared differences in those units is the *input-space deviation*. For cheese 2 against its design
+it is 0.66, so the held-out cheese sits about 0.8 standard deviations from the proposed recipe.
 
 A score plot shows the picture directly. The calibration cheeses are the points, the orange square
 is the direct-inversion solution, and the orange line is the null space: the set of scores that all
@@ -530,7 +497,8 @@ it was. That trade-off is what the diagonal line is recording.
 How well is that direction determined?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Every number quoted so far comes from one model fitted to 26 cheeses, and the direction of the null
+This is the caveat promised earlier. Every number quoted so far comes from one model fitted to 26
+cheeses, and the direction of the null
 space rests on the second :math:`y`-loading, :math:`q_2 = -0.262`. That component was the one
 cross-validation did not keep. It adds 3.0% to :math:`R^2Y`, against 64.3% for the first. It is worth
 asking how much of the geometry survives if the 26 cheeses had come out slightly differently.
@@ -578,7 +546,8 @@ more than 45 degrees away in 15% of the resamples.
 
 The direct-inversion solution itself holds up much better. Its 95% intervals are 5.24 to 5.74 for
 acetic acid, 4.97 to 6.26 for hydrogen sulfide, and 1.30 to 1.49 for lactic acid, each narrow next to
-the spread of the calibration cheeses. The reason for the difference is worth seeing: the solution
+the spread of the calibration cheeses, which run from 4.48 to 6.46 in acetic acid and from 3.00 to
+10.20 in hydrogen sulfide. The reason for the difference is worth seeing: the solution
 depends mostly on :math:`q_1`, which is estimated well, while the null-space direction depends on the
 ratio of :math:`q_1` to :math:`q_2`.
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -779,11 +779,9 @@ is one |X| here, not two blocks of data side by side:
 	\end{aligned}
 
 Here :math:`\mathbf{T}_\text{o}` and :math:`\mathbf{P}_\text{o}` carry one column per orthogonal
-component, and :math:`\mathbf{E}` and :math:`\mathbf{f}` hold what no component explains.
-
-The order O-PLS works in is not visible in that split, and it matters. The orthogonal score is formed
-first, from |X| itself. The predictive score is formed second, from what is left of |X| once the
-orthogonal piece has been removed, which is what allows it to absorb all of the taste information:
+component, and :math:`\mathbf{E}` and :math:`\mathbf{f}` hold what no component explains. What the split
+does not show is the order the pieces are found in. The orthogonal score comes first, from |X| itself,
+then the predictive score from what is left, which is what lets it absorb all of the taste information:
 
 .. math::
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -27,6 +27,8 @@ concentrations of acetic acid, hydrogen sulfide and lactic acid, and each was gi
 panel. The forward question was "what taste do these three measurements imply?" The inversion question
 is "which three measurements would give me a taste I have chosen?"
 
+.. _LVM-PLS-cheese-scatterplot:
+
 .. figure:: ../../figures/examples/cheese/cheese-plots-no-random.png
 	:alt: Scatterplot matrix of the cheddar-cheese data: acetic acid, hydrogen sulfide, lactic acid and taste
 	:width: 600px
@@ -350,7 +352,7 @@ a hill where you stay at exactly the same elevation (the output value) while you
 longitude change (a different set of inputs). So the null space is that contour line: the predicted
 taste stays the same even though you are at different coordinates in the score plot. Every parallel
 line in the score plot is another contour, for another target taste, which is why the three lines in
-the figure do not converge.
+the :ref:`score plot <LVM-PLS-null-space-figure>` do not converge.
 
 .. _LVM-PLS-null-space-geometry-figure:
 
@@ -461,7 +463,7 @@ along the null space costs.
 	blue markers are the rows tabulated earlier for steps of :math:`-1`, :math:`0` and :math:`+1`.
 
 Both curves are parabolas in :math:`s`, but they are not the same parabola. The orange one is
-:math:`\|\boldsymbol{\tau}_\text{DI}\|^2 + s^2` from the equation above, so its lowest point is exactly
+:math:`\|\boldsymbol{\tau}_\text{DI}\|^2 + s^2`, the Pythagoras result, so its lowest point is exactly
 the direct-inversion solution. The blue one is tilted, and reaches its lowest point at
 :math:`s = -0.103` instead. The two scores have standard deviations of 1.468 and 0.657, so :math:`t_2`
 counts for more in :math:`T^2` than in the plain norm, and the null-space direction
@@ -476,7 +478,7 @@ further.
 
 Two further points are worth making. First, the perpendicularity is a statement about the score
 coordinates, so it reads as a right angle on the page only when both axes are drawn to the same scale, as
-they are in the figure above but not in the earlier
+they are in the :ref:`contour figure <LVM-PLS-null-space-geometry-figure>` but not in the
 :ref:`score plot <LVM-PLS-null-space-figure>`, where the two scores have different spreads.
 Second, the same reasoning is what the code performs in general. For one response,
 ``null_space_basis`` comes from a singular value decomposition of the :math:`y`-loadings: the first left
@@ -489,9 +491,9 @@ Multiplying the direction by the |X|-loadings maps it back to the three measurem
 :math:`+1` moves acetic acid by :math:`+0.57`, hydrogen sulfide by :math:`-0.54`, and lactic acid by only
 :math:`+0.06`, in the original units. Moving along the null space therefore trades acetic acid up against
 hydrogen sulfide down, leaving lactic acid nearly alone. Both of those measurements rise with taste,
-correlating :math:`+0.55` and :math:`+0.76` across the thirty cheeses, as the scatterplot matrix at the
-start of this section reports, so raising one while lowering the other leaves the predicted taste where
-it was. That trade-off is what the diagonal line is recording.
+correlating :math:`+0.55` and :math:`+0.76` across the thirty cheeses, as the
+:ref:`scatterplot matrix <LVM-PLS-cheese-scatterplot>` reports, so raising one while lowering the other
+leaves the predicted taste where it was. That trade-off is what the diagonal line is recording.
 
 .. _LVM-PLS-null-space-uncertainty:
 
@@ -588,8 +590,8 @@ taste exists, and roughly where it sits, is supported by these data. Which direc
 without changing the prediction is not pinned down by 26 cheeses and a component that
 cross-validation set aside. The null space is exactly what the algebra says it is for a *given* model;
 what the algebra cannot supply is certainty that this model's second component points where the next
-26 cheeses would point it. The figures that follow quote three decimals because that is what the
-arithmetic returns, not because the data support that precision.
+26 cheeses would point it. The numbers in this section are quoted to three decimals because that is
+what the arithmetic returns, not because the data support that precision.
 
 None of this makes the geometry wrong or the method unusable. It sets the terms on which to use it: a
 design proposed at the direct-inversion solution rests on firmer ground than one reached by a long walk
@@ -615,7 +617,8 @@ For the first component of the cheese model those two vectors are close, but the
 
 .. _LVM-PLS-weight-loading-table:
 
-.. list-table:: The two vectors of the first PLS component, their difference, and what that difference becomes. Entries are in the mean-centred, unit-variance units the model works in.
+.. list-table:: The two vectors of the first PLS component, their difference, and what that
+	difference becomes. Entries are in the mean-centred, unit-variance units the model works in.
 	:header-rows: 1
 	:widths: 38 14 14 14 20
 
@@ -803,11 +806,11 @@ Substituting this cheese model's coefficients, with |X| centred and scaled:
 	\hat{\mathbf{y}} &= 0.571\, \mathbf{t}_\text{p}
 	\end{aligned}
 
-In the scaled units the model works in, the predictive piece carries 68.7% of the sum of squares in |X|, the
-orthogonal piece 18.3%, and the residual 13.0%. Those percentages describe |X| alone. The first is not
-the share of the input variation that is about taste: most of it is the joint spread of three correlated
-measurements, which would be there whether or not taste had been recorded. How much of taste the model
-accounts for is the separate :math:`R^2` of 0.672.
+In the scaled units the model works in, the predictive piece carries 68.7% of the sum of squares in
+|X|, the orthogonal piece 18.3%, and the residual 13.0%. Those percentages describe |X| alone. The
+first is not the share of the input variation that is about taste: most of it is the joint spread of
+three correlated measurements, which would be there whether or not taste had been recorded. How much
+of taste the model accounts for is the separate :math:`R^2` of 0.672.
 
 The predictive loading closes the loop. In the PLS model the first weight and its loading sat 5.49
 degrees apart, and that gap was the starting point. The O-PLS pair,
@@ -959,7 +962,10 @@ deviation is a distance in the input space, measured between the two recipes the
 
 	print(pd.DataFrame(rows).round(2))
 
-.. list-table:: The four held-out cheeses. Each row compares the recipe the inversion proposes for that cheese's taste against the cheese as it was actually measured. The two :math:`T^2` columns are distances from the centre of the calibration data, one for each of those two points; the last column is the distance between the two points. The 99% limit on :math:`T^2` is 12.14.
+.. list-table:: The four held-out cheeses. Each row compares the recipe the inversion proposes for
+	that cheese's taste against the cheese as it was actually measured. The two :math:`T^2` columns are
+	distances from the centre of the calibration data, one for each of those two points; the last
+	column is the distance between the two points. The 99% limit on :math:`T^2` is 12.14.
 	:header-rows: 1
 	:widths: 12 14 22 22 30
 
@@ -989,11 +995,11 @@ deviation is a distance in the input space, measured between the two recipes the
 		- 0.94
 		- 1.57
 
-Reading down the :math:`T^2` of the design, the moderate tastes near the middle of the calibration range
-give designs with small :math:`T^2`, while the more extreme tastes push the design further from the data:
-asking for a
-taste of 47.9 gives the largest value, 4.82. A large :math:`T^2` does not make a design wrong, but it
-flags that the model is extrapolating and that the predicted taste rests on less support from the data.
+Reading down the :math:`T^2` of the design, the moderate tastes near the middle of the calibration
+range give designs with small :math:`T^2`, while the more extreme tastes push the design further from
+the data: asking for a taste of 47.9 gives the largest value, 4.82. A large :math:`T^2` does not make
+a design wrong, but it flags that the model is extrapolating and that the predicted taste rests on
+less support from the data.
 All four are well inside the 99% limit of 12.14.
 
 The input-space deviation compares each design with the cheese that actually had that taste. Cheese 2 is
@@ -1010,8 +1016,7 @@ how far apart the two recipes are, not how wrong either of them is.
 For a single response, then, PLS model inversion and O-PLS model inversion lead to the same set of
 designs. They differ in how they reach it: PLS inversion solves an underdetermined system and returns the
 minimum-norm point, while O-PLS inversion is a single division once the orthogonal space has been
-separated during fitting. The equivalence has been proved for one response; the multiple-response case
-remains open (García-Carrión et al., 2025).
+separated during fitting.
 
 .. _LVM-PLS-specification-regions:
 
@@ -1186,6 +1191,6 @@ García-Carrión et al. (2025).
   <https://literature.learnche.org/item/181/establishing-multivariate-specification-regions-for-incoming-raw-materials-using-projection-to-latent-structure-models-comparison-between-direct-mapping-and-model-inversion>`_",
   *Frontiers in Analytical Science*, **1** (2021): 729732.
 
-* S. García-Carrión, F. Sartori, J. Borràs-Ferrís, P. Facco, M. Barolo, and A. Ferrer, "On the equivalence
-  between null space and orthogonal space in latent variable regression modeling", *Journal of
-  Chemometrics*, 39 (2025): e70057, `doi:10.1002/cem.70057 <https://doi.org/10.1002/cem.70057>`_.
+* S. García-Carrión, F. Sartori, J. Borràs-Ferrís, P. Facco, M. Barolo, and A. Ferrer, "On the
+  equivalence between null space and orthogonal space in latent variable regression modeling",
+  *Journal of Chemometrics*, 39 (2025): e70057, `doi:10.1002/cem.70057 <https://doi.org/10.1002/cem.70057>`_.

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -907,9 +907,11 @@ representative points on it: PLS the point of smallest score norm, O-PLS the poi
 score is zero. Written as unit vectors in the inputs both bases come out as
 :math:`(0.948,\ -0.238,\ 0.211)`, with a cosine of 1.0 between them. This is what the green circles in
 the :ref:`score plot <LVM-PLS-null-space-figure>` show: the orthogonal space projected into the PLS
-score plot, lying on the orange null-space line. The two approaches differ in bookkeeping rather than in
-what they find. PLS solves for the freedom after the fact and hands it back as a null-space basis;
-O-PLS sets it aside during fitting and hands it back as a coordinate axis.
+score plot, lying on the orange null-space line.
+
+What neither method settles is which point on that line to build. Every design on it predicts the same
+taste, and the model has nothing further to say about them. Choosing between them means asking a
+different question: how far each one sits from the cheeses the model was built on.
 
 .. _LVM-PLS-inversion-in-practice:
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -62,8 +62,10 @@ and fit the model on the remaining twenty-six.
 	print(round(float(pls.r2_cumulative_.iloc[-1]), 3))   # R2 on Taste: 0.672
 
 The two-component model explains about 67% of the variation in Taste. It is a moderate predictor, which
-is fine for what follows: the null space is a property of the model's geometry, not of how accurately it
-predicts.
+is fine for what follows: the null space is a property of the model's geometry rather than of its
+predictive accuracy. That geometry is itself estimated from the same 26 cheeses, though, so it carries
+its own uncertainty. We return to
+:ref:`how well the direction is determined <LVM-PLS-null-space-uncertainty>` once it has been derived.
 
 .. _LVM-PLS-null-space:
 
@@ -92,7 +94,10 @@ predicts will give that taste.
 
 The prediction at the designed inputs is exactly 20.9, by construction. To judge whether that design
 is a reasonable one, compare it with the cheese we held out. For this model the 99% limits are
-:math:`T^2 = 12.14` and :math:`\text{SPE} = 1.60`.
+:math:`T^2 = 12.14` and :math:`\text{SPE} = 1.60`. These are the limits for a *new* observation rather
+than for one of the 26 used to fit the model, which is the right choice here: a proposed design is
+being judged against the model, not summarised by it. The distinction is small at this sample size,
+moving the :math:`T^2` limit from 11.69 to 12.14, and it grows smaller as :math:`N` grows.
 
 .. list-table:: Cheese 2: its measured inputs, and the inputs the inversion returns for taste 20.9.
 	:header-rows: 1
@@ -123,6 +128,13 @@ is a reasonable one, compare it with the cheese we held out. For this model the 
 Both rows sit well inside the SPE and :math:`T^2` limits, so neither is an extrapolation. The
 predicted inputs have an SPE of exactly zero, because the inversion rebuilds the inputs from their
 scores: the result lies on the model plane by construction, leaving no residual.
+
+That zero is a statement about the arithmetic, not a claim about cheese. Every real cheese carries some
+variation the two components do not describe, which is why the measured row has an SPE of 0.68 rather
+than zero. A design returned by inversion is an idealised point on the model plane, and any cheese
+actually made to it will land near the plane rather than on it. The useful reading of a zero SPE is
+therefore that the design is internally consistent with the model, not that it is more attainable than
+the cheeses the model was built from.
 
 .. _LVM-PLS-input-space-deviation:
 
@@ -489,6 +501,74 @@ hydrogen sulfide down, leaving lactic acid nearly alone. Both of those measureme
 this data set, with correlations of 0.56 and 0.77, so raising one while lowering the other leaves the
 predicted taste where it was. That trade-off is what the diagonal line is recording.
 
+.. _LVM-PLS-null-space-uncertainty:
+
+How well is that direction determined?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Every number quoted so far comes from one model fitted to 26 cheeses, and the direction of the null
+space rests on the second :math:`y`-loading, :math:`q_2 = -0.262`. That component was the one
+cross-validation did not keep. It adds 3.0% to :math:`R^2Y`, against 64.3% for the first. It is worth
+asking how much of the geometry survives if the 26 cheeses had come out slightly differently.
+
+Refitting the model on bootstrap resamples of the calibration set answers that directly.
+
+.. code-block:: python
+
+	rng = np.random.default_rng(0)
+	reference = np.array([0.948, -0.238, 0.211])         # the direction reported below
+	reference = reference / np.linalg.norm(reference)
+
+	q2, slopes, angles, designs = [], [], [], []
+	for _ in range(2000):
+	    sample = train.iloc[rng.integers(0, len(train), len(train))]
+	    boot = PLS(n_components=2).fit(sample[x_columns], sample[["Taste"]])
+	    q_b = boot.y_loadings_.to_numpy().ravel()
+	    q2.append(q_b[1])
+	    slopes.append(-q_b[0] / q_b[1])
+
+	    result_b = boot.invert(20.9)
+	    designs.append(result_b.x_new.to_numpy())
+	    d = result_b.null_space_basis.to_numpy().ravel() @ boot.x_loadings_.to_numpy().T
+	    d = d / np.linalg.norm(d)
+	    # A direction and its negative describe the same line, so compare without sign.
+	    angles.append(np.degrees(np.arccos(np.clip(abs(d @ reference), 0, 1))))
+
+	print(np.percentile(q2, [2.5, 97.5]).round(3))        # [-0.56   0.377]
+	print(round(float(np.mean(np.array(q2) > 0)), 3))     # 0.244, the share that change sign
+	print(np.percentile(slopes, [2.5, 97.5]).round(2))    # [-5.09  6.13]
+	print(np.percentile(angles, [50, 90, 95]).round(1))   # [20.6 54.4 68.3]
+	print(round(float(np.mean(np.array(angles) > 45)), 2))  # 0.15
+	print(np.percentile(designs, [2.5, 97.5], axis=0).round(2))
+	# [[5.24 4.97 1.3 ]
+	#  [5.74 6.26 1.49]]
+
+The direction is poorly determined. A 95% bootstrap interval for :math:`q_2` runs from
+:math:`-0.56` to :math:`+0.38`, so it straddles zero, and in 24% of the resamples it changes sign. The
+slope of the null-space line is a ratio with that near-zero quantity in the denominator, so its
+interval, :math:`-5.1` to :math:`+6.1`, is wide enough to be of little use. Read as a line in the
+inputs, the resampled null space sits a median of 21 degrees away from the direction reported here, and
+more than 45 degrees away in 15% of the resamples.
+
+The direct-inversion solution itself holds up much better. Its 95% intervals are 5.24 to 5.74 for
+acetic acid, 4.97 to 6.26 for hydrogen sulfide, and 1.30 to 1.49 for lactic acid, each narrow next to
+the spread of the calibration cheeses. The reason for the difference is worth seeing: the solution
+depends mostly on :math:`q_1`, which is estimated well, while the null-space direction depends on the
+ratio of :math:`q_1` to :math:`q_2`.
+
+So the two statements this section makes are not equally firm. That a set of inputs reaching a target
+taste exists, and roughly where it sits, is supported by these data. Which direction one may then walk
+without changing the prediction is not pinned down by 26 cheeses and a component that
+cross-validation set aside. The null space is exactly what the algebra says it is for a *given* model;
+what the algebra cannot supply is certainty that this model's second component points where the next
+26 cheeses would point it. The figures that follow quote three decimals because that is what the
+arithmetic returns, not because the data support that precision.
+
+None of this makes the geometry wrong or the method unusable. It sets the terms on which to use it: a
+design proposed at the direct-inversion solution rests on firmer ground than one reached by a long walk
+along the null space, and a walk of any length is worth repeating on a refitted model before it is
+acted on.
+
 .. _LVM-PLS-orthogonal-space:
 
 The same space, reached a different way: O-PLS
@@ -647,6 +727,12 @@ The vector :math:`\mathbf{t}_\text{p}` is the single predictive score, one value
 each orthogonal component asked for, while :math:`\mathbf{E}` and :math:`\mathbf{f}` hold what no
 component explains. For these cheeses, in the scaled units the model works in, the predictive piece
 carries 68.7% of the sum of squares in |X|, the orthogonal piece 18.3%, and the residual 13.0%.
+
+Those three percentages describe |X| alone. It would be a misreading to take the first as the share of
+the input variation that is about taste. The predictive component is the one that carries all of the
+taste information, but most of what it explains in |X| is simply the joint spread of three correlated
+measurements, which would be there whether or not taste had ever been recorded. How much of taste the
+model accounts for is a separate number, the :math:`R^2` of 0.672 quoted earlier.
 
 The predictive loading repays a second look, because it closes the loop on where this section started.
 In the PLS model the first weight and its loading sat 5.49 degrees apart, and that gap was the whole

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -1068,10 +1068,7 @@ Suppose a taste between 20 and 30 is acceptable.
 A cheese whose inputs fall in this region is predicted to have an acceptable taste. Note that these
 minima and maxima are the box that encloses the region, not the region itself. The region is a slanted
 band in the three inputs, so a lot may sit inside every one of the three ranges while still lying
-outside the band. Note also that the enclosing box reaches slightly past the observed range of acetic
-acid in the training cheeses (4.48 to 6.46). The :math:`T^2` limit bounds the joint distance from the
-centre of the model, not each measurement separately, so a corner of the region can sit a little
-outside the range of any one measurement.
+outside the band.
 
 Both the region and the box it is reported as can be drawn.
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -1044,14 +1044,14 @@ the past, then applied engineering judgement to pick a point in that window, suc
 or most energy-efficient one. Bounding by :math:`T^2` is a way of making "within the range of past
 operating conditions" a single, testable number.
 
-Suppose a taste between 20 and 40 is acceptable.
+Suppose a taste between 20 and 30 is acceptable.
 
 .. code-block:: python
 
 	t2_limit = pls.hotellings_t2_limit(0.95)
 
 	region = []
-	for target in np.linspace(20.0, 40.0, 5):        # the range of taste we accept
+	for target in np.linspace(20.0, 30.0, 5):        # the range of taste we accept
 	    for step in np.linspace(-6, 6, 2001):        # walk along that target's null space
 	        candidate = pls.invert(target, null_space_coordinates=[step])
 	        if candidate.hotellings_t2 <= t2_limit:
@@ -1062,15 +1062,54 @@ Suppose a taste between 20 and 40 is acceptable.
 	print(region.agg(["min", "max"]).round(2))
 	#      Acetic   H2S  Lactic
 	# min    4.35  4.44    1.25
-	# max    6.99  9.47    1.86
+	# max    6.80  8.04    1.68
 
 A cheese whose inputs fall in this region is predicted to have an acceptable taste. Note that these
-minima and maxima are the box that encloses the region, not the region itself: the region is a slanted
-band in the three inputs, and a lot may sit inside every one of the three ranges while
-still lying outside the band. Note also that the enclosing box reaches slightly past the observed range
-of acetic acid in the training cheeses (4.48 to 6.46). The :math:`T^2` limit bounds the joint distance
-from the centre of the model, not each measurement separately, so a corner of the region can sit a little
+minima and maxima are the box that encloses the region, not the region itself. The region is a slanted
+band in the three inputs, so a lot may sit inside every one of the three ranges while still lying
+outside the band. Note also that the enclosing box reaches slightly past the observed range of acetic
+acid in the training cheeses (4.48 to 6.46). The :math:`T^2` limit bounds the joint distance from the
+centre of the model, not each measurement separately, so a corner of the region can sit a little
 outside the range of any one measurement.
+
+Both the region and the box it is reported as can be drawn.
+
+.. code-block:: python
+
+	corners = np.array(np.meshgrid(*zip(region.min(), region.max()))).reshape(3, -1).T
+	corner_taste = pls.predict(pd.DataFrame(corners, columns=x_columns)).to_numpy().ravel()
+	print(np.sort(corner_taste).round(1))
+	# [11.7 15.9 19.7 23.9 26.  30.2 34.  38.2]
+
+	fig = go.Figure()
+	fig.add_scatter3d(x=region["Acetic"], y=region["H2S"], z=region["Lactic"],
+	                  mode="markers", marker={"size": 2, "color": "orange", "opacity": 0.3})
+	fig.add_scatter3d(x=corners[:, 0], y=corners[:, 1], z=corners[:, 2], mode="markers+text",
+	                  text=[f"{t:.0f}" for t in corner_taste], marker={"size": 5, "color": "darkred"})
+	fig.update_layout(scene={"xaxis_title": "Acetic", "yaxis_title": "H2S",
+	                         "zaxis_title": "Lactic"})
+	fig.show()
+
+.. _LVM-PLS-specification-region-figure:
+
+.. figure:: ../../figures/pls/pls-specification-region.png
+	:alt: The specification region in the score plot, and the same region inside the box of three ranges
+	:width: 720px
+	:align: center
+
+	Left: sweeping the target taste from 20 to 30 sweeps its null space across the score plot, and the
+	95% :math:`T^2` limit closes the region off along the other direction. Right: the same region in the
+	three inputs, with the box of three ranges drawn around it. The region is flat, because every point
+	on it is rebuilt from two scores, while the box is a solid. Each corner is labelled with the taste
+	it is predicted to have.
+
+The eight corners make the difference concrete. Every one of them satisfies all three ranges, since
+each coordinate is either the reported minimum or the reported maximum, and not one of them predicts an
+acceptable taste: they run from 11.7 to 38.2, against a window of 20 to 30. Three ranges are the
+smallest box that contains the region, and a box that contains a flat, slanted set is mostly not that
+set. This is why a multivariate specification is stated as a region rather than as a table of limits
+per input: the limits are a summary of the region, and reading them as though they were the
+specification accepts lots the model would reject.
 
 Inversion is not the only route to a specification region. The inputs can also be mapped directly into a
 region without inverting a model, an approach known as direct mapping. Paris and co-workers (2021)

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -498,9 +498,10 @@ Finally, it is worth asking what that direction means for the inputs, rather tha
 Multiplying the direction by the |X|-loadings maps it back to the three measurements, and a step of
 :math:`+1` moves acetic acid by :math:`+0.57`, hydrogen sulfide by :math:`-0.54`, and lactic acid by only
 :math:`+0.06`, in the original units. Moving along the null space therefore trades acetic acid up against
-hydrogen sulfide down, leaving lactic acid nearly alone. Both of those measurements rise with taste in
-this data set, with correlations of 0.56 and 0.77, so raising one while lowering the other leaves the
-predicted taste where it was. That trade-off is what the diagonal line is recording.
+hydrogen sulfide down, leaving lactic acid nearly alone. Both of those measurements rise with taste,
+correlating :math:`+0.55` and :math:`+0.76` across the thirty cheeses, as the scatterplot matrix at the
+start of this section reports, so raising one while lowering the other leaves the predicted taste where
+it was. That trade-off is what the diagonal line is recording.
 
 .. _LVM-PLS-null-space-uncertainty:
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -760,11 +760,11 @@ The consequence shows up in the scores, not the weights.
 		- 0.000
 
 Both models explain the same amount of taste; they differ in how many components it takes. PLS reaches
-an :math:`R^2` of 0.672 only with both: the first component gets to 0.642, and the second supplies the
+an :math:`R^2` of 0.672 with two: the first component gets to 0.642, and the second supplies the
 remaining 0.030, which is why it still correlates with taste rather than sitting at zero. The O-PLS
-predictive score reaches the same 0.672 on its own, since :math:`0.820^2 = 0.672`. Nothing has been
-created or lost, the same explained variance is packaged into one component instead of two, and that is
-what leaves the orthogonal score at exactly zero.
+predictive score reaches the same 0.672 on its own in one component, since :math:`0.820^2 = 0.672`.
+Nothing has been created or lost, the same explained variance is packaged into one O-PLS component
+instead of two.
 
 What O-PLS ends up with is a single |X| matrix split three ways, the pieces adding back up to |X|. There
 is one |X| here, not two blocks of data side by side:

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -1051,18 +1051,19 @@ Suppose a taste between 20 and 30 is acceptable.
 	t2_limit = pls.hotellings_t2_limit(0.95)
 
 	region = []
-	for target in np.linspace(20.0, 30.0, 41):       # the tastes we accept
-	    for step in np.linspace(-6, 6, 801):         # walk along that target's null space
+	for target in np.linspace(20.0, 30.0, 11):       # the tastes we accept
+	    for step in np.linspace(-2.5, 2.5, 50):      # walk along that target's null space
 	        candidate = pls.invert(target, null_space_coordinates=[step])
 	        if candidate.hotellings_t2 <= t2_limit:
 	            region.append(candidate.x_new)
 
 	region = pd.DataFrame(region)
 	print(round(t2_limit, 2))                        # 7.36
+	print(len(region))                               # 415 of the 550 inversions are kept
 	print(region.agg(["min", "max"]).round(2))
 	#      Acetic   H2S  Lactic
-	# min    4.35  4.44    1.25
-	# max    6.80  8.04    1.68
+	# min    4.38  4.44    1.25
+	# max    6.78  7.99    1.68
 
 A cheese whose inputs fall in this region is predicted to have an acceptable taste. Note that these
 minima and maxima are the box that encloses the region, not the region itself. The region is a slanted
@@ -1077,15 +1078,22 @@ Both the region and the box it is reported as can be drawn.
 .. code-block:: python
 
 	corners = np.array(np.meshgrid(*zip(region.min(), region.max()))).reshape(3, -1).T
-	corner_taste = pls.predict(pd.DataFrame(corners, columns=x_columns)).to_numpy().ravel()
-	print(np.sort(corner_taste).round(1))
-	# [11.7 15.9 19.7 23.9 26.  30.2 34.  38.2]
+	corner_frame = pd.DataFrame(corners, columns=x_columns)
+	corner_taste = pls.predict(corner_frame).to_numpy().ravel()
+	corner_t2 = pls.diagnose(corner_frame).hotellings_t2.to_numpy()
+
+	for taste, t2 in sorted(zip(corner_taste.round(1), corner_t2.round(1))):
+	    print(taste, t2)
+	# 11.9 3.9    15.9 10.7    19.8 3.2    23.8 10.5
+	# 26.0 10.3   30.0 3.4     33.9 10.8   37.9 4.4
 
 	fig = go.Figure()
 	fig.add_scatter3d(x=region["Acetic"], y=region["H2S"], z=region["Lactic"],
 	                  mode="markers", marker={"size": 2, "color": "orange", "opacity": 0.3})
 	fig.add_scatter3d(x=corners[:, 0], y=corners[:, 1], z=corners[:, 2], mode="markers+text",
-	                  text=[f"{t:.0f}" for t in corner_taste], marker={"size": 5, "color": "darkred"})
+	                  text=[f"{t:.0f}" for t in corner_taste],
+	                  marker={"size": 5, "color": np.where(
+	                      (corner_taste >= 20) & (corner_taste <= 30), "steelblue", "darkred")})
 	fig.update_layout(scene={"xaxis_title": "Acetic", "yaxis_title": "H2S",
 	                         "zaxis_title": "Lactic"})
 	fig.show()
@@ -1097,19 +1105,29 @@ Both the region and the box it is reported as can be drawn.
 	:width: 720px
 	:align: center
 
-	Left: sweeping the target taste from 20 to 30 sweeps its null space across the score plot, and the
-	95% :math:`T^2` limit closes the region off along the other direction. Right: the same region in the
-	three inputs, with the box of three ranges drawn around it. The region is flat, because every point
-	on it is rebuilt from two scores, while the box is a solid. Each corner is labelled with the taste
-	it is predicted to have.
+	Left: eleven acceptable tastes, each inverted at fifty points along its own null space, so the
+	swept lines fill out the region. The 95% :math:`T^2` limit closes it off along the other direction.
+	Right: the same region in the three inputs, with the box of three ranges drawn around it. The region
+	is flat, because every point on it is rebuilt from two scores, while the box is a solid.
+
+	Five points are marked in both panels with the same shape and colour, so a location in the score
+	plot can be followed to the recipe it stands for: the four corners of the region, where the outer
+	null spaces meet the :math:`T^2` limit, and its centre, the direct-inversion solution for a taste of
+	25. Each corner of the box carries the taste it is predicted to have, dark red where that taste is
+	outside the window and blue where it is acceptable but the recipe lies beyond the :math:`T^2` limit.
 
 The eight corners make the difference concrete. Every one of them satisfies all three ranges, since
-each coordinate is either the reported minimum or the reported maximum, and not one of them predicts an
-acceptable taste: they run from 11.7 to 38.2, against a window of 20 to 30. Three ranges are the
-smallest box that contains the region, and a box that contains a flat, slanted set is mostly not that
-set. This is why a multivariate specification is stated as a region rather than as a table of limits
-per input: the limits are a summary of the region, and reading them as though they were the
-specification accepts lots the model would reject.
+each coordinate is either the reported minimum or the reported maximum, and not one of them is an
+acceptable lot. They fail in two different ways. Six predict a taste outside the window, running from
+11.9 at one corner to 37.9 at another. The other two predict a taste that would be perfectly
+acceptable, 23.8 and 26.0, but they sit at :math:`T^2` values of 10.5 and 10.3 against a limit of
+7.36. A recipe that far from the centre of the calibration data is an extrapolation, and the model
+carries no evidence about what it would really taste like.
+
+Three ranges are the smallest box that contains the region, and a box that contains a flat, slanted set
+is mostly not that set. This is why a multivariate specification is stated as a region rather than as a
+table of limits per input: the limits are a summary of the region, and reading them as though they were
+the specification accepts lots the model would reject.
 
 Inversion is not the only route to a specification region. The inputs can also be mapped directly into a
 region without inverting a model, an approach known as direct mapping. Paris and co-workers (2021)

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -495,65 +495,98 @@ The same space, reached a different way: O-PLS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Orthogonal projections to latent structures (O-PLS) was developed in a separate line of work, for a
-different reason: to make a model easier to interpret. O-PLS splits the systematic variation in |X| into
-two parts. One *predictive* component carries the variation that is related to |Y|; the remaining
-*Y-orthogonal* components carry systematic variation in |X| that has no bearing on |Y|.
+different reason: to make a model easier to interpret. What it does is quickest to see by starting
+from the PLS model already fitted here, and taking one step at a time.
 
-It is worth writing that split out, because there is a single |X| matrix here, not two blocks of data
-sitting side by side. O-PLS writes that one matrix as a predictive piece plus an orthogonal piece plus a
-residual, and the three pieces add back up to |X|:
+Start with a single PLS component, which carries two vectors rather than one. The weight
+:math:`\mathbf{w}_1` is the direction we choose to look along, picked so that the score it produces
+lines up with the response. The loading :math:`\mathbf{p}_1` is what we find afterwards: regress the
+inputs back onto that score, and the loading records how strongly each input moved with it. The weight
+is an instruction, the loading is a measurement.
+
+For the first component of the cheese model those two vectors are close, but they are not the same.
+
+.. _LVM-PLS-weight-loading-table:
+
+.. list-table:: The two vectors of the first PLS component, their difference, and what that difference becomes. Entries are in the mean-centred, unit-variance units the model works in.
+	:header-rows: 1
+	:widths: 38 14 14 14 20
+
+	*	- Vector
+		- Acetic
+		- H2S
+		- Lactic
+		- Angle to :math:`\mathbf{w}_1`, in degrees
+	*	- Weight :math:`\mathbf{w}_1`
+		- 0.474
+		- 0.657
+		- 0.586
+		- 0
+	*	- Loading :math:`\mathbf{p}_1`
+		- 0.552
+		- 0.600
+		- 0.587
+		- 5.49
+	*	- Difference :math:`\mathbf{p}_1 - \mathbf{w}_1`
+		- 0.078
+		- -0.057
+		- 0.001
+		- 90
+	*	- That difference, scaled to unit length
+		- 0.808
+		- -0.590
+		- 0.008
+		- 90
+
+Why should they differ at all? The weight was aimed at taste. The score it produces, though, carries
+along whatever else happens to vary in that same pattern across the cheeses, and the loading records
+all of it. The difference between the loading and the weight is therefore the part of the variation
+that travelled with the score without being about taste.
+
+That difference is simpler to write down than it looks. For every PLS component the weight and its own
+loading satisfy :math:`\mathbf{w}_a^T \mathbf{p}_a = 1`, which follows by substituting
+:math:`\mathbf{p}_a = \mathbf{X}^T \mathbf{t}_a / (\mathbf{t}_a^T \mathbf{t}_a)` and
+:math:`\mathbf{t}_a = \mathbf{X} \mathbf{w}_a` and cancelling. Taking away from the loading the part
+of it that lies along the weight therefore leaves a plain subtraction, and what is left is exactly
+perpendicular to the weight:
 
 .. math::
 
-	\begin{aligned}
-	\mathbf{X} &= \underbrace{\mathbf{t}_\text{p} \mathbf{p}_\text{p}^T}_{\text{predictive}}
-	  \,+\, \underbrace{\mathbf{T}_\text{o} \mathbf{P}_\text{o}^T}_{Y\text{-orthogonal}}
-	  \,+\, \underbrace{\mathbf{E}}_{\text{residual}} \\
-	\mathbf{y} &= q_\text{p}\, \mathbf{t}_\text{p} + \mathbf{f}
-	\end{aligned}
+	\left(\mathbf{p}_1 - \mathbf{w}_1\right)^T \mathbf{w}_1
+	  = \mathbf{p}_1^T \mathbf{w}_1 - \mathbf{w}_1^T \mathbf{w}_1 = 1 - 1 = 0
 
-The vector :math:`\mathbf{t}_\text{p}` is the single predictive score, one value per observation, and
-:math:`\mathbf{p}_\text{p}` is its loading, one value per input. :math:`\mathbf{T}_\text{o}` and
-:math:`\mathbf{P}_\text{o}` are the matching orthogonal scores and loadings, carrying one column for
-each orthogonal component asked for, while :math:`\mathbf{E}` and :math:`\mathbf{f}` hold what no
-component explains. For these cheeses, in the scaled units the model works in, the predictive piece
-carries 68.7% of the sum of squares in |X|, the orthogonal piece 18.3%, and the residual 13.0%.
+That perpendicular difference is the orthogonal direction. The orthogonal direction is simply the
+amount by which the first PLS loading misses the first PLS weight. For these cheeses the difference is
+:math:`(0.078, -0.057, 0.001)`, which scaled to unit length is :math:`(0.808, -0.590, 0.008)`. Nothing
+was searched for or optimised to get it: it is a subtraction between two vectors the PLS model had
+already produced.
 
-The equation for |Y|, the second of the two lines given for the decomposition, is where O-PLS parts
-company with PLS. Only :math:`\mathbf{t}_\text{p}` appears in it:
-the orthogonal scores :math:`\mathbf{T}_\text{o}` are absent, so movement in the orthogonal piece
-cannot change the predicted taste, however large that piece is. Filtering out the orthogonal part
-leaves a model with the same predictions as ordinary PLS, but with the response-relevant variation
-gathered into a single component.
+O-PLS is what follows from taking that direction seriously. Instead of leaving the non-taste variation
+mixed into the first component, it removes that direction from |X| first, and computes the predictive
+component afterwards, on what is left.
 
-It is worth being concrete about how that split is built, because it explains everything that follows.
-O-PLS works in the same two-dimensional plane the PLS model already found, and, as we will see below,
-along the same two directions within it. The first of those directions points along the variation in the inputs
-that tracks taste. The fitted model reports it as ``opls.predictive_weights_``, one entry per input,
-and for these cheeses that direction is
+The fitted model reports the two directions as ``opls.predictive_weights_`` and
+``opls.orthogonal_weights_``, the second carrying one column per orthogonal component asked for. Here
+that is one column, and the two directions are
 
 .. math::
 
 	\mathbf{w}_\text{p} = (0.474,\ 0.657,\ 0.586)
-	\qquad \text{for (acetic, hydrogen sulfide, lactic)}
-
-The entries are in the mean-centred, unit-variance units the model works in, so they can be compared
-with each other directly. All three are positive and of similar size, which is the raw-data picture
-restated: the three inputs rise together, and each rises with taste. The second direction takes what is
-left of the plane once that predictive direction has been removed, reported as
-``opls.orthogonal_weights_``, one column per orthogonal component. Here there is one column, the
-orthogonal weight
-
-.. math::
-
+	\qquad
 	\mathbf{w}_\text{o} = (0.808,\ -0.590,\ 0.008)
 
-Read that as a recipe: raise acetic acid, lower hydrogen sulfide, and leave lactic acid essentially
-untouched. It is the same trade-off the null space described, arrived at without ever inverting anything,
-and the same one the :ref:`table of null-space steps <LVM-PLS-null-space-steps-table>` set out in the
-original units.
-The defining property is that this second axis carries no taste information at all. Its score is
-uncorrelated with the response, exactly, while the predictive score is strongly correlated with it.
+for (acetic, hydrogen sulfide, lactic). The predictive weight is the first PLS weight, unchanged, and
+the orthogonal weight is the difference just computed. All three entries of
+:math:`\mathbf{w}_\text{p}` are positive and of similar size, which is the raw-data picture restated:
+the three inputs rise together, and each rises with taste.
+
+Read :math:`\mathbf{w}_\text{o}` as a recipe: raise acetic acid, lower hydrogen sulfide, and leave
+lactic acid essentially untouched. It is the same trade-off the null space described, arrived at
+without ever inverting anything, and the same one the
+:ref:`table of null-space steps <LVM-PLS-null-space-steps-table>` set out in the original units.
+The defining property of this second direction is that it carries no taste information at all. Its
+score is uncorrelated with the response, exactly, while the predictive score is strongly correlated
+with it.
 
 .. code-block:: python
 
@@ -561,6 +594,9 @@ uncorrelated with the response, exactly, while the predictive score is strongly 
 
 	print(opls.predictive_weights_.round(3).to_numpy())           # [0.474 0.657 0.586]
 	print(opls.orthogonal_weights_.round(3).to_numpy().ravel())   # [ 0.808 -0.59   0.008]
+
+	print(opls.predictive_loadings_.round(3).to_numpy())           # [0.472 0.654 0.591]
+	print(opls.orthogonal_loadings_.round(3).to_numpy().ravel())   # [ 1.044 -0.263  0.232]
 
 	print(pls.x_weights_.to_numpy().round(3))    # the PLS weights, side by side
 	# [[ 0.474  0.808]
@@ -592,36 +628,53 @@ correlates with it at exactly zero. The PLS first score correlates with taste at
 predictive score at 0.820: the taste information that PLS left on its second component has been
 gathered onto the first.
 
-.. _LVM-PLS-opls-construction:
-
-That first correlation is exactly zero rather than merely small, and it is worth seeing why, because
-the orthogonality is built by construction rather than arrived at by fitting. O-PLS finds the two
-directions in three steps (Trygg and Wold, 2002).
-
-The predictive weight is read straight off the response,
-:math:`\mathbf{w}_\text{p} = \mathbf{X}^T \mathbf{y}` scaled to unit length. Each entry is the
-covariance between one input and taste. This direction is settled before anything else happens, and
-it is never revised.
-
-The orthogonal weight is then built to be perpendicular to it. Projecting the data onto
-:math:`\mathbf{w}_\text{p}` gives a score :math:`\mathbf{t}`, and regressing |X| back onto that score
-gives a loading :math:`\mathbf{p}`. The loading is not the same vector as the weight: it collects
-everything that varies together with :math:`\mathbf{t}`, including variation that has no bearing on
-taste. That difference is what O-PLS separates out, by subtracting from the loading its component
-along the predictive weight:
+Written out, what O-PLS ends up with is a single |X| matrix split into a predictive piece, an
+orthogonal piece and a residual, the three adding back up to |X|. There is one |X| matrix here, not
+two blocks of data sitting side by side:
 
 .. math::
 
-	\mathbf{w}_\text{o} = \mathbf{p} - \left(\mathbf{w}_\text{p}^T \mathbf{p}\right) \mathbf{w}_\text{p}
+	\begin{aligned}
+	\mathbf{X} &= \underbrace{\mathbf{t}_\text{p} \mathbf{p}_\text{p}^T}_{\text{predictive}}
+	  \,+\, \underbrace{\mathbf{T}_\text{o} \mathbf{P}_\text{o}^T}_{Y\text{-orthogonal}}
+	  \,+\, \underbrace{\mathbf{E}}_{\text{residual}} \\
+	\mathbf{y} &= q_\text{p}\, \mathbf{t}_\text{p} + \mathbf{f}
+	\end{aligned}
 
-Finally the component this new weight defines is removed from |X|, and the previous step repeats for
-as many orthogonal components as were requested. The predictive component is computed last, on what
-is left.
+The vector :math:`\mathbf{t}_\text{p}` is the single predictive score, one value per observation, and
+:math:`\mathbf{p}_\text{p}` is its loading, one value per input. :math:`\mathbf{T}_\text{o}` and
+:math:`\mathbf{P}_\text{o}` are the matching orthogonal scores and loadings, carrying one column for
+each orthogonal component asked for, while :math:`\mathbf{E}` and :math:`\mathbf{f}` hold what no
+component explains. For these cheeses, in the scaled units the model works in, the predictive piece
+carries 68.7% of the sum of squares in |X|, the orthogonal piece 18.3%, and the residual 13.0%.
 
-Nothing there searches for orthogonality. The subtraction removes the predictive part of the loading,
-so :math:`\mathbf{w}_\text{o}` is perpendicular to :math:`\mathbf{w}_\text{p}` as a matter of algebra.
-The zero correlation then follows in one line, because the predictive weight was defined from the
-response in the first place:
+The predictive loading repays a second look, because it closes the loop on where this section started.
+In the PLS model the first weight and its loading sat 5.49 degrees apart, and that gap was the whole
+starting point. In the O-PLS model the corresponding pair,
+:math:`\mathbf{w}_\text{p} = (0.474, 0.657, 0.586)` and
+:math:`\mathbf{p}_\text{p} = (0.472, 0.654, 0.591)`, sit 0.31 degrees apart. Once the orthogonal
+variation has been taken out of |X| there is almost nothing left for the loading to drift towards, so
+the direction we look along and the direction we find have very nearly converged. That is the
+interpretability O-PLS was built to deliver.
+
+The equation for |Y|, the second of the two lines just given, is where O-PLS parts company with PLS.
+Only :math:`\mathbf{t}_\text{p}` appears in it: the orthogonal scores :math:`\mathbf{T}_\text{o}` are
+absent, so movement in the orthogonal piece cannot change the predicted taste, however large that
+piece is. Filtering out the orthogonal part leaves a model with the same predictions as ordinary PLS,
+but with the response-relevant variation gathered into a single component.
+
+.. _LVM-PLS-opls-construction:
+
+That first correlation is exactly zero rather than merely small, and it is worth seeing why, because
+the orthogonality holds by algebra rather than by fitting. One more fact about the construction is
+needed. The predictive weight is read straight off the response,
+:math:`\mathbf{w}_\text{p} = \mathbf{X}^T \mathbf{y}` scaled to unit length, so each entry is the
+covariance between one input and taste (Trygg and Wold, 2002). That direction is settled before
+anything else happens, and it is never revised.
+
+The subtraction that produced :math:`\mathbf{w}_\text{o}` already guarantees it is perpendicular to
+:math:`\mathbf{w}_\text{p}`. The zero correlation then follows in one line, because the predictive
+weight was defined from the response in the first place:
 
 .. math::
 
@@ -634,7 +687,10 @@ observations. The argument survives the removal step as well: what is taken out 
 :math:`\mathbf{t}_\text{o} \mathbf{p}_\text{o}^T`, which changes :math:`\mathbf{X}^T\mathbf{y}` by
 :math:`\mathbf{p}_\text{o}\left(\mathbf{t}_\text{o}^T \mathbf{y}\right)`, and that is zero by the line
 just given. The quantity the predictive weight was built from is therefore untouched, so the same
-reasoning applies at every subsequent orthogonal component.
+reasoning applies at every subsequent orthogonal component. The plain subtraction carries over too:
+the score at each round is formed as :math:`\mathbf{X}\mathbf{w}_\text{p}` on whatever is left of
+|X|, so :math:`\mathbf{w}_\text{p}^T \mathbf{p} = 1` holds every time, and the orthogonal weight is
+always the amount by which that round's loading misses :math:`\mathbf{w}_\text{p}`.
 
 That is the whole difference between the two models, and it shows up in the :math:`y`-loadings. The PLS
 model spread the response across both of its components, :math:`\mathbf{q} = (0.546, -0.262)`, so

--- a/tools/sync_proof_artifact.py
+++ b/tools/sync_proof_artifact.py
@@ -17,12 +17,18 @@ Output defaults to ``_build/proof/<basename>.html``.
 from __future__ import annotations
 
 import base64
+import html as htmllib
+import json
 import mimetypes
+import os
 import re
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
 BUILD = Path(__file__).resolve().parent.parent / "_build" / "html"
+TEX2SVG = Path(__file__).resolve().parent / "tex2svg.mjs"
 
 # Reading styles for the standalone page. Deliberately close to the book's own
 # proportions so that line breaks and paragraph rhythm proofread the same way.
@@ -77,6 +83,10 @@ th:first-child,td:first-child{text-align:left}
 thead th{background:var(--raised);font-weight:600;color:var(--blue)}
 .headerlink{display:none}
 :focus-visible{outline:2px solid var(--amber);outline-offset:2px}
+mjx-container{color:var(--ink)}
+mjx-container[display="true"]{display:block;margin:1.3rem 0;text-align:center;
+  overflow-x:auto;overflow-y:hidden;padding:.2rem 0}
+mjx-container svg{max-width:none}
 """
 
 # Theme furniture that carries no prose: strip it so the page reads as an article.
@@ -112,6 +122,64 @@ def inline_images(html: str, page: Path) -> tuple[str, int]:
     return html, count
 
 
+#: Sphinx with ``sphinx.ext.mathjax`` leaves the TeX in place for the browser to
+#: render. ``\(...\)`` marks inline math, ``\[...\]`` display math.
+MATH_PATTERN = re.compile(
+    r'<(span|div) class="math[^"]*"[^>]*>\s*\\([(\[])(.*?)\\[)\]]\s*</\1>',
+    re.S,
+)
+
+
+def render_math(body: str) -> tuple[str, int, int]:
+    """Replace every MathJax placeholder with SVG rendered ahead of time.
+
+    Returns the body, how many expressions were rendered, and how many were left
+    as source because they did not parse. If node or the ``mathjax-full`` package
+    is missing, every expression is left alone and the page still builds.
+    """
+    matches = list(MATH_PATTERN.finditer(body))
+    if not matches:
+        return body, 0, 0
+
+    node = shutil.which("node")
+    mathjax_dir = os.environ.get("MATHJAX_DIR", str(TEX2SVG.parent))
+    if node is None or not Path(mathjax_dir, "node_modules", "mathjax-full").is_dir():
+        print(
+            "  note: node or mathjax-full not found, leaving math as TeX source.\n"
+            "        npm install mathjax-full, then set MATHJAX_DIR to its parent.",
+            file=sys.stderr,
+        )
+        return body, 0, len(matches)
+
+    payload = [
+        {"tex": htmllib.unescape(m.group(3)), "display": m.group(2) == "["}
+        for m in matches
+    ]
+    result = subprocess.run(  # noqa: S603
+        [node, str(TEX2SVG)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=True,
+        env={**os.environ, "MATHJAX_DIR": mathjax_dir},
+    )
+    svgs = json.loads(result.stdout)
+
+    rendered = failed = 0
+    pieces, cursor = [], 0
+    for match, svg in zip(matches, svgs):
+        pieces.append(body[cursor : match.start()])
+        if svg:
+            pieces.append(svg)
+            rendered += 1
+        else:
+            pieces.append(match.group(0))
+            failed += 1
+        cursor = match.end()
+    pieces.append(body[cursor:])
+    return "".join(pieces), rendered, failed
+
+
 def extract_article(html: str) -> str:
     """Return the ``<article class="bd-article">`` body, without its wrapper tag."""
     start = html.find('<article class="bd-article">')
@@ -132,6 +200,8 @@ def scrub(body: str) -> str:
     """Drop the logo/PDF badge images and the anchor-link pilcrows."""
     body = re.sub(r'<a class="headerlink".*?</a>', "", body, flags=re.S)
     body = re.sub(r"<img[^>]*(textbook-logo|Document-pdf)[^>]*>", "", body)
+    # Sphinx links each figure to the full-size file, which is not carried over.
+    body = re.sub(r'<a[^>]*href="[^"]*_images/[^"]*"[^>]*>(.*?)</a>', r"\1", body, flags=re.S)
     return re.sub(r"<p>\s*</p>", "", body)
 
 
@@ -148,6 +218,7 @@ def main() -> None:
     raw = page.read_text(encoding="utf-8")
     body = scrub(extract_article(raw))
     body, n_images = inline_images(body, page)
+    body, n_math, n_math_failed = render_math(body)
 
     title_match = re.search(r"<title>(.*?)</title>", raw, re.S)
     title = title_match.group(1).split("&#8212;")[0].strip() if title_match else docname
@@ -164,7 +235,11 @@ def main() -> None:
         f"{body}\n</div>\n",
         encoding="utf-8",
     )
-    print(f"wrote {out} ({out.stat().st_size / 1024:.0f} KB, {n_images} images inlined)")
+    note = f", {n_math_failed} left as source" if n_math_failed else ""
+    print(
+        f"wrote {out} ({out.stat().st_size / 1024:.0f} KB, "
+        f"{n_images} images inlined, {n_math} equations rendered{note})"
+    )
 
 
 if __name__ == "__main__":

--- a/tools/sync_proof_artifact.py
+++ b/tools/sync_proof_artifact.py
@@ -1,0 +1,171 @@
+"""Render one built book page into a single self-contained HTML file for proofreading.
+
+The page is taken from ``_build/html``, so whatever this produces is exactly what
+Sphinx produced from the RST: there is no second copy of the prose to drift out of
+step. Images are inlined as data URIs and the theme chrome (navigation, sidebars,
+search) is dropped, leaving the article body on a plain reading page.
+
+Run ``make html`` first, then::
+
+    python tools/sync_proof_artifact.py <docname> [output.html]
+
+``docname`` is the path under ``_build/html`` without any extension, for example
+``latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space``.
+Output defaults to ``_build/proof/<basename>.html``.
+"""
+
+from __future__ import annotations
+
+import base64
+import mimetypes
+import re
+import sys
+from pathlib import Path
+
+BUILD = Path(__file__).resolve().parent.parent / "_build" / "html"
+
+# Reading styles for the standalone page. Deliberately close to the book's own
+# proportions so that line breaks and paragraph rhythm proofread the same way.
+STYLE = """
+:root{
+  --blue:#1f3d7a; --amber:#e6820a; --maroon:#7b1d2b;
+  --paper:#fcfcfd; --raised:#f2f4f8; --ink:#12151c; --muted:#5b6478; --rule:#d9dee7;
+  --code:#f3f5fa;
+  --serif:"Charter","Iowan Old Style","Palatino Linotype",Palatino,Georgia,serif;
+  --sans:"Avenir Next","Segoe UI",system-ui,-apple-system,sans-serif;
+  --mono:"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;
+}
+@media (prefers-color-scheme:dark){:root{
+  --paper:#0e1117; --raised:#171b24; --ink:#e4e7ee; --muted:#98a1b4; --rule:#2a303c;
+  --code:#151922; --blue:#8fb0ea; --amber:#f0a03c; --maroon:#e08496;}}
+:root[data-theme="dark"]{
+  --paper:#0e1117; --raised:#171b24; --ink:#e4e7ee; --muted:#98a1b4; --rule:#2a303c;
+  --code:#151922; --blue:#8fb0ea; --amber:#f0a03c; --maroon:#e08496;}
+:root[data-theme="light"]{
+  --paper:#fcfcfd; --raised:#f2f4f8; --ink:#12151c; --muted:#5b6478; --rule:#d9dee7;
+  --code:#f3f5fa; --blue:#1f3d7a; --amber:#e6820a; --maroon:#7b1d2b;}
+*{box-sizing:border-box}
+body{margin:0;background:var(--paper);color:var(--ink);font-family:var(--serif);
+     font-size:17.5px;line-height:1.62;-webkit-font-smoothing:antialiased}
+.wrap{max-width:52rem;margin:0 auto;padding:2.4rem 1.4rem 6rem}
+.banner{font-family:var(--sans);font-size:.72rem;letter-spacing:.12em;text-transform:uppercase;
+  color:var(--muted);font-weight:600;border-bottom:2px solid var(--rule);
+  padding-bottom:.8rem;margin-bottom:2rem}
+h1{font-size:2rem;line-height:1.18;font-weight:600;margin:0 0 1.2rem;text-wrap:balance}
+h2{font-size:1.32rem;font-weight:600;margin:2.6rem 0 .8rem;padding-top:1rem;
+   border-top:1px solid var(--rule);text-wrap:balance}
+h3{font-size:1.12rem;font-weight:600;margin:2rem 0 .6rem;color:var(--blue)}
+h4,h5{font-size:1rem;font-weight:600;margin:1.6rem 0 .5rem}
+p{margin:0 0 1rem}
+a{color:var(--blue)}
+figure{margin:1.8rem 0}
+img{max-width:100%;height:auto;display:block;border:1px solid var(--rule);
+    border-radius:4px;background:#fff}
+figcaption,.caption{font-family:var(--sans);font-size:.79rem;line-height:1.5;
+  color:var(--muted);margin-top:.6rem}
+pre{font-family:var(--mono);font-size:.8rem;line-height:1.55;background:var(--code);
+  border:1px solid var(--rule);border-radius:5px;padding:.85rem 1rem;overflow-x:auto;margin:1.2rem 0}
+code{font-family:var(--mono);font-size:.87em;background:var(--code);padding:.08em .3em;border-radius:3px}
+pre code{background:none;padding:0}
+.table-wrap,.table-responsive{overflow-x:auto}
+table{border-collapse:collapse;width:100%;font-family:var(--sans);font-size:.8rem;
+  font-variant-numeric:tabular-nums;margin:1.4rem 0}
+caption{font-family:var(--sans);font-size:.78rem;color:var(--muted);text-align:left;
+  padding:.7rem .2rem;line-height:1.45}
+th,td{padding:.45rem .8rem;text-align:right;border-bottom:1px solid var(--rule);white-space:nowrap}
+th:first-child,td:first-child{text-align:left}
+thead th{background:var(--raised);font-weight:600;color:var(--blue)}
+.headerlink{display:none}
+:focus-visible{outline:2px solid var(--amber);outline-offset:2px}
+"""
+
+# Theme furniture that carries no prose: strip it so the page reads as an article.
+DROP_SELECTORS = (
+    "sphinx-tabs",
+    "prev-next",
+    "bd-sidebar",
+    "bd-header",
+    "bd-footer",
+    "searchbox",
+    "toc-item",
+)
+
+
+def inline_images(html: str, page: Path) -> tuple[str, int]:
+    """Replace every ``src`` with a base64 data URI so the file stands alone."""
+    count = 0
+
+    def repl(match: re.Match[str]) -> str:
+        nonlocal count
+        src = match.group(2)
+        if src.startswith("data:"):
+            return match.group(0)
+        target = (page.parent / src).resolve()
+        if not target.is_file():
+            return match.group(0)
+        mime = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
+        payload = base64.b64encode(target.read_bytes()).decode("ascii")
+        count += 1
+        return f'{match.group(1)}"data:{mime};base64,{payload}"'
+
+    html = re.sub(r'(<img[^>]*\ssrc=)"([^"]+)"', repl, html)
+    return html, count
+
+
+def extract_article(html: str) -> str:
+    """Return the ``<article class="bd-article">`` body, without its wrapper tag."""
+    start = html.find('<article class="bd-article">')
+    if start == -1:
+        msg = "no <article class='bd-article'> found; did the theme change?"
+        raise SystemExit(msg)
+    open_len = len('<article class="bd-article">')
+    depth, i = 1, start + open_len
+    for match in re.finditer(r"</?article\b", html[start + open_len :]):
+        depth += 1 if match.group(0) == "<article" else -1
+        if depth == 0:
+            i = start + open_len + match.start()
+            break
+    return html[start + open_len : i]
+
+
+def scrub(body: str) -> str:
+    """Drop the logo/PDF badge images and the anchor-link pilcrows."""
+    body = re.sub(r'<a class="headerlink".*?</a>', "", body, flags=re.S)
+    body = re.sub(r"<img[^>]*(textbook-logo|Document-pdf)[^>]*>", "", body)
+    return re.sub(r"<p>\s*</p>", "", body)
+
+
+def main() -> None:
+    """Render the named docname into a self-contained proofreading page."""
+    if len(sys.argv) < 2:
+        raise SystemExit(__doc__)
+    docname = sys.argv[1].removesuffix(".html")
+    page = BUILD / docname
+    if not page.is_file():
+        msg = f"{page} not found; run `make html` first"
+        raise SystemExit(msg)
+
+    raw = page.read_text(encoding="utf-8")
+    body = scrub(extract_article(raw))
+    body, n_images = inline_images(body, page)
+
+    title_match = re.search(r"<title>(.*?)</title>", raw, re.S)
+    title = title_match.group(1).split("&#8212;")[0].strip() if title_match else docname
+
+    out = Path(sys.argv[2]) if len(sys.argv) > 2 else (
+        BUILD.parent / "proof" / f"{Path(docname).name}.html"
+    )
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(
+        f"<title>{title}</title>\n<style>{STYLE}</style>\n"
+        f'<div class="wrap">\n'
+        f'<div class="banner">Process Improvement using Data '
+        f"&middot; proof copy, generated from the Sphinx build</div>\n"
+        f"{body}\n</div>\n",
+        encoding="utf-8",
+    )
+    print(f"wrote {out} ({out.stat().st_size / 1024:.0f} KB, {n_images} images inlined)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/tex2svg.mjs
+++ b/tools/tex2svg.mjs
@@ -1,0 +1,57 @@
+/**
+ * Render a batch of TeX expressions to standalone SVG, for the proofreading page.
+ *
+ * The published proof copy is served under a policy that blocks every external
+ * request, so MathJax cannot run in the browser there and web fonts cannot load.
+ * Rendering here instead produces SVG built from glyph outlines, which needs
+ * neither.
+ *
+ * Reads JSON on stdin:  [{"tex": "...", "display": true|false}, ...]
+ * Writes JSON on stdout: ["<svg .../>", ...], in the same order. An expression
+ * that fails to parse comes back as null, so the caller can leave the original
+ * source in place rather than losing it.
+ *
+ * `mathjax-full` is resolved from MATHJAX_DIR (the directory containing
+ * node_modules), falling back to this script's own directory. ES modules
+ * resolve imports relative to the importing file rather than the working
+ * directory, so the location has to be given explicitly.
+ */
+
+import { pathToFileURL } from 'node:url'
+import { join } from 'node:path'
+
+const base = process.env.MATHJAX_DIR || import.meta.dirname
+const load = (p) => import(pathToFileURL(join(base, 'node_modules', 'mathjax-full', 'js', p)).href)
+
+const { mathjax } = await load('mathjax.js')
+const { TeX } = await load('input/tex.js')
+const { SVG } = await load('output/svg.js')
+const { liteAdaptor } = await load('adaptors/liteAdaptor.js')
+const { RegisterHTMLHandler } = await load('handlers/html.js')
+const { AllPackages } = await load('input/tex/AllPackages.js')
+
+const adaptor = liteAdaptor()
+RegisterHTMLHandler(adaptor)
+
+const doc = mathjax.document('', {
+  InputJax: new TeX({ packages: AllPackages }),
+  // fontCache 'local' keeps each SVG self-contained: glyph paths are defined
+  // inside the element rather than referenced from a shared document-level cache.
+  OutputJax: new SVG({ fontCache: 'local' }),
+})
+
+const chunks = []
+for await (const chunk of process.stdin) chunks.push(chunk)
+const items = JSON.parse(Buffer.concat(chunks).toString('utf8'))
+
+process.stdout.write(
+  JSON.stringify(
+    items.map(({ tex, display }) => {
+      try {
+        return adaptor.outerHTML(doc.convert(tex, { display: !!display }))
+      } catch {
+        return null
+      }
+    }),
+  ),
+)


### PR DESCRIPTION
Follow-up to #258 (merged), on the same PLS model-inversion page. This round answers three questions
the merged version raised but did not settle: why the direct-inversion solution is the minimum-norm
one, where O-PLS actually comes from, and how much of the geometry the data support.

**Merge order:** kgdunn/figures#73 must merge first. This page embeds `pls-null-space-distance.png`
and `pls-null-space-bootstrap.png`, and a missing figure only warns in the HTML build while being
fatal to `pdflatex`.

## New section: how well is the direction determined?

The page derived the null space, quoted its direction to three decimals and moved on. That direction
rests entirely on the second `y`-loading, which is the component cross-validation did not keep (it
adds 3.0% to R2Y, against 64.3% for the first). A bootstrap over 2000 refits of the 26 calibration
cheeses says:

| Quantity | Point estimate | 95% bootstrap interval |
|---|---|---|
| `q2` | -0.262 | [-0.56, +0.38], straddles zero, sign changes in 24% of resamples |
| Null-space slope | 2.08 | [-5.1, +6.1] |
| Direction in the inputs | (0.948, -0.238, 0.211) | median 21 degrees away, beyond 45 degrees in 15% |

The asymmetry is the useful part, and it is stated: the direct-inversion **point** holds up well
(acetic 5.24 to 5.74, hydrogen sulfide 4.97 to 6.26, lactic 1.30 to 1.49), because it leans on `q1`,
which is estimated well, while the **direction** leans on the ratio of `q1` to `q2`. So "a set of
inputs reaching this taste exists, and roughly where" is supported; "here is the line you may walk
along" is not pinned down by 26 cheeses. The code that produces every one of those numbers is in the
section.

A new figure shows that rather than only asserting it: all 2000 refits drawn as faint lines, so
overplotting turns the spread into a density. The fan pinches at the direct-inversion solution and
opens out from there, which puts the point-and-direction asymmetry in one picture. The second panel
is the same spread as an angle, compared without sign since a line and its reverse are the same line.

## Minimum norm, explained rather than asserted

The page said the perpendicular foot is the smallest-norm solution without saying why. Two steps were
missing: the score norm is the distance from the origin, and because the null-space step is at right
angles to the solution, Pythagoras gives `||tau_DI + s g||^2 = ||tau_DI||^2 + s^2`, so the norm grows
by `s^2` and is least when no step is taken.

The geometry figure now carries that argument in a second panel, enlarged from a dashed box on the
first, because the triangle is about one unit across while the contour family spans seven. The left
panel is otherwise unchanged.

A further figure plots the score norm alongside Hotelling's T2 over `s` from -2 to +2. They are
different parabolas: the norm is least exactly at `s = 0`, T2 at `s = -0.103`, because T2 divides each
score by its standard deviation first. That distinction says what direct inversion does and does not
give. The -1 and +1 steps are marked on it with the same orange triangles used in the two score plots,
so the same pair of designs can be followed across all three figures.

## O-PLS built up one step at a time

The section named the predictive and orthogonal directions and gave their values, but never said where
the orthogonal one comes from, so O-PLS read as a separate machine rather than something following from
the PLS model already fitted. It now starts from a single PLS component and the two vectors it carries:
the weight is the direction chosen to look along, the loading is what is found by regressing the inputs
back onto the resulting score. For this model they sit 5.49 degrees apart, and that gap is variation
that travelled with the score without being about taste.

Since `w'p = 1` holds for every PLS component, removing the predictive part of the loading is the plain
subtraction `p - w`, which is exactly perpendicular to `w`. Scaled to unit length that is the
orthogonal direction: **the amount by which the first PLS loading misses the first PLS weight.**

Two consequences are now stated and shown. The O-PLS weights *are* the PLS weights, the same numbers in
the same order, with regression coefficients agreeing to 1.4e-13; what differs is the order the
components are removed in, and therefore the scores. And once the orthogonal variation is stripped
first, the predictive weight and its loading end up 0.31 degrees apart rather than 5.49, which is the
interpretability O-PLS was built for.

## Smaller corrections

- A zero SPE on a design is a property of the arithmetic, not a claim that the design is attainable.
  A real cheese carries variation the two components do not describe, which is why the measured row
  has an SPE of 0.68.
- The 68.7% of `X` carried by the predictive component is not the share of the inputs that is about
  taste. Most of it is the joint spread of three correlated measurements.
- The Hotelling's T2 limits are the new-observation ones, which is the right choice for judging a
  proposed design. Named explicitly. An earlier revision of this branch compared them against a
  number that was not the Phase I limit; that comparison has been removed rather than corrected,
  since the three candidate limits differ by more than the point being made could carry.
- The two correlations quoted from the scatterplot matrix are the ones that figure prints (all 30
  cheeses), not the 26-cheese training values.
- The null-space direction `g` is now printed before it is tested against `q`.
- "The second line" now says which equation it means.
- Two output comments quoted trailing zeros Python does not print.

## Verification

All sixteen code blocks extracted and run end to end against the vendored CSVs; every quoted number
reproduces, including the whole bootstrap section from its stated seed. `make text` and `make html`
both exit 0 with zero Sphinx warnings, and `grep -r goatcounter _build/html/contents` returns zero.
The bootstrap generator in the figures repo uses the same 2000 refits and the same seed as the
chapter's own code block, so the figure and the prose report the same numbers.

Section numbering shifts: the new section becomes 6.7.11.4 and the four after it move down one. No
prose anywhere in the book hard-codes those numbers.

`CITATION.cff` version and date-released are 2026-07-27.

## Note for after merge

`docs/blog/orthogonal-space-and-model-inversion.md` (added in #258) is a working draft for a blog
post, not book content. Delete it once the post is published.

## Related

- Figures: kgdunn/figures#73 (merge first)
- Code: kgdunn/process-improve#470 (`PLS.invert`, `OPLS`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsTypY4FcRbrXRxorb9raz