### PR TITLE
Rewrite the model-inversion blog draft

### DIFF
--- a/docs/blog/orthogonal-space-and-model-inversion.md
+++ b/docs/blog/orthogonal-space-and-model-inversion.md
@@ -10,14 +10,14 @@ content of a cheese and it tells you what the tasting panel will say.
 Turn it around and you get the question people actually have. Not "what will this taste like?" but
 "what should I make so that it tastes like this?"
 
-That reversal has a name, **model inversion**, and it goes back to Jaeckle and MacGregor in 2000. What
-surprises people is not that it works. It is what comes back.
+That reversal has a name, **model inversion**, and it goes back to Jaeckle and MacGregor in 2000. It
+works. What surprises people is what comes back.
 
-## The answer is not a recipe. It is a set of them.
+## One target, many recipes
 
-Ask a fitted model for the inputs that give a chosen quality and it does not hand you one recipe. It
-hands you a line of them. Every point on that line is a different set of inputs, and every point
-predicts exactly the target you asked for.
+Ask a fitted model for the inputs that give a chosen quality and it hands you a whole line of recipes.
+Every point on that line is a different set of inputs, and every point predicts exactly the target you
+asked for.
 
 Picture the prediction as a hill standing over the space of your inputs. Some directions take you
 uphill quickly. Asking for a specific outcome is asking to stand at a specific height, and the set of
@@ -27,13 +27,15 @@ altitude does not. Different inputs, same predicted result.
 ![The null space in the score plot](../../figures/pls/pls-model-inversion-null-space.png)
 
 In the cheddar-cheese example from the book, 18.3% of everything that varies in the three inputs moves
-you along that contour and changes the predicted taste not at all. That is not noise, and not a
-rounding error. It is systematic, repeatable variation with no bearing on the outcome.
+you along that contour and doesn't change the predicted taste. That variation is systematic and
+repeatable, well beyond anything measurement noise would account for, and it has no bearing on the
+outcome.
 
 It is worth having, twice over. It tells you what you do not have to control tightly. And it means the
-model has handed you a choice: many recipes reach the target, so you spend the difference on cost, on
-safety, on whichever raw material you can actually get this week. The model never saw those concerns
-and does not need to.
+model has handed you a choice: many recipes reach the target, so you can make additional choices based
+on safety, costs, whichever raw material you can actually get this week, alternatives suited to
+regional preferences and regulations, process robustness, and so on. The model never saw those
+concerns and does not need to.
 
 ## Two fields found it, and gave it two names
 
@@ -54,28 +56,24 @@ Widen the target from a number to a range and the contour sweeps out a region: t
 you would accept. That is what a specification is.
 
 So write that region down the way specifications are usually written, as an acceptable range for each
-input, one line each. Entirely reasonable, and it is easy to show what it costs.
+input.
 
 ![The specification region, and the box of three ranges around it](../../figures/pls/pls-specification-region.png)
 
 The region is a thin slanted slice. A list of ranges describes the box around it. In the cheese
-example, every one of the eight corners of that box sits inside all three ranges, and not one of them
-is a lot you would accept. Six would taste wrong. The other two would taste fine, but nothing
-resembling them has ever been made, so the model carries no evidence about them at all.
+example, every one of the eight corners of that box sits inside all three ranges, however not one of
+them is a lot you would accept. Showing once again that with multivariate systems, the process moves
+within a smaller embedded subspace.
 
-Every corner satisfies the specification as written. Not one of them is acceptable.
+## One realization of many
 
-## The part that is not in the theory
+Equally interesting when inverting is to refit your model many times, in a bootstrap manner. Doing
+this shows where your designs sit, but also where they could possibly have sat.
 
-One caveat does not come out of the algebra, so we went looking for it.
+![Left panel only: the null space from each of 2000 refits of the model](../../figures/pls/pls-null-space-bootstrap.png)
 
-The line is exactly what the algebra says it is, for a given model. But the model came from data, and
-if you refit it on resampled data the line pivots. It typically lands about twenty degrees away from
-the one your model reported. Its starting point barely moves at all.
-
-The two things inversion tells you are therefore not equally firm. Where the design sits, the data
-support. Which way you may walk from it, they largely do not. Design at the solution and the ground is
-firm; take a long walk along the freedom and it is worth refitting the model first.
+So take a walk along your contours, but recognize it is just one realization of many potential
+options.
 
 ## Read the chapter
 

--- a/docs/blog/orthogonal-space-and-model-inversion.md
+++ b/docs/blog/orthogonal-space-and-model-inversion.md
@@ -2,86 +2,98 @@
 > It lives here only so the draft travels with the material it describes. Nothing in the Sphinx
 > build references it, and it is not meant to ship with the book.
 
