### PR TITLE
Count complete days only, and stop calling the sparkline "year-long"

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.08.02"
-date-released: 2026-08-02
+version: "2026.08.03"
+date-released: 2026-08-03
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/_static/js/telemetry.js
+++ b/_static/js/telemetry.js
@@ -46,10 +46,14 @@
   // Front-end display window.
   //
   // The backend (build-sparklines.py + /etc/pid-book/sparklines.conf)
-  // keeps a 365-day window in /_stats/sparklines.json. The in-book UI
-  // is intentionally narrower: showing 365-day totals on a young
-  // deployment (or one with historical log gaps) makes pages look
-  // unread when they are actually being read every day.
+  // keeps a rolling 365-day window in /_stats/sparklines.json. That is
+  // the ceiling, not the current contents: the access-log history only
+  // starts in May 2026 (see stats.rst), so the file holds however many
+  // days have accumulated since then and grows by one per night.
+  //
+  // The in-book UI is intentionally narrower than the backend window:
+  // showing 365-day totals while the history is still filling in makes
+  // pages look unread when they are actually being read every day.
   //
   // Change DISPLAY_DAYS in lockstep with the labels that mention "N
   // days" in:
@@ -60,16 +64,34 @@
   var DISPLAY_DAYS = 60;
   var DISPLAY_LABEL = DISPLAY_DAYS + " days";
 
