### PR TITLE
Show the scatterplot matrices and heat maps the correlation section describes

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.07.30"
-date-released: 2026-07-30
+version: "2026.08.02"
+date-released: 2026-08-02
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/least-squares-modelling/covariance-and-correlation.rst
+++ b/least-squares-modelling/covariance-and-correlation.rst
@@ -210,91 +210,262 @@ Note that correlation is the same whether we measure temperature in Celsius or K
 	:alt: Example scatter plots with their correlation values
 
 
+.. _LS_scatterplot_matrix:
+
+The scatterplot matrix
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Each panel in that figure takes one pair of variables. A *scatterplot matrix* puts every pair into
+a single display, so a data set with :math:`K` variables is read in one figure instead of
+:math:`K(K-1)/2` separate ones. The layout used in this book carries:
+
+	-	the scatter plot for each pair below the diagonal;
+
+	-	the correlation coefficient :math:`r(x, y)` for that same pair above the diagonal, sized
+		and coloured by its magnitude;
+
+	-	and each variable on its own along the diagonal, drawn as a smooth density curve over a
+		*rug*: a short tick for every value recorded.
+
+The rug is worth drawing next to the curve, because it shows where the readings actually fall. A
+variable recorded in whole numbers, or one that a controller holds at a handful of set points,
+gives evenly spaced ticks that a smooth curve on its own would cover over.
+
+The function below draws that display. It is used again further on in this section for two process
+data sets, so it is written once here:
+
+.. code-block:: python
+
+	import pandas as pd
+	import plotly.graph_objects as go
+	from plotly.subplots import make_subplots
+
+	BLUE, VERMILLION = "#0072B2", "#D55E00"
+
+
+	def density(x, points=256):
+	    """Gaussian kernel density estimate; bandwidth from the nrd0 rule."""
+	    x = np.asarray(x, float)
+	    iqr = np.subtract(*np.percentile(x, [75, 25]))
+	    spread = min(x.std(ddof=1), iqr / 1.349) if iqr > 0 else x.std(ddof=1)
+	    bandwidth = 0.9 * spread * x.size**-0.2
+	    grid = np.linspace(x.min(), x.max(), points)
+	    return grid, np.exp(-0.5 * ((grid[:, None] - x) / bandwidth) ** 2).sum(axis=1)
+
+
+	def r_text(r):
+	    """Two decimals, unless that rounds an imperfect r up to 1.00."""
+	    text = f"{r:+.2f}"
+	    return f"{r:+.3f}" if text in {"+1.00", "-1.00"} and abs(r) != 1 else text
+
+
+	def scatterplot_matrix(data, marker_size=5, opacity=1.0):
+	    """Scatter plots below the diagonal, r above it, distributions on it."""
+	    names, corr = list(data.columns), data.corr()
+	    n = len(names)
+	    # Fade the rug in proportion to the number of readings, so that a few
+	    # thousand ticks show where values pile up instead of filling in solid.
+	    rug_opacity = float(np.clip(30 / len(data), 0.05, 1.0))
+	    fig = make_subplots(rows=n, cols=n, horizontal_spacing=0.012,
+	                        vertical_spacing=0.012)
+	    for i in range(n):
+	        for j in range(n):
+	            at = dict(row=i + 1, col=j + 1)
+	            if i == j:                                # density over a rug
+	                x = data[names[i]].to_numpy(float)
+	                grid, curve = density(x)
+	                fig.add_scatter(x=grid, y=curve / curve.max(), mode="lines",
+	                                line_color=BLUE, **at)
+	                fig.add_scatter(x=x, y=np.zeros_like(x), mode="markers", **at,
+	                                marker=dict(symbol="line-ns-open", size=7,
+	                                            color=BLUE, opacity=rug_opacity))
+	                fig.add_annotation(text=names[i], showarrow=False, **at,
+	                                   x=grid.mean(), y=1.35)
+	                fig.update_yaxes(range=[-0.08, 1.5], **at)
+	            elif i < j:                               # the r value itself
+	                r = corr.iloc[i, j]
+	                fig.add_annotation(text=r_text(r), showarrow=False, x=0, y=0,
+	                                   **at, font=dict(size=11 + 9 * abs(r),
+	                                   color=BLUE if r > 0 else VERMILLION))
+	            else:                                     # the data themselves
+	                fig.add_scatter(x=data[names[j]], y=data[names[i]],
+	                                mode="markers", **at,
+	                                marker=dict(size=marker_size, color=BLUE,
+	                                            opacity=opacity))
+	            fig.update_xaxes(showticklabels=(i == n - 1 and i != j),
+	                             visible=(i >= j), **at)
+	            fig.update_yaxes(showticklabels=(j == 0 and i != j),
+	                             visible=(i >= j), **at)
+	            if j == 0 and i > 0:
+	                fig.update_yaxes(title_text=names[i], **at)
+	            if i == n - 1 and j < n - 1:
+	                fig.update_xaxes(title_text=names[j], **at)
+	    fig.update_layout(showlegend=False, width=190 * n, height=180 * n,
+	                      margin=dict(l=70, r=20, t=20, b=60))
+	    return fig
+
+
+	cylinder = pd.DataFrame({"Temperature": temp, "Pressure": pres,
+	                         "Humidity": humidity})
+	scatterplot_matrix(cylinder, marker_size=8).show()
+
+.. _LS_cylinder_scatterplot_matrix:
+
+.. figure:: ../figures/least-squares/gas-cylinder-scatterplot-matrix.png
+	:width: 700px
+	:align: center
+	:alt: Scatterplot matrix of the cylinder temperature, pressure and humidity readings
+
+	The ten cylinder readings. The two correlations calculated above appear in the top row:
+	:math:`r(T, p) = 0.997` and :math:`r(T, \text{humidity}) = 0.380`. Temperature and pressure lie
+	almost on a straight line, which is what a correlation near :math:`+1` describes. Neither shows
+	any such alignment against humidity.
+
+
 .. _LS_correlation_matrix_in_python:
 
 Visualizing the correlation matrix
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When working with a real data set that has many variables, looking at correlations one pair at a
-time is tedious. Pandas can compute every pairwise correlation in one call with ``.corr()``, and we
-can visualize the resulting matrix as a *heat map* to spot patterns at a glance.
-
-The example below uses a `flotation cell <https://openmv.net/info/flotation-cell>`_ data set:
+Pandas computes every pairwise correlation in one call with ``.corr()``, returning a square,
+symmetric matrix with ones down the diagonal. The example below uses a `flotation cell
+<https://openmv.net/info/flotation-cell>`_ data set: five process tags, sampled every 30 seconds,
+2922 samples in all. The first column holds the date and time; reading it in as the index leaves
+``.corr()`` with only the five numeric columns to work on.
 
 .. code-block:: python
 