-# The part of the model you filter out
+# Run the model backwards
 
-Picture the prediction from your model as a hill standing over the space of inputs. Moving in some
-directions takes you uphill fast; moving in others barely changes your altitude at all. The steepest
-way up has a name in a PLS model: it is the vector of y-loadings.
+Every model you fit points one way. Measurements go in, a prediction comes out. Give it the acid
+content of a cheese and it tells you what the tasting panel will say.
 
-Now ask for a specific outcome. You are asking to stand at a specific height on that hill, and the
-set of points at one height is a contour line. Walk along the contour and your position changes while
-your altitude does not. Different inputs, same predicted result.
+Turn it around and you get the question people actually have. Not "what will this taste like?" but
+"what should I make so that it tastes like this?"
 
-That contour is the thing this post is about. It is real, it is useful, and in most write-ups it is
-the part that gets filtered out and called a nuisance.
+That reversal has a name, **model inversion**, and it goes back to Jaeckle and MacGregor in 2000. What
+surprises people is not that it works. It is what comes back.
 
-## Run the model backwards
+## The answer is not a recipe. It is a set of them.
 
-The forward question is the ordinary one: given these measurements, what quality do we predict? The
-design question is the reverse: which measurements would give me the quality I have chosen? That is
-**model inversion**, and it goes back to Jaeckle and MacGregor (2000).
+Ask a fitted model for the inputs that give a chosen quality and it does not hand you one recipe. It
+hands you a line of them. Every point on that line is a different set of inputs, and every point
+predicts exactly the target you asked for.
 
-The answer is not one recipe. Fixing the target puts you on the contour, and every point on it is a
-recipe the model says will hit the target. Product designers call that line the **null space**.
+Picture the prediction as a hill standing over the space of your inputs. Some directions take you
+uphill quickly. Asking for a specific outcome is asking to stand at a specific height, and the set of
+points at one height is a contour line. Walk along the contour and your position changes while your
+altitude does not. Different inputs, same predicted result.
 
-The algebra is one line. If a step in the scores leaves the prediction unchanged, then
+![The null space in the score plot](../../figures/pls/pls-model-inversion-null-space.png)
 
-**q**ᵀ Δ**t** = 0
+In the cheddar-cheese example from the book, 18.3% of everything that varies in the three inputs moves
+you along that contour and changes the predicted taste not at all. That is not noise, and not a
+rounding error. It is systematic, repeatable variation with no bearing on the outcome.
 
-The free directions are exactly the ones perpendicular to the gradient. Perpendicular to steepest
-ascent means along the contour, which is what the hill already told us.
+It is worth having, twice over. It tells you what you do not have to control tightly. And it means the
+model has handed you a choice: many recipes reach the target, so you spend the difference on cost, on
+safety, on whichever raw material you can actually get this week. The model never saw those concerns
+and does not need to.
 
-## The same line, from the other side
+## Two fields found it, and gave it two names
 
-O-PLS was built for an unrelated reason: to make a model easier to read, by splitting the inputs into
-the part that drives the response and the part that does not. That second piece is the **orthogonal
-space**.
+People inverting models to design products called that freedom the **null space**.
 
-García-Carrión and co-authors proved this year that, for a single response, the two are the same
-linear space. Inverting a PLS model and fitting an O-PLS model give the same direction, to numerical
-precision. One geometry, discovered twice by two communities solving two different problems.
+Chemometricians had arrived at the same place from an unrelated direction. They wanted models that were
+easier to read, so they separated the inputs into the part that drives the response and the part that
+does not, and called the second the **orthogonal space**. For them it was housekeeping: the leftover,
+filtered out to tidy the model up.
 
-## Why the leftover is worth having
+It is the same space. García-Carrión and co-authors proved it last year for a single response. One
+piece of geometry, discovered twice by two communities solving two different problems, one of them
+filtering out what the other was designing with.
 
-In the cheddar-cheese example from the book, the orthogonal piece carries **18.3% of the variation in
-the inputs and contributes nothing at all to the predicted taste**. Not a rounding error, and not
-noise: systematic variation with no effect on the outcome.
+## Now write it down as a specification
 
-That buys two things.
+Widen the target from a number to a range and the contour sweeps out a region: the set of all inputs
+you would accept. That is what a specification is.
 
-**Robustness.** Inputs can move a long way in those directions without shifting the target. It tells
-you what you do not have to control tightly.
+So write that region down the way specifications are usually written, as an acceptable range for each
+input, one line each. Entirely reasonable, and it is easy to show what it costs.
 
