### PR TITLE
Fix the PLS sign convention in the bootstrap, and tighten the inversion chapter

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.07.28"
-date-released: 2026-07-28
+version: "2026.07.29"
+date-released: 2026-07-29
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/docs/blog/orthogonal-space-and-model-inversion.md
+++ b/docs/blog/orthogonal-space-and-model-inversion.md
@@ -4,28 +4,32 @@
 
 # The part of the model you filter out
 
-Fit a PLS model and the write-up goes to the component that tracks the response. The rest, the
-systematic variation in the inputs that has nothing to do with the outcome, gets filtered away as a
-nuisance.
+Picture the prediction from your model as a hill standing over the space of inputs. Moving in some
+directions takes you uphill fast; moving in others barely changes your altitude at all. The steepest
+way up has a name in a PLS model: it is the vector of y-loadings.
 
-It is not a nuisance. And it has been discovered twice, by two communities solving two different
-problems.
+Now ask for a specific outcome. You are asking to stand at a specific height on that hill, and the
+set of points at one height is a contour line. Walk along the contour and your position changes while
+your altitude does not. Different inputs, same predicted result.
+
+That contour is the thing this post is about. It is real, it is useful, and in most write-ups it is
+the part that gets filtered out and called a nuisance.
 
 ## Run the model backwards
 
-Thirty cheddar cheeses, each measured for acetic acid, hydrogen sulfide and lactic acid, each given a
-taste score by a panel. The forward question is "what taste do these measurements imply?" The design
-question is the reverse: "which measurements would give me the taste I have chosen?" That is **model
-inversion**, and it goes back to Jaeckle and MacGregor (2000).
+The forward question is the ordinary one: given these measurements, what quality do we predict? The
+design question is the reverse: which measurements would give me the quality I have chosen? That is
+**model inversion**, and it goes back to Jaeckle and MacGregor (2000).
 
-The answer is not one recipe. It is a whole line of them, every one of which the model says will hit
-the target. Product designers call that line the **null space**.
+The answer is not one recipe. Fixing the target puts you on the contour, and every point on it is a
+recipe the model says will hit the target. Product designers call that line the **null space**.
 
-```python
-result = pls.invert(y_desired=20.9)
-result.x_new                 # {'Acetic': 5.52, 'H2S': 5.56, 'Lactic': 1.40}
-result.null_space_dimension  # 1, so this is one point on a line of answers
-```
+The algebra is one line. If a step in the scores leaves the prediction unchanged, then
+
+**q**ᵀ Δ**t** = 0
+
+The free directions are exactly the ones perpendicular to the gradient. Perpendicular to steepest
+ascent means along the contour, which is what the hill already told us.
 
 ## The same line, from the other side
 
@@ -34,14 +38,14 @@ the part that drives the response and the part that does not. That second piece 
 space**.
 
 García-Carrión and co-authors proved this year that, for a single response, the two are the same
-linear space. In the cheese model both come out as the same unit vector in the inputs,
-(0.948, -0.238, 0.211), with a cosine of 1.0 between them. One geometry, named twice.
+linear space. Inverting a PLS model and fitting an O-PLS model give the same direction, to numerical
+precision. One geometry, discovered twice by two communities solving two different problems.
 
 ## Why the leftover is worth having
 
-For these cheeses the orthogonal piece carries **18.3% of the variation in the inputs and contributes
-exactly nothing to the predicted taste**. Not a rounding error, and not noise: systematic variation
-with no effect on the outcome.
+In the cheddar-cheese example from the book, the orthogonal piece carries **18.3% of the variation in
+the inputs and contributes nothing at all to the predicted taste**. Not a rounding error, and not
+noise: systematic variation with no effect on the outcome.
 
 That buys two things.
 
@@ -51,21 +55,21 @@ you what you do not have to control tightly.
 **Alternatives.** Many recipes, one outcome. The freedom is yours to spend on cost, safety,
 availability, or anything else the model never saw.
 
-Widen the target from a point to a range and the line becomes a region: a multivariate specification.
-That is how you judge an incoming lot, transfer a product between sites, or state a design space.
+Widen the target from a point to a range and the contour sweeps out a region: a multivariate
+specification. That is how you judge an incoming lot, transfer a product between sites, or state a
+design space.
 
-One thing to watch. Report that region as one range per input and you have described a box, not the
-region. In the cheese example all eight corners of that box satisfy every one of the three ranges, and
-not one of them is an acceptable lot. Six predict a taste outside the window. The other two predict a
-perfectly good taste from a recipe far outside anything the data support.
+One thing to watch. Report that region as one acceptable range per input and you have described a
+box, not the region. The region is a thin slanted slice through that box. In the cheese example every
+single corner of the box satisfies all three ranges, and not one of them is a lot you would accept.
 
 ## The caveat that keeps it useful
 
-The direction of that line is estimated, and often poorly. Refitting the cheese model on bootstrap
-resamples, the null space sits a median of 21 degrees away from the reported direction, and beyond 45
-degrees in 15% of resamples. The inverted *point* holds up well. The *direction* does not.
+The direction of the contour is estimated, and often poorly. Refit the cheese model on bootstrap
+resamples and the null space typically lands about 20 degrees away from the direction the full data
+set reports. The inverted *point* holds up well. The *direction* does not.
 
-So design at the solution with reasonable confidence, and treat a long walk along the line as
+So design at the solution with reasonable confidence, and treat a long walk along the contour as
 something to re-check on a refitted model before acting on it.
 
 ## Try it

--- a/docs/blog/orthogonal-space-and-model-inversion.md
+++ b/docs/blog/orthogonal-space-and-model-inversion.md
@@ -2,222 +2,82 @@
 > It lives here only so the draft travels with the material it describes. Nothing in the Sphinx
 > build references it, and it is not meant to ship with the book.
 
-# The orthogonal space is as useful as the predictive space
+# The part of the model you filter out
 