-	import pandas as pd
-
-	flot = pd.read_csv("https://openmv.net/file/flotation-cell.csv")
+	flot = pd.read_csv(
+	    "https://openmv.net/file/flotation-cell.csv", index_col=0
+	)
+	flot.shape                # (2922, 5)
 
 	# A square matrix of correlation values, one
 	# per pair of numeric columns:
-	flot.corr()
+	flot.corr().round(3)
 
-For a wider data set, the numeric matrix becomes hard to read; a heat map encodes the same
-information visually. Here we use a `distillation column
-<https://openmv.net/info/distillation-tower>`_ data set, where the goal is to predict
-``VapourPressure`` from process measurements:
+	scatterplot_matrix(flot, marker_size=3, opacity=0.15).show()
+
+.. _LS_flotation_scatterplot_matrix:
+
+.. figure:: ../figures/least-squares/flotation-cell-scatterplot-matrix.png
+	:width: 800px
+	:align: center
+	:alt: Scatterplot matrix of the five flotation cell variables
+
+	The five flotation cell tags. The strongest correlation in the whole matrix is
+	:math:`r = 0.44`, between the feed rate and the copper sulphate added; the rest are below 0.2.
+	Two of the diagonals show what the rug is for: the air flow rate is recorded to two decimals,
+	so its readings sit on a small number of discrete levels, and the copper sulphate dosage
+	spends part of the record at zero.
+
+The same matrix can be shown as a *heat map*: one coloured cell per pair, on a diverging scale
+running from :math:`-1`, through white at zero, to :math:`+1`. Reading the colour rather than the
+number means a near-zero correlation is pale whatever its sign, and the sign of a large correlation
+is read from the direction of the colour rather than from a minus sign.
 
 .. code-block:: python
 
