### PR TITLE
Read release notes from the tag object, not the tagged commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      # actions/checkout writes refs/tags/<tag> as a lightweight ref pointing
+      # straight at the commit, so the annotated tag object never reaches the
+      # runner and its message is lost. Fetching the ref again, with force,
+      # replaces that placeholder with the real tag object.
+      - name: Restore the annotated tag object
+        run: git fetch --force --no-tags origin "+refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}"
+
       - name: Create the GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -26,9 +33,16 @@ jobs:
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
           TITLE="Process Improvement using Data: ${TAG#v} edition"
-          # The annotated tag's message is the release notes. Fall back to
-          # auto-generated notes only if the tag carries no message.
-          NOTES="$(git for-each-ref "refs/tags/${TAG}" --format='%(contents)')"
+          # The annotated tag's message is the release notes. Read it only when
+          # the ref really is a tag object: for a lightweight tag %(contents)
+          # returns the tagged commit's message, which is not release notes.
+          # Fall back to auto-generated notes in that case, and when an
+          # annotated tag carries no message.
+          if [ "$(git cat-file -t "refs/tags/${TAG}")" = "tag" ]; then
+            NOTES="$(git for-each-ref "refs/tags/${TAG}" --format='%(contents)')"
+          else
+            NOTES=""
+          fi
           if [ -n "${NOTES//[[:space:]]/}" ]; then
             printf '%s\n' "$NOTES" > release-notes.md
             gh release create "$TAG" --title "$TITLE" --notes-file release-notes.md


### PR DESCRIPTION
The release published for `v2026.07.29` has a merge-commit message as its entire body instead of the notes written into the tag. This is why.

## The bug

`release.yml` reads the notes with:

```bash
NOTES="$(git for-each-ref "refs/tags/${TAG}" --format='%(contents)')"
```

`actions/checkout` writes `refs/tags/<tag>` as a *lightweight* ref pointing straight at the commit, so the annotated tag object never reaches the runner. `%(contents)` on a ref that resolves to a commit returns the **commit** message. That string is never empty, so the `--generate-notes` fallback never fired, and every release so far has been published with whatever merge-commit message happened to be at the tip.

## The fix

Two parts:

1. A new step re-fetches the tag ref with `--force`, which replaces the placeholder with the real annotated tag object.
2. The message is read only when the ref genuinely is a tag object. A lightweight tag now falls through to `--generate-notes`, which is what the original fallback was meant to cover but could not detect.

## Verification

Reproduced end to end in a scratch clone against the real `v2026.07.29` tag, by recreating the exact state `actions/checkout` leaves behind:

```
before fix, ref type: commit
before fix, %(contents) first line: Merge pull request #248 from kgdunn/claude/draft-paper-pid-book-0z4sjj
--- applying the fix ---
after fix, ref type:  tag
after fix, %(contents) first line: Two new chapters, five new sections on experimental design, and a sweep that
```

Both guard branches were exercised: an annotated tag reads its message, and a lightweight tag falls back to auto-generated notes. The workflow YAML parses, and the `run:` block passes `bash -n`.

## Not covered by this PR

The already-published `v2026.07.29` release keeps its wrong body until it is edited by hand:

```bash
gh release edit v2026.07.29 --repo kgdunn/pid-book \
  --notes "$(git for-each-ref refs/tags/v2026.07.29 --format='%(contents)')"
```

Zenodo took its description from the release when the webhook fired, so that record may need the same correction in the Zenodo interface. The DOI and the archived files are unaffected.

No book content changes, so no `make html` / `make text` verification applies; `CITATION.cff` already carries today's date from #263.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsTypY4FcRbrXRxorb9raz)_