-We build a model to predict an outcome from measurements. A latent variable model like PLS does that
-by compressing many correlated inputs into a few components, and the usual write-up spends all its
-attention on the component that tracks the response. The rest of the model, the systematic variation
-that has nothing to do with the response, gets filtered out and described as a nuisance.
+Fit a PLS model and the write-up goes to the component that tracks the response. The rest, the
+systematic variation in the inputs that has nothing to do with the outcome, gets filtered away as a
+nuisance.
 
-That leftover space has a use, and a name, and it turns out to have been discovered twice under two
-different names by two groups of people solving two different problems. This post is about what it
-is good for.
+It is not a nuisance. And it has been discovered twice, by two communities solving two different
+problems.
 
-## Running the model backwards
+## Run the model backwards
 
-Start with a small, old, well-worn data set: 30 cheddar cheeses, each with three measurements
-(acetic acid, hydrogen sulfide, lactic acid) and a taste score from a panel. The forward question is
-the ordinary one: given the three measurements, what taste do we predict?
+Thirty cheddar cheeses, each measured for acetic acid, hydrogen sulfide and lactic acid, each given a
+taste score by a panel. The forward question is "what taste do these measurements imply?" The design
+question is the reverse: "which measurements would give me the taste I have chosen?" That is **model
+inversion**, and it goes back to Jaeckle and MacGregor (2000).
 
-Many design problems ask the reverse. We fix the taste we want, and solve for the measurements that
-would produce it. That is called **model inversion**, and it is the basis of latent variable product
-and process design, going back to Jaeckle and MacGregor (2000).
-
-I hold out four cheeses, fit a two-component PLS model on the other 26, and invert it toward a taste
-of 20.9, which is what one of the held-out cheeses actually scored.
+The answer is not one recipe. It is a whole line of them, every one of which the model says will hit
+the target. Product designers call that line the **null space**.
 
 ```python
-pls = PLS(n_components=2).fit(X, Y)
 result = pls.invert(y_desired=20.9)
-
-print(result.x_new.round(2).to_dict())
-# {'Acetic': 5.52, 'H2S': 5.56, 'Lactic': 1.40}
-print(result.null_space_dimension)        # 1
+result.x_new                 # {'Acetic': 5.52, 'H2S': 5.56, 'Lactic': 1.40}
+result.null_space_dimension  # 1, so this is one point on a line of answers
 ```
 
-A recipe comes back. So far this is unremarkable.
+## The same line, from the other side
 
-The interesting part is the second line of output. The null space has dimension 1, which is the
-model telling us that this is not *the* answer. It is one point on a whole line of answers.
+O-PLS was built for an unrelated reason: to make a model easier to read, by splitting the inputs into
+the part that drives the response and the part that does not. That second piece is the **orthogonal
+space**.
 
-## Many recipes, one target
+García-Carrión and co-authors proved this year that, for a single response, the two are the same
+linear space. In the cheese model both come out as the same unit vector in the inputs,
+(0.948, -0.238, 0.211), with a cosine of 1.0 between them. One geometry, named twice.
 
-Two components, one response. The target fixes one direction in the score space and leaves the other
-free. Anything we do along that free direction changes the recipe without moving the prediction.
+## Why the leftover is worth having
 
-Stepping one unit either way along it:
+For these cheeses the orthogonal piece carries **18.3% of the variation in the inputs and contributes
+exactly nothing to the predicted taste**. Not a rounding error, and not noise: systematic variation
+with no effect on the outcome.
 
-| Row | Target taste | Acetic | H2S | Lactic | T² | SPE |
-|---|---|---|---|---|---|---|
-| Predicted at step -1 | 20.9 | 4.95 | 6.10 | 1.33 | 1.63 | 0.00 |
-| Predicted at step 0 | 20.9 | 5.52 | 5.56 | 1.40 | 0.06 | 0.00 |
-| Predicted at step +1 | 20.9 | 6.09 | 5.02 | 1.46 | 2.44 | 0.00 |
+That buys two things.
 
-Read down the rows and the inputs move substantially. Acetic acid goes from about 5 to 6, hydrogen
-sulfide falls from 6.10 to 5.02, lactic acid rises slightly. Every one of them still predicts a
-taste of 20.9. This set of equally-good recipes is the **null space** of the inversion.
+**Robustness.** Inputs can move a long way in those directions without shifting the target. It tells
+you what you do not have to control tightly.
 
-That is a practical result on its own. If three recipes all hit the target, we are free to choose
-among them on something the model never saw: cost, supplier availability, energy, shelf life,
-whichever raw material lot happens to be in the yard this week.
+**Alternatives.** Many recipes, one outcome. The freedom is yours to spend on cost, safety,
+availability, or anything else the model never saw.
 
-*Figure: the score plot, with the calibration cheeses, the direct-inversion solution, and the null
-space drawn as a line through it. Parallel lines for other target tastes.*
-(`pls/pls-model-inversion-null-space.png`)
+Widen the target from a point to a range and the line becomes a region: a multivariate specification.
+That is how you judge an incoming lot, transfer a product between sites, or state a design space.
 
-## Why it is a line, and not a point
+One thing to watch. Report that region as one range per input and you have described a box, not the
+region. In the cheese example all eight corners of that box satisfy every one of the three ranges, and
+not one of them is an acceptable lot. Six predict a taste outside the window. The other two predict a
+perfectly good taste from a recipe far outside anything the data support.
 
-The geometry is worth a moment, because it makes everything that follows easier to see.
+## The caveat that keeps it useful
 
-With two components the prediction is just a weighted sum of the two scores, ŷ = q₁t₁ + q₂t₂. So the
-vector **q** of y-loadings is the *gradient* of the prediction in the score plot: the direction in
-which predicted taste climbs fastest.
+The direction of that line is estimated, and often poorly. Refitting the cheese model on bootstrap
+resamples, the null space sits a median of 21 degrees away from the reported direction, and beyond 45
+degrees in 15% of resamples. The inverted *point* holds up well. The *direction* does not.
 