-	import pandas as pd
-	import seaborn as sns
+	def correlation_heatmap(data, annotate=False, size=600):
+	    """The correlation matrix as a diverging colour map, red high, blue low."""
+	    corr = data.corr()
+	    fig = go.Figure(go.Heatmap(
+	        z=corr, x=corr.columns, y=corr.columns, zmin=-1, zmax=1,
+	        colorscale="RdBu_r", xgap=1, ygap=1,
+	        texttemplate="%{z:+.2f}" if annotate else None,
+	        colorbar=dict(title="r(x, y)", len=0.7),
+	    ))
+	    fig.update_yaxes(autorange="reversed", scaleanchor="x")
+	    fig.update_layout(width=size * 1.25, height=size)
+	    return fig
+
+
+	correlation_heatmap(flot, annotate=True).show()
+
+.. _LS_flotation_heatmap:
+
+.. figure:: ../figures/least-squares/flotation-cell-correlation-heatmap.png
+	:width: 650px
+	:align: center
+	:alt: Correlation heat map of the five flotation cell variables
+
+	The flotation cell correlation matrix as a heat map. With five variables the numbers still fit
+	inside the cells, so this display and the printed matrix carry the same information. The
+	diagonal is :math:`+1` by construction, since :math:`r(x, x) = 1`.
+
+The heat map earns its place as the number of variables grows. The `distillation column
+<https://openmv.net/info/distillation-tower>`_ data set has 27 variables recorded on 253 days,
+where the goal is to predict ``VapourPressure`` from the process measurements. That is 351 distinct
+pairs, more than can be read from a table of numbers.
+
+.. code-block:: python
 
 	distill = pd.read_csv(
-	    "https://openmv.net/file/distillation-tower.csv"
+	    "https://openmv.net/file/distillation-tower.csv", index_col=0
 	)
+	distill.shape             # (253, 27)
 
-	# Print the correlation matrix as numbers:
-	display(distill.corr())
+	correlation_heatmap(distill, size=800).show()
 
-	# A diverging palette is helpful: red for
-	# positive, blue for negative correlations,
-	# white for near-zero.
-	cmap = sns.diverging_palette(220, 10, as_cmap=True)
-	sns.set(rc={"figure.figsize": (15, 15)})
-	sns.heatmap(
-	    distill.corr(),
-	    cmap=cmap,
-	    square=True,
-	    linewidths=0.2,
-	    cbar_kws={"shrink": 0.5},
-	)
+.. _LS_distillation_heatmap:
 
-A complementary view is the *scatter plot matrix*, which shows the actual data behind each
-correlation. The diagonal panels are replaced by a kernel density estimate (kde) of each variable's
-distribution:
+.. figure:: ../figures/least-squares/distillation-tower-correlation-heatmap.png
+	:width: 800px
+	:align: center
+	:alt: Correlation heat map of the 27 distillation column variables
+
+	The 27 distillation column variables. The colour shows structure that the numbers on their own
+	would not: a large block of tray temperatures that move together, the three ``InvTemp``
+	columns opposing that block, and a few variables (``PressureC1``, ``TempC3``, ``Temp4``) that
+	stay pale against everything else, meaning they carry information the rest do not.
+
+A scatterplot matrix of all 27 variables would need 351 panels and would not be readable at any
+printable size. The usual approach is to select a few columns and show those. When the goal is to
+model a particular outcome variable, the row of the correlation matrix belonging to that outcome
+ranks every potential predictor by how strongly it correlates with the outcome.
 
 .. code-block:: python
 
-	from pandas.plotting import scatter_matrix
+	# How each variable correlates with the outcome
+	# variable, VapourPressure, strongest first:
+	outcome = distill.corr()["VapourPressure"].drop("VapourPressure")
+	outcome.reindex(
+	    outcome.abs().sort_values(ascending=False).index
+	).round(3)
+	# InvTemp3        0.927
+	# Temp9          -0.918
+	# InvTemp1        0.912
+	# ...
+	# TempC3         -0.018
+	# InvPressure1   -0.015
+	# PressureC1      0.005
 
-	scatter_matrix(
-	    distill,
-	    alpha=0.2,
-	    figsize=(15, 15),
-	    diagonal="kde",
-	)
+	# Five columns spanning that range, from the strongest
+	# negative correlation with VapourPressure through to
+	# the strongest positive one:
+	subset = ["Temp9", "Temp7", "OC1", "InvTemp3", "VapourPressure"]
+	scatterplot_matrix(distill[subset], marker_size=4, opacity=0.55).show()
 