-  // Find the most recent date present anywhere in the JSON. Used as
-  // the anchor for the rolling display window. Series are sorted
-  // ascending in the producer, so the last element holds the latest.
+  // The newest day that can possibly be complete, in UTC. The nightly
+  // builder already stops at yesterday (lag_days), but a server still
+  // running the older script publishes a bucket for the running day
+  // holding only a few hours of traffic, which plots as a near-zero
+  // cliff at the right-hand edge. Bounding the window here keeps the
+  // charts correct regardless of which build of the script is deployed.
+  function lastCompleteDate() {
+    var d = new Date();
+    d.setUTCDate(d.getUTCDate() - 1);
+    return d.toISOString().slice(0, 10);
+  }
+
+  // Find the most recent *complete* date present anywhere in the JSON.
+  // Used as the anchor for the rolling display window. Series are sorted
+  // ascending in the producer, so we walk back from the end and take the
+  // first point that is not the running day. Returns "" when the file
+  // holds nothing but a partial day (or nothing at all).
   function globalAnchorDate(data) {
+    var limit = lastCompleteDate();
     var max = "";
     for (var page in data) {
       var s = data[page];
-      if (s && s.length) {
-        var last = s[s.length - 1][0];
-        if (last > max) max = last;
+      if (!s) continue;
+      for (var i = s.length - 1; i >= 0; i--) {
+        var d = s[i][0];
+        if (d > limit) continue;
+        if (d > max) max = d;
+        break;
       }
     }
     return max;
@@ -84,9 +106,14 @@
     return d.toISOString().slice(0, 10);
   }
 
-  function filterToWindow(series, cutoff) {
-    if (!series || !cutoff) return series || [];
-    return series.filter(function (p) { return p[0] >= cutoff; });
+  // Clip a series to [cutoff, anchor] inclusive. The upper bound drops
+  // the running day; an empty cutoff means no complete day was found,
+  // in which case there is nothing safe to plot.
+  function filterToWindow(series, cutoff, anchor) {
+    if (!series || !cutoff) return [];
+    return series.filter(function (p) {
+      return p[0] >= cutoff && p[0] <= anchor;
+    });
   }
 
   // 1. Path normalisation: extensionless URLs, fold trailing slash and /index.
@@ -184,12 +211,12 @@
         return r.json();
       })
       .then(function (data) {
-        // The JSON is the full 365-day window; the UI shows only
-        // the most recent DISPLAY_DAYS days from the global anchor
-        // (so different pages compare against the same date range).
+        // The JSON holds up to 365 days; the UI shows only the most
+        // recent DISPLAY_DAYS complete days from the global anchor (so
+        // different pages compare against the same date range).
         var anchor = globalAnchorDate(data);
         var cutoff = cutoffDateString(anchor, DISPLAY_DAYS);
-        var series = filterToWindow(data && data[pageKey], cutoff);
+        var series = filterToWindow(data && data[pageKey], cutoff, anchor);
         if (!series || !series.length) {
           // No history for this page in the display window (fresh
           // page, content blocker tampering, or genuinely unread for
@@ -310,17 +337,20 @@
         var pages = data && Object.keys(data);
         if (!pages || !pages.length) { showEmpty(); return; }
 
-        // The JSON holds 365 days; the UI shows the most recent
-        // DISPLAY_DAYS days only. Compute the cutoff once and filter
-        // every per-page series through it before aggregating.
+        // The JSON holds up to 365 days; the UI shows the most recent
+        // DISPLAY_DAYS complete days only. Compute the bounds once and
+        // filter every per-page series through them before aggregating,
+        // so the summary cards, the daily chart, and the top-pages
+        // table all describe exactly the same date range.
         var anchor = globalAnchorDate(data);
+        if (!anchor) { showEmpty(); return; }
         var cutoff = cutoffDateString(anchor, DISPLAY_DAYS);
 
         var totalReads = 0;
         var dailyMap = {};
         var pageTotals = [];
         pages.forEach(function (page) {
-          var series = filterToWindow(data[page], cutoff);
+          var series = filterToWindow(data[page], cutoff, anchor);
           var pageTotal = 0;
           series.forEach(function (p) {
             var date = p[0], count = p[1] | 0;

--- a/docs/telemetry/README.md
+++ b/docs/telemetry/README.md
@@ -66,18 +66,64 @@ self-hosting reusers.
 3. **Search-query events** — what readers type into the sidebar
    search box, debounced and PII-stripped, sent to GoatCounter as
    custom events.
-4. **Per-page year-long sparkline + reader count** — derived from the
+4. **Per-page sparkline + reader count**, derived from the
    access logs by `scripts/server/build-sparklines.py` into a public
    `sparklines.json`, rendered with a same-origin ECharts build in
-   the sidebar of every page. The 365-day total reads for the current
-   page are written next to the heading. Because it is log-derived it
-   counts ad-blocked readers — the *honest* signal.
+   the sidebar of every page. The backend is configured for a rolling
+   365-day window, but it holds only as much history as the logs do:
+   the archive starts in late May 2026 (see "History depth" below) and
+   reaches a full year in May 2027. The sidebar shows the most recent
+   60 days and writes that total next to the heading. Because it is
+   log-derived it counts ad-blocked readers too.
 5. **In-book stats page** — [`/pid/stats`](https://learnche.org/pid/stats)
    reads the same `sparklines.json` and shows three site-wide
    widgets: a summary (total reads / pages with traffic / days of
    data), a daily totals chart across the whole book, and a top-20
    most-read pages table. All filled by `telemetry.js` at runtime;
    empty-state hides the widgets cleanly when no data is available.
+
+## History depth: the window is a ceiling, not a promise
+
+`sparklines.json` is configured for a rolling 365-day window, and both
+this document and the code comments used to describe it as "year-long".
+That was never true in practice and is worth stating plainly:
+
+* Debian's stock `/etc/logrotate.d/apache2` ships `rotate 4`, so the
+  learnche.org access logs were **purged every four days** until
+  2026-05-26. Almost nothing between Feb 2022 and May 2026 survives on
+  disk. That history is gone and cannot be reconstructed.
+* Retention was raised to `rotate 1825` (5 years) on 2026-05-26, and
+  real client IPs have been logged since 2026-05-24 (`mod_remoteip` +
+  `CF-Connecting-IP`); before that, deduplication happened on
+  Cloudflare edge IPs and undercounted by roughly 10-50×.
+
+So the usable archive starts in **late May 2026** and grows by one day
+per night. It reaches the full 365-day window in **May 2027**; a
+year-on-year comparison needs two years on disk, so mid-2028.
+
+Practical consequences:
+
+* Do not describe the sparkline as "year-long" in reader-facing copy.
+  The in-book display window (`DISPLAY_DAYS`, currently 60) exists
+  precisely because the backing history is still short.
+* A page whose total looks low may simply predate the archive.
+* When the window looks wrong, check the log archive depth before
+  suspecting the aggregator. `operations.md` has the commands.
+
+## Complete days only
+
+The nightly cron runs in the small hours, so at the moment it fires the
+current day's bucket holds only a few hours of traffic. Publishing it
+put a near-zero point at the right-hand edge of every chart, every day,
+which reads as a collapse in traffic rather than an artefact of when the
+job ran.
+
+`build-sparklines.py` therefore ends its window `lag_days` days back
+(default 1, i.e. yesterday), so every published bucket covers a full 24
+hours. `telemetry.js` independently clips its display window to the last
+complete UTC day, so the charts stay correct even against a server still
+running an older build of the script. Set `lag_days = 0` in
+`sparklines.conf` to publish the running day again.
 
 ## Operating principles
 
@@ -106,8 +152,10 @@ self-hosting reusers.
 ## Threat model in one paragraph
 
 We trust GoatCounter to discard IPs and not set cookies (their public
-docs and code make this checkable). We trust our own webserver to
-rotate access logs within 30 days. We do not protect against a
+docs and code make this checkable). We trust our own webserver to hold
+the raw access logs securely for their retention period (currently 5
+years, raised from 4 days on 2026-05-26 so that the readership history
+survives) and to expose only the aggregates. We do not protect against a
 network adversary correlating the GoatCounter request with the ECharts
 fetch on the same TLS connection (theoretically possible, practically
 irrelevant for an open educational site). We do not run our own

--- a/docs/telemetry/architecture.md
+++ b/docs/telemetry/architecture.md
@@ -57,8 +57,10 @@ spots.
   readers, machine-to-machine fetches, and old-browser readers.
 * **Output:** static HTML report at
   <https://learnche.org/_stats/>, regenerated nightly.
-* **Privacy posture:** invoked with `--anonymize-ip`; raw logs rotate
-  within 30 days; only aggregated daily roll-ups survive.
+* **Privacy posture:** invoked with `--anonymize-ip`; only aggregated
+  daily roll-ups are published. Raw logs are retained for 5 years
+  (`rotate 1825`, set 2026-05-26); the previous 4-day rotation is what
+  destroyed the pre-May-2026 history.
 * **Limitations:** doesn't measure engagement (no time-on-page, no
   scroll depth), inflated by bots without filtering.
 
@@ -96,15 +98,19 @@ spots.
 * **Limitations:** same ad-block undercounting as Layer B; the
   email-regex guard is heuristic, not bulletproof.
 
-### Layer D — Per-page year-long sparkline
+### Layer D — Per-page sparkline
 
 * **Source:** same access logs as Layer A, processed by
   [`scripts/server/build-sparklines.py`](../../scripts/server/build-sparklines.py)
   into a public JSON file
   `https://learnche.org/_stats/sparklines.json`.
+* **Window:** configured for a rolling 365 days, ending at the last
+  complete day (the running day is excluded; see `lag_days`). The file
+  holds only as much history as the logs do, which currently means late
+  May 2026 onward. See "History depth" in
+  [`README.md`](README.md#history-depth-the-window-is-a-ceiling-not-a-promise).
 * **Strength:** because it derives from server logs, it counts
-  **ad-blocked readers** too — making it the *honest* signal in the
-  sidebar. Each page shows its own trend.
+  **ad-blocked readers** too. Each page shows its own trend.
 * **Output:** ECharts SVG line chart in the sidebar, lazy-loaded only
   when a `#pid-sparkline` mount point exists.
 * **Privacy posture:** the JSON is aggregate-only — daily unique-IP
@@ -193,9 +199,11 @@ We do **not** defend against:
 * **Compromise of the GoatCounter SaaS.** If their data is leaked it
   contains anonymous pageview hits and search queries, no cookies, no
   IPs. Damage is bounded.
-* **Compromise of the production webserver.** Raw logs exist for up
-  to 30 days; an attacker with shell access could see IPs. Mitigated
-  by standard server hardening (out of scope for this doc).
+* **Compromise of the production webserver.** Raw logs are retained
+  for 5 years, so an attacker with shell access could see IPs over
+  that whole span. This is the cost of keeping the readership history
+  after the 4-day rotation destroyed the earlier archive. Mitigated by
+  standard server hardening (out of scope for this doc).
 
 ## Why not just one provider for everything
 

--- a/docs/telemetry/build-and-deploy.md
+++ b/docs/telemetry/build-and-deploy.md
@@ -158,7 +158,7 @@ has two telemetry-related blocks:
 ```jinja
 {% if pid_telemetry %}
 <hr/>
-<p style="color:#777; font-size:0.85em; margin:0.3em 0 0.1em">Page views (365 days)</p>
+<p style="color:#777; font-size:0.85em; margin:0.3em 0 0.1em">Page views (60 days)</p>
 <div id="pid-sparkline" style="width:100%; height:38px"
      data-page="{{ pagename }}"></div>
 {% endif %}

--- a/docs/telemetry/client.md
+++ b/docs/telemetry/client.md
@@ -293,7 +293,7 @@ if (!series || !series.length) {
 
 A page with no historical data (e.g. a freshly added page like
 `privacy` itself) gets **no UI at all** — we hide both the mount
-and the "Page views (365 days)" heading. The alternative (showing a
+and the "Page views (60 days)" heading. The alternative (showing a
 "0 hits" placeholder) would be misleading and visually noisy.
 
 ### Phase 4c.5 — reader count in the heading
@@ -311,7 +311,7 @@ if (totalEl) {
 
 The `<span id="pid-sparkline-total">` ships from
 `_templates/pid-sidebar-extra.html`, floated to the right of the
-"Page views (365 days)" heading. Tabular-numeric CSS keeps the digits
+"Page views (60 days)" heading. Tabular-numeric CSS keeps the digits
 aligned across pages. The `if (totalEl)` guard makes this a no-op
 when an older cached template doesn't have the span — pageview
 tracking and the sparkline still work.

--- a/docs/telemetry/operations.md
+++ b/docs/telemetry/operations.md
@@ -133,6 +133,18 @@ curl -sI https://learnche.org/_stats/sparklines.json | grep -i last-modified
 curl -s https://learnche.org/_stats/sparklines.json |
     python3 -c "import json,sys; d=json.load(sys.stdin);
 print('pages:', len(d), '— sample:', d.get('contents', [])[-1:])"
+
+# 6. The newest bucket is yesterday, not today.
+curl -s https://learnche.org/_stats/sparklines.json | python3 -c "
+import json,sys,datetime
+d=json.load(sys.stdin)
+newest=max(p[0] for s in d.values() for p in s)
+print('newest bucket:', newest,
+      '| expected:', datetime.date.today() - datetime.timedelta(days=1))
+"
+# A bucket dated today means lag_days is 0 or the server is running an
+# older build of build-sparklines.py: the count is partial and will
+# plot as a near-zero point at the edge of every chart.
 ```
 
 ### Are the dashboards meaningful?
@@ -334,7 +346,7 @@ section for the canonical talking points.
 
 ### "The sparkline shows nothing on a page that should have data."
 
-Symptoms: sidebar shows the "Page views (365 days)" heading but no
+Symptoms: sidebar shows the "Page views (60 days)" heading but no
 chart underneath, or shows no heading at all when the page does have
 hits.
 
@@ -375,6 +387,64 @@ suspicious goes into `/etc/pid-book/bots.txt`; both pipelines pick
 it up on the next nightly run. Mirror the entry into
 [`scripts/server/bots.txt.example`](../../scripts/server/bots.txt.example)
 in a follow-up PR so a fresh server install starts current.
+
+### "Traffic looks like it is collapsing on the stats page."
+
+Check the right-hand edge of the chart first. Until 2026-08-03 the
+producer published a bucket for the running day, which at cron time
+held only a few hours of traffic, so every chart ended in a near-vertical
+drop to almost zero. That was an artefact of when the job ran, not a
+change in readership.
+
+Both halves now exclude it: `build-sparklines.py` ends its window at
+`lag_days` (default 1) days back, and `telemetry.js` clips to the last
+complete UTC day regardless of what the file contains. If you still see
+the cliff, the server is running an older copy of the script and a
+browser is serving a cached `telemetry.js`; redeploy the script and
+hard-reload.
+
+Once the partial day is excluded, judge the trend on complete days and
+allow for the weekly cycle before concluding anything. Weekends run
+well below weekdays for a textbook, so a Saturday/Sunday pair at the
+end of the window reads as a dip that is not one:
+
+```sh
+# Daily totals across the whole book, most recent 21 complete days.
+curl -sf https://learnche.org/_stats/sparklines.json | python3 -c "
+import json,sys,collections,datetime
+d=json.load(sys.stdin); t=collections.Counter()
+for series in d.values():
+    for day,c in series: t[day]+=c
+for day in sorted(t)[-21:]:
+    name=datetime.date.fromisoformat(day).strftime('%a')
+    print(day, name, str(t[day]).rjust(6))
+"
+```
+
+### "The window is shorter than the 365 days I configured."
+
+Expected, and not a fault. `[windows] days` is a ceiling; the file can
+only hold as much history as the access logs hold. The learnche.org
+archive starts in late May 2026 because the previous `rotate 4`
+logrotate setting purged everything older every four days. See "History
+depth" in [`README.md`](README.md#history-depth-the-window-is-a-ceiling-not-a-promise).
+
+Confirm the archive depth rather than suspecting the aggregator:
+
+```sh
+# Oldest access log still on disk.
+ls -la --time-style=long-iso /var/www/logs/learnche.org/access.log* | head -3
+# Oldest date present in the published JSON.
+curl -sf https://learnche.org/_stats/sparklines.json | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+print(min(p[0] for s in d.values() for p in s))
+"
+```
+
+If the JSON's oldest date is materially newer than the oldest log on
+disk, that is a real problem; check `days` and the `logs` globs in
+`/etc/pid-book/sparklines.conf`.
 
 ### "GoatCounter shows zero hits since yesterday."
 

--- a/docs/telemetry/server-runbook.md
+++ b/docs/telemetry/server-runbook.md
@@ -173,7 +173,11 @@ Key points:
   Caddyfile back to `json`.
 * **`roll_size` / `roll_keep` / `roll_keep_for`** — Caddy rotates the
   log itself. The 400-day retention is ≥ the 365-day sparkline window
-  with ~5 weeks of slack. Increase if you want longer history.
+  with ~5 weeks of slack. Note that the current Apache server keeps 5
+  years (`rotate 1825`), so migrating to this Caddy block as written
+  would start discarding history beyond ~13 months. Raise
+  `roll_keep_for` to match before cutting over if you want to keep the
+  longer archive; logs dropped at rotation cannot be recovered.
 * **`/_stats/*` handle** — same-origin under `learnche.org` so the
   sidebar `fetch("/_stats/sparklines.json")` does not need CORS
   headers. The 1-hour cache is the staleness budget for browser
@@ -232,9 +236,13 @@ occasionally — Cloudflare updates the list every few months.
 
 **Log rotation.** Debian's default `/etc/logrotate.d/apache2` ships
 with `rotate 4`, which keeps only **4 days** of history for busy
-vhosts. With a 365-day sparkline window, that's catastrophic — the
-script reads 4 days of recent data and silently shows almost nothing.
-For 5 years of history bump it to **`rotate 1825`**:
+vhosts. With a 365-day sparkline window, the script then reads 4 days of
+recent data and silently shows almost nothing. This is not hypothetical:
+it is what ran on learnche.org until 2026-05-26, and it is why the
+readership archive now starts in late May 2026 with nothing usable from
+Feb 2022 onward. Deleted logs cannot be recovered, so fix this **before**
+you start relying on the window. For 5 years of history bump it to
+**`rotate 1825`**:
 
 ```sh
 sudo sed -i 's/^\s*rotate 4$/    rotate 1825/' /etc/logrotate.d/apache2
@@ -408,7 +416,9 @@ is stdlib-only Python. Algorithm:
    * UAs matching the bot list (`/etc/pid-book/bots.txt` or fallback),
    * paths matching `STATIC_EXTS`,
    * paths outside `/pid/`,
-   * timestamps outside the 365-day window.
+   * timestamps outside the window, which runs 365 days back from the
+     last complete day. The current day is excluded via `lag_days`
+     (default 1) so no partial bucket is ever published.
 4. For each surviving hit, normalise the URL to a Sphinx pagename
    via `normalise_pagename` (rules documented in
    [`sparklines-schema.md`](sparklines-schema.md)).

--- a/docs/telemetry/sparklines-schema.md
+++ b/docs/telemetry/sparklines-schema.md
@@ -110,11 +110,25 @@ Each value is an array of `[date, count]` pairs.
   at least one hit appears exactly once. **Days with zero hits are
   omitted.** The consumer should not assume the array length equals
   the window length.
-* The window is **the most recent 365 days** (configurable via the
-  producer's `[windows] days` setting, but the JS assumes 90 in its
-  layout). If you change the window length on the server, also
-  update the sidebar heading text in
-  `_templates/pid-sidebar-extra.html` (`"Page views (365 days)"`).
+* The window ends at the **last complete day**, not today. The
+  producer steps back `[windows] lag_days` days (default 1) from the
+  current UTC date, because the nightly cron fires while the current
+  day is still being logged and a partial bucket plots as a near-zero
+  point at the right-hand edge of every chart.
+* The window is **the most recent 365 days** counting back from that
+  last complete day, configurable via the producer's `[windows] days`
+  setting. It is a ceiling: the file holds only as much history as the
+  access logs do, which currently means late May 2026 onward. See
+  "History depth" in
+  [`README.md`](README.md#history-depth-the-window-is-a-ceiling-not-a-promise).
+* The **producer** window and the **consumer** window are independent.
+  `_static/js/telemetry.js` filters this file down to `DISPLAY_DAYS`
+  (currently 60) before rendering, and separately clips to the last
+  complete UTC day so a stale server build cannot reintroduce a
+  partial day. If you change `DISPLAY_DAYS`, also update the sidebar
+  heading text in `_templates/pid-sidebar-extra.html`
+  (`"Page views (60 days)"`) and the three `(last 60 days)` headings
+  plus body text in `stats.rst`.
 * If a page got at least one hit in the window, its entry exists.
 * If a page got **zero hits** in the window, it is **not** in the
   JSON. The consumer treats missing keys and empty arrays
@@ -239,6 +253,7 @@ curl -sf https://learnche.org/_stats/sparklines.json |
 ```
 
 If `sparklines.json` ever becomes a bottleneck (e.g. > 1 MB), revisit
-the schema — but for a book with O(100) pages and 365 days of daily
-counts, the file is ~50–200 KB depending on activity, well below any
-problematic threshold.
+the schema, but for a book with O(100) pages and a 365-day window of
+daily counts, the file is ~50–200 KB depending on activity, well below
+any problematic threshold. (At ~75 days of accumulated history it is
+~140 KB, so a full year lands near the upper end of that range.)

--- a/privacy.rst
+++ b/privacy.rst
@@ -18,15 +18,20 @@ What is collected
   characters are dropped, and anything that looks like an email address is
   dropped client-side before sending.
 * **Server access logs**, processed locally with
-  `GoAccess <https://goaccess.io>`_. IPs are anonymised and only daily
-  aggregates are kept; raw logs rotate within 30 days.
+  `GoAccess <https://goaccess.io>`_. IPs are anonymised in the published
+  reports, and the per-page counts are daily unique-IP totals from which the
+  IPs are discarded after aggregation. The raw logs themselves are rotated by
+  the webserver and retained for up to 5 years, so that the readership
+  history survives; they are never published, and nothing derived from them
+  identifies a reader.
 
-The resulting aggregates — top pages, the 90-day per-page sparklines you see
-in the sidebar, search queries, and an overview report — are **public** at
+The resulting aggregates (top pages, the 60-day per-page sparklines you see
+in the sidebar, search queries, and an overview report) are **public** at
 `learnche.org/_stats/ <https://learnche.org/_stats/>`_, in keeping with the
 open spirit of this CC BY-SA 4.0 book. The same numbers are also surfaced
-inside the book itself on the :ref:`stats` page, and as the 90-day reader
-count next to the sparkline in the sidebar of every page.
+inside the book itself on the :ref:`stats` page, and as the 60-day reader
+count next to the sparkline in the sidebar of every page. Every figure covers
+complete days only, so the most recent day shown is yesterday.
 
 Opt out
 -------

--- a/scripts/server/build-sparklines.py
+++ b/scripts/server/build-sparklines.py
@@ -41,8 +41,19 @@ Algorithm
    (Trailing slash means index page.)
 7. Aggregate (pagename, date) → set of unique IPs.
 8. Convert to (pagename, date) → unique-IP count for the configured
-   window (default 365 days).
+   window (default 365 days), ending at the last *complete* day.
 9. Atomically write JSON to the output path.
+
+Complete days only
+------------------
+The window ends ``lag_days`` days before the current UTC date (default
+1, i.e. yesterday). The cron job runs in the small hours, so the bucket
+for the current date holds only a few hours of traffic; including it put
+a near-zero point at the right-hand edge of every chart that renders
+this file, every day. Excluding it means every point plotted covers a
+full 24 hours and is comparable with its neighbours.
+
+Set ``lag_days = 0`` to include the running (partial) day again.
 
 Privacy
 -------
@@ -64,6 +75,7 @@ otherwise the defaults below. The config is a tiny INI file:
 
     [windows]
     days = 365
+    lag_days = 1
 
 The bot list is one user-agent substring per line; lines starting with
 '#' are comments. Any UA containing one of the substrings (case-
@@ -110,6 +122,10 @@ DEFAULT_LOG_GLOBS = [
 DEFAULT_OUTPUT = "/var/www/learnche.org/_stats/sparklines.json"
 DEFAULT_BOT_LIST = "/etc/pid-book/bots.txt"
 DEFAULT_DAYS = 365
+# Days to step back from "now" for the newest bucket written out. 1 means
+# the window ends yesterday, so no partial day is ever published. See
+# "Complete days only" in the module docstring.
+DEFAULT_LAG_DAYS = 1
 
 # Bot UA substrings used when no bot_list file is present. Keep in sync with
 # scripts/server/goaccessrc.example.
@@ -387,6 +403,7 @@ def build(
     output_path: str,
     bot_list: str,
     days: int,
+    lag_days: int = DEFAULT_LAG_DAYS,
 ) -> None:
     bot_substrings = load_bot_substrings(bot_list)
     log_paths = expand_globs(log_globs)
@@ -394,8 +411,17 @@ def build(
         LOG.error("no log files matched: %s", log_globs)
         sys.exit(2)
 
-    today = dt.date.today()
-    cutoff = today - dt.timedelta(days=days - 1)
+    # Anchor the window in UTC: Caddy JSON timestamps are parsed as UTC,
+    # so using the server's local date here would shift the bucket
+    # boundary whenever the server is not on UTC.
+    #
+    # `newest` is the last complete day. Anything after it is the running
+    # day, which is only partially logged at cron time.
+    lag_days = max(0, lag_days)
+    now_utc = dt.datetime.now(dt.timezone.utc).date()
+    newest = now_utc - dt.timedelta(days=lag_days)
+    cutoff = newest - dt.timedelta(days=days - 1)
+    LOG.info("window %s .. %s (%d days, lag %d)", cutoff, newest, days, lag_days)
 
     # (pagename, date) -> set[ip]
     buckets: dict[tuple[str, dt.date], set[str]] = defaultdict(set)
@@ -426,7 +452,7 @@ def build(
                 if pagename is None:
                     continue
                 day = hit.ts.date()
-                if day < cutoff or day > today:
+                if day < cutoff or day > newest:
                     continue
                 buckets[(pagename, day)].add(hit.ip)
                 matched += 1
@@ -482,7 +508,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     p.add_argument("--bot-list", default=None,
                    help="Override bot UA substring list path.")
     p.add_argument("--days", type=int, default=None,
-                   help="Override window length (default: 90).")
+                   help=f"Override window length (default: {DEFAULT_DAYS}).")
+    p.add_argument("--lag-days", type=int, default=None,
+                   help="Days to step back from today for the newest bucket "
+                        f"(default: {DEFAULT_LAG_DAYS}, i.e. end at "
+                        "yesterday so no partial day is published). "
+                        "Use 0 to include the running day.")
     p.add_argument("--verbose", action="store_true")
     return p.parse_args(argv)
 
@@ -510,9 +541,15 @@ def main(argv: list[str] | None = None) -> None:
     days = (args.days
             or cfg.getint("windows", "days", fallback=0)
             or DEFAULT_DAYS)
+    # 0 is a meaningful lag (publish the running day), so resolve this
+    # one with explicit None checks rather than the `or` chain above.
+    if args.lag_days is not None:
+        lag_days = args.lag_days
+    else:
+        lag_days = cfg.getint("windows", "lag_days", fallback=DEFAULT_LAG_DAYS)
 
     build(log_globs=log_globs, output_path=output,
-          bot_list=bot_list, days=days)
+          bot_list=bot_list, days=days, lag_days=lag_days)
 
 
 if __name__ == "__main__":

--- a/scripts/server/sparklines.conf.example
+++ b/scripts/server/sparklines.conf.example
@@ -1,11 +1,18 @@
 # Configuration for scripts/server/build-sparklines.py.
 #
-# Default backend window is 365 days (1 year). This controls what
-# /_stats/sparklines.json contains. The in-book UI display window is
-# independent: the JS in _static/js/telemetry.js filters this JSON to
-# a shorter window (look for DISPLAY_DAYS) before rendering. Change
-# this value to widen/narrow the backend; change DISPLAY_DAYS to
-# widen/narrow what readers see.
+# Default backend window is 365 days (1 year). This is a ceiling, not a
+# promise: the window can only ever contain as much history as the logs
+# themselves hold. The learnche.org access logs were rotated away every
+# four days until 2026-05-26, so the archive currently starts in late
+# May 2026 and grows by one day per night. The 365-day window fills in
+# over the course of the following year; until then the file simply
+# holds fewer days than the setting allows.
+#
+# This controls what /_stats/sparklines.json contains. The in-book UI
+# display window is independent: the JS in _static/js/telemetry.js
+# filters this JSON to a shorter window (look for DISPLAY_DAYS) before
+# rendering. Change this value to widen/narrow the backend; change
+# DISPLAY_DAYS to widen/narrow what readers see.
 #
 # Install as /etc/pid-book/sparklines.conf. Any value can also be passed
 # on the command line; CLI flags win.
@@ -39,5 +46,15 @@ output = /var/www/learnche.org/_stats/sparklines.json
 bot_list = /etc/pid-book/bots.txt
 
 [windows]
-# How many days of history each sparkline shows.
+# How many days of history each sparkline shows, counting back from the
+# newest complete day. The file holds fewer days than this while the
+# log archive is still filling in (see the note at the top).
 days = 365
+
+# How many days to step back from the current UTC date for the newest
+# bucket written out. The cron job runs in the small hours, so the
+# bucket for the running day would hold only a few hours of traffic and
+# plot as a near-zero point at the right-hand edge of every chart. The
+# default of 1 ends the window at yesterday, so every published bucket
+# covers a full 24 hours. Set to 0 to publish the running day as well.
+lag_days = 1

--- a/stats.rst
+++ b/stats.rst
@@ -26,11 +26,22 @@ See :ref:`privacy` for what is and isn't collected.
      days, so almost nothing from Feb 2022 to May 2026 exists on
      disk.
 
-   The backend keeps a full 365-day window in
-   `sparklines.json <https://learnche.org/_stats/sparklines.json>`_;
-   the in-book display is filtered to a shorter window so a young
-   deployment doesn't look unread. The window will gradually widen
-   over the next few weeks.
+   Because of that second point, there is no year of history to show
+   yet. The backend
+   (`sparklines.json <https://learnche.org/_stats/sparklines.json>`_)
+   is configured for a rolling 365-day window, but a window can only
+   hold what the logs hold: the archive starts in late May 2026 and
+   gains one day per night, so it reaches a full year in May 2027.
+   Until then the file contains fewer days than the setting allows,
+   and the in-book display is filtered to a shorter window so a young
+   deployment doesn't look unread. Year-on-year comparisons are not
+   possible until there are two years on disk.
+
+   All the figures count **complete days only**. The nightly
+   aggregator runs in the small hours, so the current day is still
+   being logged when it runs; publishing it would put a partial count
+   at the right-hand edge of every chart. The most recent day shown is
+   therefore yesterday.
 
 Summary
 -------


### PR DESCRIPTION
The stats page looked like readership was collapsing. It was not. Two
separate things were wrong, one in the code and one in the documentation.

## 1. The chart ended in a cliff every single day

The nightly cron fires in the small hours, so the bucket it wrote for the
current date held only a few hours of traffic. Every chart drawn from
`sparklines.json` therefore dropped to near-zero at its right-hand edge,
every day. On 2026-08-03 the running day showed **63 reads** against a
~500/day baseline, next to a Saturday/Sunday pair that is legitimately low
for a textbook. Together that reads as a collapse.

**`build-sparklines.py`** now ends its window at `lag_days` (default 1) days
before the current UTC date, so every published bucket covers a full 24
hours. `lag_days = 0` restores the old behaviour. The window is also
anchored in UTC now, matching how the Caddy JSON timestamps are parsed,
rather than the server's local date.

**`telemetry.js`** independently clips its display window to the last
complete UTC day. Both guards are deliberate: the book redeploys from CI but
the server script is installed by hand, so the charts stay correct during the
interval when only one of the two has been updated.

## 2. There is no year of history, and the docs said there was

The docs described a "year-long" sparkline and a "365-day window" as
statements of fact. The 365 days is a ceiling, not contents. Debian's stock
`rotate 4` purged the access logs every four days until 2026-05-26, so the
usable archive starts in late May 2026 and gains one day per night. It
reaches a full year in **May 2027**; year-on-year comparison needs two years
on disk. That is now stated plainly in the reader-facing note on
`/pid/stats` and throughout `docs/telemetry/`, with troubleshooting entries
for both symptoms ("traffic looks like it is collapsing", "the window is
shorter than the 365 days I configured").

## Stale claims corrected along the way

All pre-existing, none newly broken by this PR:

- **`privacy.rst` promised raw logs rotate "within 30 days".** They are
  retained 5 years (`rotate 1825`), which was the fix for the data loss. The
  same claim was repeated in the telemetry README's threat model and in
  `architecture.md`, including its risk assessment. **This is a change to the
  public privacy statement, so it is worth your explicit sign-off.** The
  runbook is the source I used; if the production value differs, say so and I
  will correct it.
- `privacy.rst` described the sidebar figures as 90-day; `DISPLAY_DAYS` has
  been 60.
- `sparklines-schema.md` said the JS assumes 90 days, and that the sidebar
  heading reads "Page views (365 days)"; it reads "(60 days)".
- `--days` help text advertised a default of 90 against `DEFAULT_DAYS = 365`.
- The Caddy block in the runbook keeps 400 days, which would silently discard
  history the Apache box now retains for 5 years. Flagged at the point of
  migration rather than changed, since the value is your call.

## What did not change

No change to what is collected, to the telemetry gate, or to the
GoatCounter/GoAccess pipelines. `DISPLAY_DAYS` stays at 60. The underlying
readership numbers are untouched.

## Verification

- `make text`: builds with **zero warnings**.
- `make latex`: generates with **zero warnings**. `make latexpdf` could not
  complete here because `latexmk`/TeX is not installed in the sandbox; note
  that `stats.rst` and `privacy.rst` are HTML-only and absent from `PID.tex`,
  and the other edits are to JS, Python, and Markdown that the PDF never
  reads.
- `make html`: succeeds, and `grep -r goatcounter _build/html/contents`
  returns **0**. No `__PID_TELEMETRY` config is injected into any page.
- The builder was exercised against a synthetic log: default lag stops at
  yesterday, `--lag-days 0` restores the running day.
- The new client windowing was replayed against the live `sparklines.json`.
  The partial day drops out, the window stays a full 60 days
  (2026-06-04 to 2026-08-02), the last plotted point becomes 452 instead of
  63, and the summary cards stay self-consistent at 130 pages / 60 days.

## For the record: the actual trend

Stripping the partial day, weekday (Mon-Fri) median reads went from 713
(2026-05-22 to 06-25) to 628 (06-26 to 07-31), about -12%. Weekends run well
below weekdays (Sat median 425 vs Tue 747). A mild summer softening, not a
collapse.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RB1JQZmttB7RFMpqMcSA5X)_