-**Alternatives.** Many recipes, one outcome. The freedom is yours to spend on cost, safety,
-availability, or anything else the model never saw.
+![The specification region, and the box of three ranges around it](../../figures/pls/pls-specification-region.png)
 
-Widen the target from a point to a range and the contour sweeps out a region: a multivariate
-specification. That is how you judge an incoming lot, transfer a product between sites, or state a
-design space.
+The region is a thin slanted slice. A list of ranges describes the box around it. In the cheese
+example, every one of the eight corners of that box sits inside all three ranges, and not one of them
+is a lot you would accept. Six would taste wrong. The other two would taste fine, but nothing
+resembling them has ever been made, so the model carries no evidence about them at all.
 
-One thing to watch. Report that region as one acceptable range per input and you have described a
-box, not the region. The region is a thin slanted slice through that box. In the cheese example every
-single corner of the box satisfies all three ranges, and not one of them is a lot you would accept.
+Every corner satisfies the specification as written. Not one of them is acceptable.
 
-## The caveat that keeps it useful
+## The part that is not in the theory
 
-The direction of the contour is estimated, and often poorly. Refit the cheese model on bootstrap
-resamples and the null space typically lands about 20 degrees away from the direction the full data
-set reports. The inverted *point* holds up well. The *direction* does not.
+One caveat does not come out of the algebra, so we went looking for it.
 
-So design at the solution with reasonable confidence, and treat a long walk along the contour as
-something to re-check on a refitted model before acting on it.
+The line is exactly what the algebra says it is, for a given model. But the model came from data, and
+if you refit it on resampled data the line pivots. It typically lands about twenty degrees away from
+the one your model reported. Its starting point barely moves at all.
 
-## Try it
+The two things inversion tells you are therefore not equally firm. Where the design sits, the data
+support. Which way you may walk from it, they largely do not. Design at the solution and the ground is
+firm; take a long walk along the freedom and it is worth refitting the model first.
+
+## Read the chapter
+
+The worked example, the geometry, the specification region and the uncertainty analysis are written up
+in full, with every figure reproducible from the code in the text:
+
+**[Using a PLS model backwards: model inversion and the null
+space](https://learnche.org/pid/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space)**
 
 `PLS.invert()` and the `OPLS` estimator are in
-[process-improve](https://pypi.org/project/process-improve/). The worked example, the geometry and the
-uncertainty analysis are written up in the book:
-[PLS model inversion and the orthogonal space](https://learnche.org/pid/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space).
+[process-improve](https://pypi.org/project/process-improve/).
 
 ---
 
-S. García-Carrión, F. Sartori, J. Borràs-Ferrís, P. Facco, M. Barolo and A. Ferrer, "On the
-equivalence between null space and orthogonal space in latent variable regression modeling",
-*Journal of Chemometrics*, **39** (2025): e70057.
+C. M. Jaeckle and J. F. MacGregor, "Industrial applications of product design through the inversion of
+latent variable models", *Chemometrics and Intelligent Laboratory Systems*, **50** (2000): 199-210.
+
+S. García-Carrión, F. Sartori, J. Borràs-Ferrís, P. Facco, M. Barolo and A. Ferrer, "On the equivalence
+between null space and orthogonal space in latent variable regression modeling", *Journal of
+Chemometrics*, **39** (2025): e70057.
 [doi:10.1002/cem.70057](https://doi.org/10.1002/cem.70057) (open access)


### PR DESCRIPTION
Rewrites the working draft at `docs/blog/orthogonal-space-and-model-inversion.md`. Nothing in the Sphinx build references it, so the book output is unaffected; it lives in the repository only so the draft travels with the material it describes, and it is marked for deletion once the post is published.

The previous draft led with the null-space and orthogonal-space equivalence, which asks the reader to already care about O-PLS. This version builds from the reversal itself, aimed at someone who has never thought about running a model backwards:

- the model runs backwards, and the answer is a line of recipes rather than one,
- what that freedom is worth, and the grounds it can be spent on,
- two fields arriving at the same space under two names,
- a specification written as one range per input, and the eight box corners that satisfy it while none is acceptable,
- refitting in a bootstrap to see where a design could also have sat.

Two figures, both already committed in `kgdunn/figures`, no mathematics, and the chapter as the call to action. About four minutes to read.

Style pass folded in from review: the repeated "not X, but Y" construction is down to a single deliberate use in the opening.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsTypY4FcRbrXRxorb9raz)_