-	# For large data sets, sub-sample to speed
-	# up the plot, e.g. every second row:
-	scatter_matrix(
-	    distill.iloc[0::2, :],
-	    alpha=0.2,
-	    figsize=(15, 15),
-	    diagonal="kde",
-	)
+.. _LS_distillation_scatterplot_matrix:
 
-When the goal is to model a particular outcome variable (here ``VapourPressure``), the most useful
-slice of the correlation matrix is its last row: it ranks every potential predictor by how strongly
-it correlates with the outcome.
+.. figure:: ../figures/least-squares/distillation-tower-scatterplot-matrix.png
+	:width: 800px
+	:align: center
+	:alt: Scatterplot matrix of five distillation column variables
 
-.. code-block:: python
+	Five of the 27 distillation column variables, ordered from the strongest negative correlation
+	with ``VapourPressure`` through to the strongest positive one. The bottom row shows what each
+	of those correlations corresponds to in the data: a tight band for ``InvTemp3`` at
+	:math:`r = +0.93`, a looser one for ``Temp9`` at :math:`r = -0.92`, and no visible alignment
+	for ``OC1`` at :math:`r = +0.33`.
 
-	# The last row of the correlation matrix shows
-	# how each x-variable correlates with the
-	# outcome variable VapourPressure.
-	distill.corr().iloc[-1, :]
+One pair in that figure is worth a second look. ``InvTemp3`` and ``Temp9`` have
+:math:`r = -0.998`, and their product is 1000 to within a rounding error: ``InvTemp3`` is
+:math:`1000 / \text{Temp9}`, a column derived from another one rather than a separate measurement.
+The reciprocal is not a linear function, but over the narrow range these temperatures cover it is
+close enough to one that the correlation is nearly perfect. Wide process data sets often carry
+engineered columns of this sort, and the cells near :math:`\pm 1` in the heat map are where they
+show up.
 
 
 .. _LS_correlation_near_zero_example:
@@ -302,26 +473,44 @@ it correlates with the outcome.
 What does a near-zero correlation look like?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The cylinder-pressure, distillation-tower and flotation-cell examples above all show *strong*
-correlations. It is just as important to develop intuition for what :math:`r \approx 0` looks like
-in real data. The `unlimited-time-test <https://openmv.net/info/unlimited-time-test>`_ data set is
-a useful counter-example: students were given as much time as they wanted to write an open-book
-exam, and we have two columns: ``Time`` taken to finish, and the ``Grade`` achieved.
+The :ref:`cylinder-pressure <LS_cylinder_scatterplot_matrix>` and :ref:`distillation-tower
+<LS_distillation_scatterplot_matrix>` examples both contain *strong* correlations, and the
+:ref:`flotation-cell example <LS_flotation_scatterplot_matrix>` only weak ones. It is just as
+important to develop intuition for what :math:`r \approx 0` looks like in a data set with two
+variables and nothing else to distract from them. The `unlimited-time-test
+<https://openmv.net/info/unlimited-time-test>`_ data set serves as that counter-example: 80
+students were given as much time as they wanted to write an open-book exam, and there are two
+columns, the ``Time`` taken to finish and the ``Grade`` achieved.
 
 .. code-block:: python
-
-	import pandas as pd
 
 	grades = pd.read_csv(
 	    "https://openmv.net/file/unlimited-time-test.csv"
 	)
-	grades.plot.scatter(x="Time", y="Grade", figsize=(8, 6))
 
-	# Correlation of -0.044 -- essentially zero.
-	grades.corr()
+	# Correlation of -0.044: essentially zero.
+	grades.corr().round(3)
 
