### PR TITLE
Show the concept DOI in the page footer

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.07.29"
-date-released: 2026-07-29
+version: "2026.07.30"
+date-released: 2026-07-30
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/_templates/author.html
+++ b/_templates/author.html
@@ -1,0 +1,18 @@
+{# Footer author line.
+
+   Overrides the sphinx-book-theme component of the same name so the Zenodo
+   concept DOI sits beside the author's name on every page. That DOI always
+   resolves to the latest release, so it is the one to quote when citing the
+   book. `pid_concept_doi` is set in `html_context` in conf.py, and matches the
+   `identifiers:` entry in CITATION.cff.
+
+   This file sits at the top level of `_templates/`, not under a `components/`
+   subdirectory: pydata-sphinx-theme appends its own `components/` directory to
+   `templates_path`, so the footer includes this template by bare filename.
+#}
+{% if author %}
+<p class="component-author">
+  {{ translate('By') }} {{ author }}{% if pid_concept_doi %} &middot;
+  <a class="pid-concept-doi" href="https://learnche.org/pid/contents">doi:{{ pid_concept_doi }}</a>{% endif %}
+</p>
+{% endif %}

--- a/conf.py
+++ b/conf.py
@@ -54,6 +54,13 @@ the_year = str(datetime.datetime.now().year)
 project = "Process Improvement Using Data"
 author = "Kevin Dunn"
 copyright = f"2010-{the_year} {author}"
+
+# Zenodo mints two kinds of DOI: one per release, and this concept DOI, which
+# always resolves to the latest release and therefore never changes. It is the
+# same value as the `identifiers:` entry in CITATION.cff. Surfaced to the page
+# footer by `_templates/components/author.html`.
+concept_doi = "10.5281/zenodo.20284934"
+html_context = {"pid_concept_doi": concept_doi}
 today_fmt = "%d %B %Y"
 
 # Emit warnings for all missing references.
@@ -289,11 +296,14 @@ if TELEMETRY_ENABLED:
     html_js_files = html_js_files + [("js/telemetry.js", {"defer": "defer"})]
 
     # Surfaced to Jinja templates; gates the sparkline mount in
-    # `_templates/pid-sidebar-extra.html`.
-    html_context = {
-        "pid_telemetry": True,
-        "pid_gc_code": TELEMETRY_GC_CODE,
-    }
+    # `_templates/pid-sidebar-extra.html`. Updated rather than reassigned, so
+    # the concept DOI set above survives into production builds.
+    html_context.update(
+        {
+            "pid_telemetry": True,
+            "pid_gc_code": TELEMETRY_GC_CODE,
+        }
+    )
 
     def _inject_telemetry_globals(app, pagename, templatename, context, doctree):
         # Single inline <script> appended to the per-page metatags context.


### PR DESCRIPTION
The Zenodo concept DOI, the one that always resolves to the latest release, was only visible in `CITATION.cff` and the README. A reader who wanted to cite the book had to leave the page to find it. It now sits beside the author's name in the footer of every page:

> By Kevin Dunn · [doi:10.5281/zenodo.20284934](https://learnche.org/pid/contents)

## What changed

- **`_templates/author.html`** (new): overrides the sphinx-book-theme footer component so the DOI follows the author's name, linked to the book's home page.
- **`conf.py`**: the DOI is defined once, next to `author` and `copyright`, and passed to templates through `html_context`. The telemetry block now calls `html_context.update(...)` instead of reassigning the dict, so the DOI survives into production builds where telemetry is on.

The override sits at the top level of `_templates/` rather than under a `components/` subdirectory. pydata-sphinx-theme appends its own `components/` directory to `templates_path`, so the footer includes this template by bare filename; a copy under `_templates/components/` is never found. There is a comment in the template saying so, since the first attempt made exactly that mistake.

## Verification

- `make html` succeeds; the footer renders as above on `contents`, `preface/index`, and the chapter pages spot-checked.
- `grep -r goatcounter _build/html/contents` returns zero hits.
- `make text` succeeds with zero warnings.
- `make latexpdf` cannot run in this container (no `latexmk` or TeX installation). The LaTeX *writer* was run instead, `sphinx -b latex`, and produces `PID.tex` without error, which confirms `conf.py` still imports and runs cleanly for a non-HTML builder. The change touches an HTML-only template and one `html_context` entry, so the PDF output is unaffected by construction. Worth one local `make latexpdf` before the next release if you want the belt and braces.
- `CITATION.cff` `version:` and `date-released:` set to 2026.07.30. The README attribution year range already ends in 2026.

## One thing to confirm

You asked for the DOI to link to the home page, and that is what it does. The conventional target for a DOI string is the resolver, `https://doi.org/10.5281/zenodo.20284934`, which lands on the Zenodo record. Say the word and it is a one-line change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsTypY4FcRbrXRxorb9raz)_