-Think of the prediction as a hill over the score plot. **q** points straight uphill. Asking for a
-specific taste is asking to stand at a specific height, and the set of points at one height on a
-hill is a contour line. The null space is that contour: walk along it and your coordinates change
-while your altitude does not.
-
-Which gives the whole thing in one line. If a step Δt leaves the prediction unchanged, then
-
-**q**ᵀΔt = 0
-
-The free directions are exactly those perpendicular to the gradient. For these cheeses **q** =
-(0.546, -0.262), so the contour has a slope of 2.08 in the score plot, and every design on that line
-predicts the same taste.
-
-*Figure: contours of predicted taste, perpendicular to the gradient q, drawn on equal axes so the
-right angle is visible.* (`pls/pls-null-space-geometry.png`)
-
-## The same space, arrived at from the other direction
-
-Now forget inversion completely.
-
-O-PLS (orthogonal projections to latent structures, Trygg and Wold, 2002) was invented for an
-unrelated reason: to make a model easier to interpret. It takes the one X matrix and writes it as
-two additive pieces plus a residual:
-
-X = **t**ₚ**p**ₚᵀ + **T**ₒ**P**ₒᵀ + E
-
-y = qₚ**t**ₚ + f
-
-The first piece is *predictive*, the second is *Y-orthogonal*. The important line is the second one:
-**T**ₒ does not appear in it. The orthogonal piece can be as large as it likes and the prediction
-does not move.
-
-For the cheese model, that orthogonal piece carries **18.3% of the sum of squares in X**, against
-68.7% for the predictive piece and 13.0% left in the residual. Its score correlates with taste at
-exactly zero. So nearly a fifth of the systematic variation in these three measurements does nothing
-whatsoever to taste. That is not noise, and it is not a rounding error.
-
-**That orthogonal space and the null space from the inversion are the same space.** García-Carrión
-and co-authors proved it, for a single response, in the *Journal of Chemometrics* last year. Written
-as unit vectors in the original three measurements, both come out as (0.948, -0.238, 0.211), and the
-cosine between them is 1.0.
-
-Two communities, solving two unrelated problems, with two different algorithms, named the same
-geometry twice. One called it the space to filter away; the other called it the freedom to design
-with.
-
-## What the orthogonal space is for
-
-This is the part I want to argue for, because the orthogonal space is usually presented as the part
-you discard.
-
-**It tells you what you do not have to control.** Variation along these directions is, by
-construction, variation the response does not feel. If a plant is fighting to hold a measurement
-steady and that measurement moves mostly along the orthogonal space, that effort is buying very
-little. The predictive space tells you what to control. The orthogonal space tells you where you can
-stop.
-
-**It gives you alternatives at no cost to the target.** Every point along it hits the same number.
-The freedom is real and it is free, in terms of the response. It is not free in every sense, and
-that is the caveat to state plainly: in the table above, stepping away from the middle raised T²
-from 0.06 to 1.63 and 2.44. The prediction does not change, but the support the data give that
-design does. So the freedom is bounded, and T² is how we bound it.
-
-**It is a robustness statement about incoming material.** Two lots of raw material that differ a lot
-on paper may differ almost entirely along the orthogonal space, in which case they are
-interchangeable for this product. Two others that look similar may differ along the predictive
-direction and not be interchangeable at all. The distance that matters is not the distance in the
-raw measurements.
-
-## From points to regions
-
-Everything above aimed at one target number. Real products are specified over a range, and that is
-where this gets useful rather than merely elegant.
-
-Each acceptable taste has its own null space, and those null spaces are parallel. Sweeping the
-target across the acceptable range sweeps its line across the score plot, and the swept lines fill
-out a region. Bound it in the other direction with the T² limit so we do not wander outside the
-data, and the result is a **multivariate specification region**: the set of inputs we are prepared
-to accept.
-
-```python
-t2_limit = pls.hotellings_t2_limit(0.95)   # 7.36
-
-region = []
-for target in np.linspace(20.0, 40.0, 5):        # the range of taste we accept
-    for step in np.linspace(-6, 6, 2001):        # walk along that target's null space
-        candidate = pls.invert(target, null_space_coordinates=[step])
-        if candidate.hotellings_t2 <= t2_limit:
-            region.append(candidate.x_new)
-```
-
-One warning that costs people real money: the min and max of that region are the *enclosing box*,
-not the region. The region is a slanted band. A lot can sit inside all three individual ranges and
-still fall outside the band, because what makes it acceptable is the combination, not each
-measurement separately.
-
-This shape of answer covers a lot of ground:
-
-- **Incoming raw materials.** Which lots can I accept, and how do I use the ones I have?
-- **Product and process transfer, and scale-up.** Which conditions on the new line reproduce the
-  product from the old one?
-- **Design space, in the QbD sense.** A defensible region rather than a single set point.
-- **Choosing among equivalent recipes** on cost, availability, or environmental impact.
-
-Jaeckle and MacGregor called this a *window of process operating conditions* in 2000, and moved
-along the null space over a range that kept conditions within past experience, then applied
-engineering judgement to pick a point in that window. Bounding by T² makes "within past experience"
-a single testable number. Paris, Duchesne and Poulin (2021) compare model inversion against direct
-mapping for exactly this and find neither wins in every case: inversion accepted more of the good
-lots in their study, while direct mapping is simpler and leaves more freedom in the region's shape.
-
-## The caveats worth stating
-
-The equivalence is proved for a **single response**. With more than one response, inversion still
-works, but the O-PLS shortcut does not carry over, since O-PLS separates one predictive component.
-The null space then has dimension A - rank(Y): with three components and two responses, a line. The
-multi-response equivalence is open work, noted as such by the authors.
-
-And a moderate model is fine for this. The cheese model explains about 67% of the variation in
-taste, which is unremarkable. The null space is a property of the model's geometry, not of how
-accurately it predicts. A design far from the cheese that actually had that taste is not a failed
-inversion: the inversion returns the smallest-norm solution, nature returned whatever it returned,
-and the null space is precisely the reason both can carry the same predicted taste while sitting
-some distance apart.
+So design at the solution with reasonable confidence, and treat a long walk along the line as
+something to re-check on a refitted model before acting on it.
 
 ## Try it
 