-The scatter plot shows no visible pattern, and the correlation matrix confirms it: :math:`r =
--0.044`. Two things are worth noting from this example:
+	fig = go.Figure(go.Scatter(x=grades["Time"], y=grades["Grade"],
+	                           mode="markers"))
+	fig.update_layout(xaxis_title="Time to finish the test [minutes]",
+	                  yaxis_title="Grade achieved [%]",
+	                  width=800, height=600)
+	fig.show()
+
+.. _LS_unlimited_time_scatter:
+
+.. figure:: ../figures/least-squares/unlimited-time-test-scatter.png
+	:width: 700px
+	:align: center
+	:alt: Time taken against grade achieved, showing no relationship
+
+	Time taken against grade achieved for 80 students writing an open-book exam with no time
+	limit. Grades in the 70s and 90s appear at every finishing time, and the slowest finishers are
+	spread over the full range of grades.
+
+The scatter plot shows no visible pattern, and the correlation matrix agrees: :math:`r = -0.044`.
+Two things are worth noting from this example:
 
 	-	The correlation is *symmetric*: :math:`r(\text{Time}, \text{Grade}) = r(\text{Grade},
 		\text{Time}) = -0.044`. There is no notion of an :math:`x`- or :math:`y`-variable yet.

--- a/least-squares-modelling/covariance-and-correlation.rst
+++ b/least-squares-modelling/covariance-and-correlation.rst
@@ -215,7 +215,7 @@ Note that correlation is the same whether we measure temperature in Celsius or K
 The scatterplot matrix
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Each panel in that figure takes one pair of variables. A *scatterplot matrix* puts every pair into
+A scatter plot handles one pair of variables at a time. A *scatterplot matrix* puts every pair into
 a single display, so a data set with :math:`K` variables is read in one figure instead of
 :math:`K(K-1)/2` separate ones. The layout used in this book carries:
 

--- a/least-squares-modelling/covariance-and-correlation.rst
+++ b/least-squares-modelling/covariance-and-correlation.rst
@@ -366,9 +366,15 @@ is read from the direction of the colour rather than from a minus sign.
 
 .. code-block:: python
 
-	def correlation_heatmap(data, annotate=False, size=600):
-	    """The correlation matrix as a diverging colour map, red high, blue low."""
+	def correlation_heatmap(data, annotate=False, size=600, order=None):
+	    """The correlation matrix as a diverging colour map, red high, blue low.
+
+	    `order` optionally lists the column names in the order to show them;
+	    the default keeps the order they appear in the data set.
+	    """
 	    corr = data.corr()
+	    if order is not None:
+	        corr = corr.loc[order, order]
 	    fig = go.Figure(go.Heatmap(
 	        z=corr, x=corr.columns, y=corr.columns, zmin=-1, zmax=1,
 	        colorscale="RdBu_r", xgap=1, ygap=1,
@@ -398,26 +404,81 @@ The heat map earns its place as the number of variables grows. The `distillation
 where the goal is to predict ``VapourPressure`` from the process measurements. That is 351 distinct
 pairs, more than can be read from a table of numbers.
 
+The order of the rows and columns is a free choice, and it changes how much the display shows.
+Left in the order the variables appear in the file, related variables are scattered and the eye has
+to assemble the pattern. Reordering so that correlated variables sit next to each other gathers
+them into blocks along the diagonal. The reordering here comes from *hierarchical clustering*: the
+distance between two variables is taken as :math:`1 - r(x, y)`, which is 0 for a pair that moves
+exactly together and 2 for a pair that moves exactly opposite; variables are then merged into
+successively larger groups (average linkage), and the columns are read off in the order the
+resulting tree places its leaves. This is the "by cluster" ordering that the `D3 Les Miserables
+co-occurrence matrix <https://bost.ocks.org/mike/miserables/>`_ offers alongside ordering by name
+and by frequency.
+
 .. code-block:: python
+
+	from scipy.cluster.hierarchy import leaves_list, linkage
+	from scipy.spatial.distance import squareform
 
 	distill = pd.read_csv(
 	    "https://openmv.net/file/distillation-tower.csv", index_col=0
 	)
 	distill.shape             # (253, 27)
 
-	correlation_heatmap(distill, size=800).show()
+
+	def cluster_order(corr):
+	    """Variable names reordered so that correlated ones sit together."""
+	    distance = 1 - corr.to_numpy()      # 0 when r = +1, 2 when r = -1
+	    np.fill_diagonal(distance, 0.0)
+	    # squareform wants the condensed upper triangle; the matrix is
+	    # symmetric up to floating-point noise, which checks=False allows.
+	    tree = linkage(squareform(distance, checks=False), method="average",
+	                   optimal_ordering=True)
+	    return [corr.columns[i] for i in leaves_list(tree)]
+
+
+	correlation_heatmap(distill, size=800,
+	                    order=cluster_order(distill.corr())).show()
 
 .. _LS_distillation_heatmap:
 
 .. figure:: ../figures/least-squares/distillation-tower-correlation-heatmap.png
 	:width: 800px
 	:align: center
-	:alt: Correlation heat map of the 27 distillation column variables
+	:alt: Clustered correlation heat map of the 27 distillation column variables
 
-	The 27 distillation column variables. The colour shows structure that the numbers on their own
-	would not: a large block of tray temperatures that move together, the three ``InvTemp``
-	columns opposing that block, and a few variables (``PressureC1``, ``TempC3``, ``Temp4``) that
-	stay pale against everything else, meaning they carry information the rest do not.
+	The 27 distillation column variables, with rows and columns reordered by hierarchical
+	clustering. The nine tray temperatures from ``Temp8`` through to ``Temp2`` form the dark red
+	core, correlated at :math:`0.65` and above with each other. ``VapourPressure`` sits with the
+	three ``InvTemp`` columns in a group of its own, correlated at :math:`0.87` and above
+	internally and between :math:`-0.65` and :math:`-0.998` against those nine temperatures: this
+	is the block of dark blue in the upper right. The five flow measurements from ``FlowC1`` to
+	``FlowC4`` are correlated at :math:`0.70` and above among themselves and more loosely with the
+	temperature core, reaching :math:`0.75` at most. ``Temp1``, ``TempC3`` and ``Temp4`` form a
+	small group correlated :math:`0.84` and above with each other but no more than :math:`0.14`
+	with anything else in the data set. ``FlowC2`` joins nothing: its strongest correlation
+	anywhere is :math:`0.41`.
+
+Because the distance is :math:`1 - r`, a pair that moves exactly opposite is treated as the
+furthest apart two variables can be, so a strongly negative pair ends up at opposite ends of the
+ordering rather than side by side. ``InvPressure1`` and ``PressureC1`` at :math:`r = -0.998` are
+the clearest case: they are the first and the twenty-fourth column, and their cell is the dark blue
+square in the top right. Use :math:`1 - |r(x, y)|` as the distance instead when the direction of
+the relationship does not matter and such pairs should be grouped together.
+
+That freedom cuts both ways. The correlation values are fixed by the data, but which of them the
+reader notices is set by the ordering, and the ordering is chosen by whoever draws the figure.
+Ordering by :math:`1 - r` produces the blocks above; ordering by :math:`1 - |r|` produces
+different blocks from the same numbers; ordering by each variable's correlation with
+``VapourPressure`` puts the predictors of interest at one end and says nothing about how they
+relate to each other; and an order chosen to separate variables that belong together can make a
+clear structure look like noise. None of these is wrong, and none can be checked from the picture
+alone, so state which ordering a heat map uses whenever it is not the order the variables appear
+in the data set.
+
+The flotation cell heat map was left in the order the variables appear in the file. With five
+variables there is little for a reordering to reveal, and the labels are easier to find when they
+stay where the data set puts them.
 
 A scatterplot matrix of all 27 variables would need 351 panels and would not be readable at any
 printable size. The usual approach is to select a few columns and show those. When the goal is to


### PR DESCRIPTION
The [covariance and correlation section](https://learnche.org/pid/least-squares-modelling/covariance-and-correlation#correlation) explained the scatterplot matrix and the correlation heat map, and printed code for neither's output. A reader reached the end of it without ever seeing either display. Six figures now appear.

Figures PR: kgdunn/figures#77 (must merge for the images to resolve; see "CI" below).

## What changed

**A new "The scatterplot matrix" subsection** (`LS_scatterplot_matrix`), between the correlation examples and the correlation-matrix subsection. It defines the layout used throughout the book (scatter plots below the diagonal, `r` above it, a density curve over a rug on it), gives the plotly helper that draws it, and applies it to the ten cylinder readings the section has just worked through by hand. The 0.997 and 0.380 calculated in the prose are now also visible in the top row of a figure.

**The flotation cell data set** gains both a scatterplot matrix and an annotated heat map. At five variables the numbers still fit inside the heat map cells, so the two displays can be compared directly, which is the point of introducing the heat map there rather than later.

**The distillation column data set** gains the full 27-variable heat map, plus a five-column scatterplot matrix spanning the range of correlation with `VapourPressure` (from `Temp9` at -0.918 to `InvTemp3` at +0.927). A closing paragraph notes that `InvTemp3` is `1000 / Temp9`: their product is 1000 to within a rounding error, which is why some cells in the heat map sit at almost exactly -1.

**The near-zero example** now shows its scatter plot instead of only asserting that no pattern is visible.

## Clustered ordering, and what the ordering choice costs

The 27-variable heat map reorders its rows and columns by hierarchical clustering on the distance `1 - r`, average linkage, `optimal_ordering=True`, read off in dendrogram leaf order. This is the "by cluster" option the [D3 Les Miserables co-occurrence matrix](https://bost.ocks.org/mike/miserables/) offers. Correlated variables gather into blocks on the diagonal instead of being scattered through the order the file happens to use. The caption names the four groups that separate out with the correlation range holding each together, and a following paragraph explains why a strongly negative pair such as `InvPressure1` and `PressureC1` (r = -0.998) lands at opposite ends rather than side by side.

A second paragraph makes the cost explicit. The correlation values are fixed by the data, but which of them a reader notices is set by the ordering, and the ordering is chosen by whoever draws the figure. The same numbers under `1 - |r|`, or ordered by correlation with the outcome variable, or ordered to split variables that belong together, support different readings, and none of that is checkable from the picture. The text asks for the ordering to be stated whenever it is not the order the variables appear in the data set.

`correlation_heatmap` gained an optional `order=` argument rather than a second definition, so the flotation cell call is unchanged and keeps file order.

## Corrections folded in

- `distill.corr()` and `flot.corr()` as written raised `ValueError: could not convert string to float` on pandas 2 and later, because both CSVs carry a leading date column. Both loads now pass `index_col=0`.
- The prose read "The cylinder-pressure, distillation-tower and flotation-cell examples above all show *strong* correlations." The flotation cell's strongest correlation is 0.44 and the rest are below 0.2, so that sentence now separates it from the other two and links to each with an explicit `:ref:`.

## What did not change

The seaborn and `pandas.plotting.scatter_matrix` code is replaced with plotly, matching the rest of the book; the helper is defined once and reused for all three data sets. No equations, definitions, or exercises were touched, and the covariance section is unchanged apart from the figures that follow it.

## Verification

Every number quoted in the prose was reproduced against the openmv.net data:

| Quantity | Value |
| --- | --- |
| r(temperature, pressure) | 0.9968 |
| r(temperature, humidity) | 0.3804 |
| Flotation cell shape / strongest r | 2922 x 5 / 0.438 |
| Distillation tower shape / pairs | 253 x 27 / 351 |
| r(`InvTemp3`, `VapourPressure`) | +0.927 |
| r(`Temp9`, `VapourPressure`) | -0.918 |
| r(`Temp9`, `InvTemp3`) | -0.9982 |
| r(`InvPressure1`, `PressureC1`) | -0.9979 |
| r(`Time`, `Grade`) | -0.0442 |

Block statistics in the clustered caption were recomputed against the exact ranges named: 0.65 within the nine tray temperatures, 0.87 within the `VapourPressure`/`InvTemp` group, -0.65 to -0.998 between them, 0.70 within the flows, 0.84 within `Temp1`/`TempC3`/`Temp4` against at most 0.14 elsewhere, 0.41 for `FlowC2`. The chapter's `cluster_order` reproduces the committed figure's column order exactly.

The plotly code in the chapter was run end to end and renders every figure.

- `make text`: build succeeded, zero warnings.
- `make html` (clean `_build`): build succeeded, zero Sphinx warnings, all six new images copied into `_build/html/_images/`.
- `grep -r goatcounter _build/html/contents`: 0 hits.

`CITATION.cff` `version:` and `date-released:` bumped to 2026.08.02. The README year range already ends in 2026.

## CI

`build-and-deploy` is red, blocked on the figures PR rather than on this diff. `build-deploy.yml` checks out `kgdunn/figures` with no `ref:`, so it gets `figures@main`, which does not yet carry the six PNGs, and pdflatex hard-stops on the first missing file. The Sphinx HTML stage passes; only the PDF stage fails. Merging kgdunn/figures#77 and re-running this build is the fix. Details in [this comment](https://github.com/kgdunn/pid-book/pull/265#issuecomment-5158258268).