-Everything above runs. `PLS.invert()` and an `OPLS` estimator are in the open-source
-`process_improve` library, and every number and figure in this post regenerates from public code on
-a public data set.
+`PLS.invert()` and the `OPLS` estimator are in
+[process-improve](https://pypi.org/project/process-improve/). The worked example, the geometry and the
+uncertainty analysis are written up in the book:
+[PLS model inversion and the orthogonal space](https://learnche.org/pid/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space).
 
-The fully worked version, with the algebra, the geometry, the specification region, and a
-multiple-response example on a solvents data set, is the "Using a PLS model backwards: model
-inversion and the null space" section of my free textbook.
+---
 
-## References
-
-- C. M. Jaeckle and J. F. MacGregor, "Industrial applications of product design through the
-  inversion of latent variable models", *Chemometrics and Intelligent Laboratory Systems*, **50**
-  (2000): 199-210.
-- J. Trygg and S. Wold, "Orthogonal projections to latent structures (O-PLS)", *Journal of
-  Chemometrics*, **16** (2002): 119-128, doi:10.1002/cem.695.
-- A. Paris, C. Duchesne, and É. Poulin, "Establishing multivariate specification regions for
-  incoming raw materials using projection to latent structure models", *Frontiers in Analytical
-  Science*, **1** (2021): 729732.
-- S. García-Carrión, F. Sartori, J. Borràs-Ferrís, P. Facco, M. Barolo, and A. Ferrer, "On the
-  equivalence between null space and orthogonal space in latent variable regression modeling",
-  *Journal of Chemometrics*, **39** (2025): e70057, doi:10.1002/cem.70057.
+S. García-Carrión, F. Sartori, J. Borràs-Ferrís, P. Facco, M. Barolo and A. Ferrer, "On the
+equivalence between null space and orthogonal space in latent variable regression modeling",
+*Journal of Chemometrics*, **39** (2025): e70057.
+[doi:10.1002/cem.70057](https://doi.org/10.1002/cem.70057) (open access)

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -103,7 +103,7 @@ toward a middling one.
 	x_columns = ["Acetic", "H2S", "Lactic"]
 
 	train = cheese.iloc[4:]        # cheeses 5 to 30: used to build the model
-	holdout = cheese.iloc[:4]      # cheeses 1 to 4: the targets we design toward
+	holdout = cheese.iloc[:4]      # cheeses 1 to 4: the design targets
 	X = train[x_columns]
 	Y = train[["Taste"]]
 
@@ -135,8 +135,8 @@ predicts will give that taste.
 	actual = holdout[x_columns].iloc[1]
 	for label, inputs in [("Actual", actual), ("Predicted", result.x_new)]:
 	    d = pls.diagnose(inputs.to_frame().T)
-	    print(f"{label}: T2 = {float(d.hotellings_t2.iloc[0]):.2f}, "
-	          f"SPE = {float(d.spe.iloc[0]):.2f}")
+	    print(f"{label}: T2 = {d.hotellings_t2.iloc[0]:.2f}, "
+	          f"SPE = {d.spe.iloc[0]:.2f}")
 	# Actual: T2 = 0.21, SPE = 0.68
 	# Predicted: T2 = 0.06, SPE = 0.00
 
@@ -153,7 +153,7 @@ We can walk along it by passing coordinates along its basis. Stepping one unit e
 
 	for step in (-1.0, 1.0):
 	    moved = pls.invert(y_desired=20.9, null_space_coordinates=[step])
-	    taste = float(pls.predict(moved.x_new.to_frame().T).iloc[0, 0])
+	    taste = pls.predict(moved.x_new.to_frame().T).iloc[0, 0]
 	    print(moved.x_new.round(2).to_list(), "->", round(taste, 2))
 	# [4.95, 6.10, 1.33] -> 20.9
 	# [6.09, 5.02, 1.46] -> 20.9
@@ -163,20 +163,20 @@ Collecting those points, and putting the measured cheese alongside for compariso
 .. code-block:: python
 
 	scaler = MCUVScaler().fit(X)
-	a = scaler.transform(actual.to_frame().T).iloc[0]           # actual, in std deviations
+	a = scaler.transform(actual.to_frame().T).iloc[0]   # in std deviations
 
 	designs = {
 	    "Actual": actual,
-	    "Predicted at step -1": pls.invert(20.9, null_space_coordinates=[-1.0]).x_new,
+	    "Predicted at step -1": pls.invert(20.9, null_space_coordinates=[-1]).x_new,
 	    "Predicted at step 0": result.x_new,
-	    "Predicted at step +1": pls.invert(20.9, null_space_coordinates=[+1.0]).x_new,
+	    "Predicted at step +1": pls.invert(20.9, null_space_coordinates=[+1]).x_new,
 	}
 	for label, inputs in designs.items():
 	    d = pls.diagnose(inputs.to_frame().T)
 	    v = scaler.transform(inputs.to_frame().T).iloc[0]
 	    print(f"{label:<22}{inputs.round(2).to_list()}  "
-	          f"T2 = {float(d.hotellings_t2.iloc[0]):.2f}, SPE = {float(d.spe.iloc[0]):.2f}, "
-	          f"deviation = {float(((a - v) ** 2).sum()):.2f}")
+	          f"T2 = {d.hotellings_t2.iloc[0]:.2f}, SPE = {d.spe.iloc[0]:.2f}, "
+	          f"deviation = {((a - v) ** 2).sum():.2f}")
 
 .. _LVM-PLS-null-space-steps-table:
 
@@ -944,7 +944,7 @@ deviation is a distance in the input space, measured between the two recipes the
 
 	rows = []
 	for i in range(len(holdout)):
-	    target = float(holdout["Taste"].iloc[i])
+	    target = holdout["Taste"].iloc[i]
 	    design = pls.invert(target)
 	    measured = holdout[x_columns].iloc[i]
 	    a = scaler.transform(measured.to_frame().T).iloc[0]
@@ -952,8 +952,8 @@ deviation is a distance in the input space, measured between the two recipes the
 	    rows.append({
 	        "Taste": target,
 	        "T2 design": design.hotellings_t2,          # the proposed recipe
-	        "T2 cheese": float(pls.diagnose(measured.to_frame().T).hotellings_t2.iloc[0]),
-	        "Input dev": float(((a - p) ** 2).sum()),   # between the two recipes
+	        "T2 cheese": pls.diagnose(measured.to_frame().T).hotellings_t2.iloc[0],
+	        "Input dev": ((a - p) ** 2).sum(),   # between the two recipes
 	    })
 
 	print(pd.DataFrame(rows).round(2))

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -591,18 +591,12 @@ plotting all 2000 of them faintly enough to overlap turns the spread into a dens
 That pinch is the point-and-direction asymmetry in one picture. The refits nearly agree on where the
 solution sits, and disagree widely on which way the line runs through it.
 
-So the two statements this section makes are not equally firm. That a set of inputs reaching a target
-taste exists, and roughly where it sits, is supported by these data. Which direction one may then walk
-without changing the prediction is not pinned down by 26 cheeses and a component that
-cross-validation set aside. The null space is exactly what the algebra says it is for a *given* model;
-what the algebra cannot supply is certainty that this model's second component points where the next
-26 cheeses would point it. The numbers in this section are quoted to three decimals because that is
-what the arithmetic returns, not because the data support that precision.
-
-None of this makes the geometry wrong or the method unusable. It sets the terms on which to use it: a
-design proposed at the direct-inversion solution rests on firmer ground than one reached by a long walk
-along the null space, and a walk of any length is worth repeating on a refitted model before it is
-acted on.
+The geometry itself is not in question: for a given model the null space is exactly what the algebra
+says it is. What these 26 cheeses settle is a different matter, and they settle it unevenly. Where the
+design sits, they support; which way the line runs through it, they do not. That sets the terms on
+which the method is used rather than ruling it out. Design at the direct-inversion solution and the
+ground is firm. Walk a long way along the null space and it is worth refitting the model first, because
+the direction being walked is the part the data pin down least.
 
 .. _LVM-PLS-orthogonal-space:
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -465,10 +465,7 @@ counts for more in :math:`T^2` than in the plain norm, and the null-space direct
 
 The distinction is worth keeping straight, because it says what the direct-inversion solution does and
 does not give. It is the smallest-norm design, exactly. It is not quite the design of smallest
-:math:`T^2`: a step of :math:`-0.103` would reach :math:`T^2 = 0.043` rather than 0.064. The gap is
-small here and the direct-inversion solution is still the closest of the three tabulated steps, but the
-two criteria are different questions and a model with more unequal score spreads would separate them
-further.
+:math:`T^2`.
 
 Two further points are worth making. First, the perpendicularity is a statement about the score
 coordinates, so it reads as a right angle on the page only when both axes are drawn to the same scale, as

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -108,7 +108,7 @@ toward a middling one.
 	Y = train[["Taste"]]
 
 	pls = PLS(n_components=2).fit(X, Y)
-	print(round(float(pls.r2_cumulative_.iloc[-1]), 3))   # R2 on Taste: 0.672
+	print(pls.r2_cumulative_.iloc[-1])   # R2 on Taste: 0.672
 
 It explains about 67% of the variation in Taste, which is enough for what follows: the null space is a
 property of the model's geometry rather than of its predictive accuracy. That geometry is itself
@@ -128,7 +128,7 @@ predicts will give that taste.
 	result = pls.invert(y_desired=20.9)
 
 	print(result.x_new.round(2).to_dict())
-	# {'Acetic': 5.52, 'H2S': 5.56, 'Lactic': 1.4}
+	# {'Acetic': 5.52, 'H2S': 5.56, 'Lactic': 1.40}
 	print(result.null_space_dimension)        # 1
 
 	# Compare the designed inputs with what cheese 2 actually was.
@@ -374,10 +374,10 @@ We can confirm both the slope and the perpendicularity from the fitted model.
 .. code-block:: python
 
 	q = pls.y_loadings_.to_numpy().ravel()
-	print(q.round(3))                      # [ 0.546 -0.262]
-	print(round(-q[0] / q[1], 2))          # 2.08, the slope of the line
-	print(g.round(3))                      # [0.433 0.902], the null-space direction
-	print(round(float(g @ q), 12))         # 0.0, the direction is perpendicular to q
+	print(q)                       # [0.546 -0.262]
+	print(-q[0] / q[1])            # 2.08, the slope of the line
+	print(g)                       # [0.433 0.902], the null-space direction
+	print(round(g @ q, 12))        # 0.0: g is perpendicular to q
 
 The particular solution the inversion returns is the shortest one, and the same picture shows where it
 comes from. Split any candidate :math:`\boldsymbol{\tau}` into a part along :math:`\mathbf{q}` and a
@@ -441,8 +441,8 @@ along the null space costs.
 	                  yaxis_title="squared distance from the model centre")
 	fig.show()
 
-	print(sf.round(3))                                        # [1.468 0.657]
-	print(round(-float((tau / sf**2) @ g) / float((g / sf**2) @ g), 3))
+	print(sf)                                     # [1.468 0.657]
+	print(-(tau / sf**2) @ g / ((g / sf**2) @ g))  # -0.103
 	# -0.103, the step at which T2 is least
 
 .. _LVM-PLS-null-space-distance-figure:
@@ -527,11 +527,11 @@ Refitting the model on bootstrap resamples of the calibration set answers that d
 	    # A direction and its negative describe the same line, so compare without sign.
 	    angles.append(np.degrees(np.arccos(np.clip(abs(d @ reference), 0, 1))))
 
-	print(np.percentile(q2, [2.5, 97.5]).round(3))        # [-0.56   0.377]
-	print(round(float(np.mean(np.array(q2) > 0)), 3))     # 0.244, the share that change sign
-	print(np.percentile(slopes, [2.5, 97.5]).round(2))    # [-5.09  6.13]
-	print(np.percentile(angles, [50, 90, 95]).round(1))   # [20.6 54.4 68.3]
-	print(round(float(np.mean(np.array(angles) > 45)), 2))  # 0.15
+	print(np.percentile(q2, [2.5, 97.5]))       # [-0.560 0.377]
+	print(np.mean(np.array(q2) > 0))       # 0.244, the share that change sign
+	print(np.percentile(slopes, [2.5, 97.5]))   # [-5.09 6.13]
+	print(np.percentile(angles, [50, 90, 95]))  # [20.6 54.4 68.3]
+	print(np.mean(np.array(angles) > 45))       # 0.15
 	print(np.percentile(designs, [2.5, 97.5], axis=0).round(2))
 	# [[5.24 4.97 1.3 ]
 	#  [5.74 6.26 1.49]]
@@ -696,13 +696,13 @@ The fitted model reports the two directions as ``opls.predictive_weights_`` and
 
 	opls = OPLS(n_orthogonal_components=1).fit(X, Y)
 
-	print(opls.predictive_weights_.round(3).to_numpy())           # [0.474 0.657 0.586]
-	print(opls.orthogonal_weights_.round(3).to_numpy().ravel())   # [ 0.808 -0.59   0.008]
-	print(opls.predictive_loadings_.round(3).to_numpy())          # [0.472 0.654 0.591]
+	print(opls.predictive_weights_)     # [0.474  0.657  0.586]
+	print(opls.orthogonal_weights_)     # [0.808 -0.590  0.008]
+	print(opls.predictive_loadings_)    # [0.472  0.654  0.591]
 
-	print(pls.x_weights_.to_numpy().round(3))    # the PLS weights, side by side
+	print(pls.x_weights_)               # the PLS weights, side by side
 	# [[ 0.474  0.808]
-	#  [ 0.657 -0.59 ]
+	#  [ 0.657 -0.590]
 	#  [ 0.586  0.008]]
 
 The predictive weight :math:`\mathbf{w}_\text{p} = (0.474, 0.657, 0.586)` has three positive entries of
@@ -729,16 +729,16 @@ The consequence shows up in the scores, not the weights.
 
 	for name, score in [("PLS 1", scores.iloc[:, 0]), ("PLS 2", scores.iloc[:, 1]),
 	                    ("O-PLS predictive", t_p), ("O-PLS orthogonal", t_o)]:
-	    print(name, round(float(np.corrcoef(score, y_centred)[0, 1]), 3))
+	    print(name, np.corrcoef(score, y_centred)[0, 1])
 	# PLS 1 0.802
 	# PLS 2 -0.172
 	# O-PLS predictive 0.82
 	# O-PLS orthogonal -0.0
 
-	print(round(float(np.corrcoef(t_p, scores.iloc[:, 0])[0, 1]), 3))   # 0.978
+	print(np.corrcoef(t_p, scores.iloc[:, 0])[0, 1])   # 0.978
 
-	print(pls.r2_cumulative_.round(3).to_list())                        # [0.642, 0.672]
-	print(round(float(np.corrcoef(t_p, y_centred)[0, 1]) ** 2, 3))      # 0.672
+	print(pls.r2_cumulative_)                         # [0.642, 0.672]
+	print(np.corrcoef(t_p, y_centred)[0, 1] ** 2)     # 0.672
 
 .. _LVM-PLS-score-correlation-table:
 
@@ -886,14 +886,14 @@ response.
 
 .. code-block:: python
 
-	print(opls_result.x_new.round(2).to_list())   # [5.46, 5.62, 1.39]
-	print(round(opls_result.y_hat, 2))            # 20.9
+	print(opls_result.x_new)   # [5.46, 5.62, 1.39]
+	print(opls_result.y_hat)   # 20.9
 
 	ns_input = result.null_space_basis.to_numpy().T @ pls.x_loadings_.to_numpy().T
 	os_input = opls_result.orthogonal_space_basis.to_numpy().T
 
-	print((ns_input / np.linalg.norm(ns_input)).round(3))    # [[ 0.948 -0.238  0.211]]
-	print((os_input / np.linalg.norm(os_input)).round(3))    # [[ 0.948 -0.238  0.211]]
+	print(ns_input / np.linalg.norm(ns_input))    # [0.948 -0.238 0.211]
+	print(os_input / np.linalg.norm(os_input))    # [0.948 -0.238 0.211]
 
 	cosine = np.abs(ns_input @ os_input.T).item() / (
 	    np.linalg.norm(ns_input) * np.linalg.norm(os_input)
@@ -1060,7 +1060,7 @@ Suppose a taste between 20 and 30 is acceptable.
 
 	region = pd.DataFrame(region)
 	print(round(t2_limit, 2))                        # 7.36
-	print(len(region))                               # 415 of the 550 inversions are kept
+	print(len(region))          # 415 of the 550 inversions are kept
 	print(region.agg(["min", "max"]).round(2))
 	#      Acetic   H2S  Lactic
 	# min    4.38  4.44    1.25
@@ -1112,8 +1112,9 @@ Both the region and the box it is reported as can be drawn.
 	plot can be followed to the recipe it stands for: the four corners of the region, where the outer
 	null spaces meet the :math:`T^2` limit, and its centre, the direct-inversion solution for a taste of
 	25. Colour gives the target taste, and the triangle points down at the low end of that taste's null
-	space and up at the high end. Each corner of the box carries the taste it is predicted to have, dark red where that taste is
-	outside the window and blue where it is acceptable but the recipe lies beyond the :math:`T^2` limit.
+	space and up at the high end. Each corner of the box carries the taste it is predicted to have, dark
+	red where that taste is outside the window and blue where it is acceptable but the recipe lies beyond
+	the :math:`T^2` limit.
 
 The eight corners make the difference concrete. Every one of them satisfies all three ranges, since
 each coordinate is either the reported minimum or the reported maximum, and not one of them is an
@@ -1158,7 +1159,8 @@ properties give a solvent with a chosen :math:`\log P` and solubility.
 
 	print(design.null_space_dimension)          # 1
 	print(round(design.hotellings_t2, 2))       # 2.46
-	print(model.predict(design.x_new.to_frame().T).round(2).to_dict("records")[0])
+	prediction = model.predict(design.x_new.to_frame().T)
+	print(prediction.round(2).to_dict("records")[0])
 	# {'logP': 0.5, 'Solubility': 0.0}
 
 Two things change with two responses. First, the target now pins down two score directions instead of

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -244,9 +244,7 @@ gap.
 the calibration data. Step 0, the direct-inversion solution, has the smallest at 0.06; stepping either
 way moves the design outward, to 1.63 and 2.44. The freedom along the null space is free in terms of
 predicted taste, but not in terms of how much the data support the design. All rows sit well inside the
-99% limits of :math:`T^2 = 12.14` and :math:`\text{SPE} = 1.60`, which are the limits for a *new*
-observation rather than for one of the 26 that built the model: the right choice when judging a
-proposed design rather than summarising a calibration one.
+99% limits of :math:`T^2` and SPE.
 
 .. _LVM-PLS-input-space-deviation:
 

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -249,7 +249,7 @@ predicted taste, but not in terms of how much the data support the design. All r
 .. _LVM-PLS-input-space-deviation:
 
 One quantity is worth defining now, because it recurs. Comparing recipes in raw units is hard to read:
-a gap of 0.5 in hydrogen sulfide does not mean what a gap of 0.5 in lactic acid means. Centring and
+a gap of 0.5 in hydrogen sulfide is not the same as a gap of 0.5 in lactic acid. Centring and
 scaling each input puts them on a common footing where one unit is one standard deviation, and the sum
 of squared differences in those units is the *input-space deviation*. For cheese 2 against its design
 it is 0.66, so the held-out cheese sits about 0.8 standard deviations from the proposed recipe.

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -140,12 +140,12 @@ predicts will give that taste.
 	# Actual: T2 = 0.21, SPE = 0.68
 	# Predicted: T2 = 0.06, SPE = 0.00
 
-A recipe comes back, which is unremarkable. The second line is the interesting one. The null space has
-dimension 1, which is the model saying that this is not *the* answer but one point on a line of
-answers. Two score directions, one target: the target fixes one of them and leaves the other free.
-Anything we do along that free direction changes the recipe while leaving the prediction exactly where
-it was. That free direction is the *null space*, and its dimension is the number of components minus
-the rank of the response, here :math:`2 - 1 = 1`.
+A recipe comes back, which is unremarkable. It is ``null_space_dimension``, printed on the line after
+it, that is interesting. The null space has dimension 1, which is the model saying that this is not
+*the* answer but one point on a line of answers. Two score directions, one target: the target fixes
+one of them and leaves the other free. Anything we do along that free direction changes the recipe
+while leaving the prediction exactly where it was. That free direction is the *null space*, and its
+dimension is the number of components minus the rank of the response, here :math:`2 - 1 = 1`.
 
 We can walk along it by passing coordinates along its basis. Stepping one unit either way:
 
@@ -229,8 +229,8 @@ Read down the three designs and the inputs move substantially. Acetic acid climb
 while hydrogen sulfide falls from 6.10 to 5.02, with lactic acid rising slightly. These are not small
 adjustments, and yet every one of the three still reaches a taste of 20.9. That is the practical
 content of the null space: if several recipes all hit the target, we are free to choose among them on
-grounds the model never saw, such as cost, supplier availability, or whichever raw material happens to
-be in the yard this week. This same trade-off comes back when we reach
+grounds the model never saw, such as cost, safety, or whichever raw material happens to be
+available. This same trade-off comes back when we reach
 :ref:`O-PLS <LVM-PLS-orthogonal-space>` below, where it appears directly as one of the model's axes.
 
 Two columns need reading carefully. The SPE of exactly zero is a property of the arithmetic, not a

--- a/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
+++ b/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst
@@ -497,44 +497,59 @@ space rests on the second :math:`y`-loading, :math:`q_2 = -0.262`. That componen
 cross-validation did not keep. It adds 3.0% to :math:`R^2Y`, against 64.3% for the first. It is worth
 asking how much of the geometry survives if the 26 cheeses had come out slightly differently.
 
-Refitting the model on bootstrap resamples of the calibration set answers that directly.
+Refitting the model on bootstrap resamples of the calibration set answers that directly. One step in
+the loop below is worth explaining first. A PLS component carries no inherent sign: negating
+:math:`\mathbf{w}_a`, :math:`\mathbf{p}_a`, :math:`\mathbf{t}_a` and :math:`q_a` together leaves the
+predictions and the geometry exactly as they were, and which of the two versions the algorithm returns
+depends on the sample it was given. Coordinates can only be compared across refits once that
+convention is fixed, by aligning each refit's components with those of the model fitted to all 26
+cheeses.
+
+Quantities that are already free of sign need no such care. The angle below is measured between lines
+in the input space, where a flip of :math:`\mathbf{p}_a` cancels against the flip of the null-space
+coordinate multiplying it, so the alignment leaves those numbers untouched.
 
 .. code-block:: python
 
 	rng = np.random.default_rng(0)
 	reference = np.array([0.948, -0.238, 0.211])         # the direction reported below
 	reference = reference / np.linalg.norm(reference)
+	w_full = pls.x_weights_.to_numpy()                   # the sign convention to match
 
 	q2, slopes, angles, designs, boot_lines = [], [], [], [], []
 	for _ in range(2000):
 	    sample = train.iloc[rng.integers(0, len(train), len(train))]
 	    boot = PLS(n_components=2).fit(sample[x_columns], sample[["Taste"]])
-	    q_b = boot.y_loadings_.to_numpy().ravel()
+	    flip = np.sign((boot.x_weights_.to_numpy() * w_full).sum(axis=0))
+	    q_b = boot.y_loadings_.to_numpy().ravel() * flip
 	    q2.append(q_b[1])
 	    slopes.append(-q_b[0] / q_b[1])
 
 	    result_b = boot.invert(20.9)
 	    designs.append(result_b.x_new.to_numpy())
-	    boot_lines.append((result_b.scores.to_numpy(),
-	                       result_b.null_space_basis.to_numpy().ravel()))
-	    d = result_b.null_space_basis.to_numpy().ravel() @ boot.x_loadings_.to_numpy().T
+	    g_b = result_b.null_space_basis.to_numpy().ravel()
+	    boot_lines.append((result_b.scores.to_numpy() * flip, g_b * flip))
+	    d = g_b @ boot.x_loadings_.to_numpy().T
 	    d = d / np.linalg.norm(d)
 	    # A direction and its negative describe the same line, so compare without sign.
 	    angles.append(np.degrees(np.arccos(np.clip(abs(d @ reference), 0, 1))))
 
-	print(np.percentile(q2, [2.5, 97.5]))       # [-0.560 0.377]
-	print(np.mean(np.array(q2) > 0))       # 0.244, the share that change sign
-	print(np.percentile(slopes, [2.5, 97.5]))   # [-5.09 6.13]
+	print(np.percentile(q2, [2.5, 97.5]))       # [-0.573 0.112]
+	print(np.mean(np.array(q2) > 0))       # 0.044, the share that change sign
+	print(np.percentile(slopes, [2.5, 97.5]))   # [-3.78 6.41]
 	print(np.percentile(angles, [50, 90, 95]))  # [20.6 54.4 68.3]
 	print(np.mean(np.array(angles) > 45))       # 0.15
 	print(np.percentile(designs, [2.5, 97.5], axis=0).round(2))
 	# [[5.24 4.97 1.3 ]
 	#  [5.74 6.26 1.49]]
 
-The direction is poorly determined. A 95% bootstrap interval for :math:`q_2` runs from
-:math:`-0.56` to :math:`+0.38`, so it straddles zero, and in 24% of the resamples it changes sign. The
-slope of the null-space line is a ratio with that near-zero quantity in the denominator, so its
-interval, :math:`-5.1` to :math:`+6.1`, is wide enough to be of little use. Read as a line in the
+That alignment matters here: the second component comes back reversed in a quarter of the refits, and
+without the correction each of those would be counted as a disagreement it is not.
+
+The direction is poorly determined even so. A 95% bootstrap interval for :math:`q_2` runs from
+:math:`-0.573` to :math:`+0.112`, so it straddles zero, and 4% of the resamples place it on the far
+side. The slope of the null-space line is a ratio with that near-zero quantity in the denominator, so
+its interval, :math:`-3.8` to :math:`+6.4`, is wide enough to be of little use. Read as a line in the
 inputs, the resampled null space sits a median of 21 degrees away from the direction reported here, and
 more than 45 degrees away in 15% of the resamples.
 


### PR DESCRIPTION
Follow-up to #259, on the same section: `latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space.rst`. The matching figure work is kgdunn/figures#75 (merged).

## The substantive change: sign alignment in the bootstrap

A PLS component carries no inherent sign. Negating `w`, `p`, `t` and `q` together leaves the model and its geometry unchanged, and which of the two versions NIPALS returns depends on the sample it was given. The bootstrap loop compared coordinates across 2000 refits without fixing that convention first. Across those refits:

- component 1 never flips (its weights are all-positive in 99.95% of them),
- component 2 comes back reversed in 24.5% of them.

That reversed set is 95.6% identical to the refits the text was reporting as "q2 changed sign", so most of that claim was the convention rather than disagreement. With each refit aligned to the model fitted on all 26 cheeses:

| Quantity | Before | After |
|---|---|---|
| 95% interval for q2 | -0.56 to +0.38 | -0.573 to +0.112 |
| Resamples with q2 on the far side of zero | 24% | 4% |
| 95% interval for the null-space slope | -5.1 to +6.1 | -3.8 to +6.4 |
| Median angle from the reported direction | 21 degrees | 21 degrees (unchanged) |
| Refits beyond 45 degrees | 15% | 15% (unchanged) |

The angle figures are unchanged, and provably so: the angle is measured between lines in the input space, where a flip of `p_a` cancels against the flip of the null-space coordinate multiplying it. Checked numerically, the largest difference between the aligned and unaligned angles across all 2000 refits is exactly 0.0.

So the headline conclusion stands. The null-space direction really is poorly determined; what was overstated is how much of that showed up as sign changes in q2. The chapter now explains the convention where the loop needs it, and says why the angle needs no such care.

## Prose and code-block edits

- Dropped the closing two paragraphs of the uncertainty section in favour of one that closes that half of the chapter.
- Trimmed the smallest-norm versus smallest-T2 aside, and shortened the sentence about the 99% T2 and SPE limits.
- Two wording reworks (the "third line" reference, and the raw-material phrasing) and a simpler sentence motivating the input-space deviation.
- Removed `.round()`, `.to_numpy()`, `.ravel()` and `float()` from the chapter's `print` statements, showing results as comments instead, so no code line overflows a narrow screen.
- Blog draft under `docs/blog/`, clearly marked as a working draft, referenced by nothing in the build, and to be deleted once published.

## Verification

- `make text`: succeeds, zero warnings.
- `make html`: succeeds; `grep -r goatcounter _build/html/contents` returns zero hits.
- Every number quoted in the revised passages reproduces from the chapter's own code, run against the dataset.
- `CITATION.cff` `version:` and `date-released:` set to 2026.07.29; the README attribution year range already ends in 2026.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsTypY4FcRbrXRxorb9raz)_