### PR TITLE
OMARS estimability frontier and trade-off table; generate the two-level trade-off table in code

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.08.09"
-date-released: 2026-08-09
+version: "2026.08.10"
+date-released: 2026-08-10
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ keywords:
   - multivariate data analysis
   - batch data analysis
 license: CC-BY-SA-4.0
-version: "2026.08.03"
-date-released: 2026-08-03
+version: "2026.08.09"
+date-released: 2026-08-09
 repository-code: "https://github.com/kgdunn/pid-book"
 url: "https://learnche.org/pid"
 identifiers:

--- a/design-analysis-experiments/comparing-design-families.rst
+++ b/design-analysis-experiments/comparing-design-families.rst
@@ -117,10 +117,10 @@ the library scores exactly this model and not the full second-order one:
 	def coded(result):
 	    return np.asarray(result.design[names], float)
 
-	bbd = coded(generate_design(factors, "box_behnken", center_points=6))
+	bbd = coded(generate_design(factors, "box_behnken", n_center_points=6))
 	dsd = coded(generate_design(factors, "dsd"))
 	ccd = coded(generate_design(factors, "ccd", cube="fractional",
-	                            alpha="face_centered", center_points=6))
+	                            alpha="face_centered", n_center_points=6))
 	omars = coded(generate_omars(factors, n_runs=25, model="main_quadratic",
 	                             selection_criterion="a_optimal"))
 	designs = {"Box-Behnken": bbd, "CCD": ccd, "OMARS": omars, "DSD": dsd}

--- a/design-analysis-experiments/fractional-factorial-designs/design-resolution.rst
+++ b/design-analysis-experiments/fractional-factorial-designs/design-resolution.rst
@@ -55,3 +55,52 @@ You can use the following table to visualize the trade-off between design resolu
 	:alt:	../../figures/doe/DOE-trade-off-table.svg
 	:scale: 100
 	:align: center
+
+.. _DOE-trade-off-table-in-code:
+
+Generating the trade-off table
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The table is also computed, rather than read off the page, by ``process_improve``. The
+generators in each cell are found by an exhaustive *minimum-aberration* search: for every
+candidate set of generators the defining relation is worked out, the lengths of its words are
+counted, and the set that has the fewest short words is kept. Nothing is looked up from a
+catalogue, and the cells agree with :ref:`the printed table <DOE_design_trade_off_BHH_272>`.
+
+.. code-block:: python
+
+	from process_improve.experiments import trade_off_table, tradeoff
+
+	trade_off_table()             # the whole table, as a pandas DataFrame
+	tradeoff(runs=16, factors=7)  # one cell, with its generators and alias chains
+
+Two things follow from having the table as code rather than as an image. The first is that it
+can be widened past the edge of a printed page:
+``trade_off_table(runs=(8, 16, 32), factors=range(3, 12))`` carries it out to eleven factors.
+The second is that a single cell can be asked for its details, which the image can only
+summarise as a resolution:
+
+.. code-block:: text
+
+	With 16 experiments, and 7 factors:
+	  Design: 2^(7-3) IV
+	  Resolution: IV
+	  Generators:
+	      E=ABC
+	      F=ABD
+	      G=ACD
+	      (each generator may be used with a + or a - sign)
+	  Aliasing (main effects and 2-factor interactions only):
+	      Main effects are not aliased with 2-factor interactions.
+	      A = BCE + BDF + CDG + EFG + ABCFG + ABDEG + ACDEF
+	      ...
+	      AB = CE + DF + ACFG + ADEG + BCDG + BEFG + ABCDEF
+	      ...
+
+Read those two alias chains against the resolution. This is a :math:`2^{7-3}_\text{IV}` design,
+so :math:`4 - 1 = 3` says the main effect **A** is aliased with three-factor interactions and not
+with any two-factor interaction, which is what the report prints; and :math:`4 - 2 = 2` says the
+two-factor interactions are aliased with each other, which is why the chain for **AB** opens with
+**CE** and **DF**. Passing ``display=False`` returns the same information as an object
+whose fields (``label``, ``resolution``, ``generators``, ``defining_relation``, ``aliases``) can
+be read in code.

--- a/design-analysis-experiments/fractional-factorial-designs/design-resolution.rst
+++ b/design-analysis-experiments/fractional-factorial-designs/design-resolution.rst
@@ -69,10 +69,10 @@ catalogue, and the cells agree with :ref:`the printed table <DOE_design_trade_of
 
 .. code-block:: python
 
-	from process_improve.experiments import trade_off_table, tradeoff
+	from process_improve.experiments import get_trade_off_table_entry, trade_off_table
 
-	trade_off_table()             # the whole table, as a pandas DataFrame
-	tradeoff(runs=16, factors=7)  # one cell, with its generators and alias chains
+	trade_off_table()                                       # the whole table
+	get_trade_off_table_entry(n_runs=16, n_factors=7)       # one cell, with its alias chains
 
 Two things follow from having the table as code rather than as an image. The first is that it
 can be widened past the edge of a printed page:

--- a/design-analysis-experiments/omars-designs.rst
+++ b/design-analysis-experiments/omars-designs.rst
@@ -95,9 +95,9 @@ That immediately suggests how to choose:
     *   **Few factors and a genuine response-surface goal, predicting and optimizing over the
         region**: a central composite or Box-Behnken design, or one of the largest OMARS designs.
 
-Saying which specific design is best, even once the run budget is fixed, requires the
-quantitative tools of the next section: the information matrix, the prediction variance and its
-fraction-of-design-space plot, the correlations among the effects, and the power. Those are
+Saying which specific design is best, even once the run budget is fixed, requires quantitative
+tools: the information matrix, the prediction variance and its fraction-of-design-space plot, the
+correlations among the effects, and the power. Those are
 exactly the measures developed in :ref:`Judging and comparing designs
 <DOE-judging-and-comparing-designs>`, and they turn the choice along this spectrum from a matter
 of taste into a matter of arithmetic.
@@ -117,12 +117,37 @@ Gaussian process or a spline fit, would call instead for a design optimal for th
 space-filling one. The spectrum here, and the measures that rank it, therefore describe the
 second-order case, and the model itself is one of the choices rather than a fixed backdrop.
 
+.. _DOE-omars-trade-off-table:
+
+A trade-off table for OMARS designs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :ref:`two-level trade-off table <DOE_design_trade_off_BHH_272>` answers a question of the form
+"I have sixteen runs available and seven factors on the list, what do I give up?". Its currency is
+:ref:`resolution <DOE-design-resolution>`: what is given up as more factors are studied in fewer
+runs is the ability to tell main effects apart from interactions. Resolution III, IV and V form a
+single ordered scale, and the table maps a budget onto it.
+
+The natural thing to want is the same table for OMARS designs. It does not carry over, and the
+reason is worth following, because repairing it turns on a question about run counts that has a
+surprising answer.
+
+An OMARS design has its main effects orthogonal to each other *and* to every second-order term, at
+every size in the family: that is the defining property, and it is what the "orthogonal" in the
+name records. There is no smaller OMARS design in which the main effects are dirtier, and no larger
+one in which they are cleaner. Resolution is constant across the family, so it cannot be what the
+table reports.
+
+What varies instead is *which model the run count makes estimable at all*. That question turns out
+to have a different answer from the one the usual parameter count gives, and the rest of this
+section works it out before returning to the table itself.
+
 .. _DOE-omars-estimability-frontier:
 
 How many runs a second-order model needs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The scenario is that the model is already fixed, and only the run count is open. Take the full
+Take the full
 second-order model in :math:`k` factors: an intercept, :math:`k` main effects, :math:`k` pure
 quadratics, and :math:`k(k-1)/2` two-factor interactions, so
 
@@ -359,7 +384,7 @@ refuses to size for the full second-order model below its frontier.
 .. _DOE-omars-inside-the-band:
 
 Running a design from inside the band
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""""""""""""""""""""""
 
 Suppose the nineteen-run design is run anyway. At the bench nothing goes wrong: nineteen runs give
 nineteen measurements, and none of the data is wasted. What is missing appears at the analysis
@@ -395,27 +420,16 @@ many runs until I get it in all :math:`k`?".
 If the frontier is beyond the budget, the remaining option is to fit a smaller model rather than
 accept a design that cannot fit the larger one. Main effects and pure quadratics need
 :math:`1 + 2k` parameters, which a foldover reaches at :math:`2k + 1` runs and clears with degrees
-of freedom to spare at :math:`2k + 3`. That is the choice the next section sets out cell by cell.
+of freedom to spare at :math:`2k + 3`. That is the choice the table sets out cell by cell.
 
-.. _DOE-omars-trade-off-table:
 
-A trade-off table for OMARS designs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _DOE-omars-reading-the-table:
 
-The :ref:`two-level trade-off table <DOE_design_trade_off_BHH_272>` answers a question of the
-form "I can afford sixteen runs and I have seven factors, what do I give up?". Its currency is
-:ref:`resolution <DOE-design-resolution>`: what you surrender as more factors are squeezed into
-fewer runs is the ability to tell main effects apart from interactions.
+Reading the table
+^^^^^^^^^^^^^^^^^^^^^
 
-That currency does not carry over to OMARS designs. An OMARS design has its main effects
-orthogonal to each other *and* to every second-order term, at every size in the family: that is
-the defining property, and it is what the "orthogonal" in the name records. There is no smaller
-OMARS design in which the main effects are dirtier. Resolution is constant across the family, so
-it cannot be what the table reports.
-
-What varies instead is which model the run budget makes estimable, and
-:ref:`the previous section <DOE-omars-estimability-frontier>` is what sets it. Three capability
-classes follow, tagged with four characters so that they line up in a table:
+With the frontier settled, the cells can say something useful. Three capability classes follow from
+it, tagged with four characters so that they line up in a table:
 
 ``Full``
 	:math:`N \ge k^2 + k + 1`, the estimability frontier. Main effects, pure quadratics and
@@ -469,9 +483,9 @@ leaves over, which is what the model is tested with. Five things are worth readi
 		is a staircase.
 
 	*	**The step up to** ``Full`` **in each column is the estimability frontier**
-		:math:`N = k^2 + k + 1` of :ref:`How many runs a second-order model needs
-		<DOE-omars-estimability-frontier>`: 13, 21, 31, 43 and 57 runs for three to seven
-		factors. Every cell from there down the column is ``Full``.
+		:math:`N = k^2 + k + 1` derived in :ref:`How many runs a second-order model
+		needs <DOE-omars-estimability-frontier>`: 13, 21, 31, 43 and 57 runs for three to
+		seven factors. Every cell from there down the column is ``Full``.
 
 	*	**Blank cells are not designs at all**, rather than poor ones. A foldover has
 		:math:`N = 2h + 1` runs, so an even budget cannot be one, and a budget below
@@ -529,6 +543,36 @@ thresholds are, so a cell that is not the one you wanted still tells you what it
 	  Model: main_quadratic (9 parameters), 8 error df
 	  Thresholds for 4 factors: Satd 9, Quad 11, Full 21 runs.
 	  4 more runs would reach Full (all two-factor interactions estimable).
+
+.. _DOE-omars-worked-examples:
+
+Three worked readings
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The table earns its place before any runs are made, when the design is still a plan on paper.
+Three readings show the kinds of question it settles.
+
+**Six factors in seventeen runs.** This is the size of a published extraction study: six solvent
+and process factors, seventeen runs. The cell is ``Quad df=4``. All six main effects and all six
+quadratics are estimable, with four degrees of freedom left over to test them, so curvature can be
+judged factor by factor. The cell also says what is not on offer: ``Full`` for six factors begins at
+43 runs. The two-factor interactions are in the design, and they are orthogonal to the main effects,
+but they are not in the fitted model, so an interaction that matters has to be found by the staged
+analysis of :ref:`Analysing data from these designs <DOE-analysing-economical-designs>` and then
+confirmed in a follow-up.
+
+**Four factors, with a response surface wanted from one design.** The full second-order model in
+four factors has fifteen parameters, so the parameter count suggests that nineteen runs is
+comfortable. The table gives ``Quad df=10`` at nineteen runs, and puts ``Full`` at twenty-one. Those
+two extra runs are the difference between a model that can be fitted and one that cannot, and the
+cheapest place to discover that is here, rather than after the runs are made.
+
+**Five factors, with a budget that might stretch.** Reading down the :math:`k = 5` column sets out
+the decision. Thirteen runs give ``Quad df=2``, which is estimable and testable, but on two degrees
+of freedom. Seventeen runs give ``Quad df=6``: the same model, with more power behind the tests.
+Thirty-one runs give ``Full df=10``, with every two-factor interaction estimable. Those are three
+different studies rather than three sizes of one, and the middle one is often the right answer,
+since four runs beyond the minimum triple the degrees of freedom without extending the model.
 
 Every number in this table is closed-form: the capability classes come from
 equation :eq:`eq-omars-frontier` and the degrees of freedom from a subtraction, so the table is

--- a/design-analysis-experiments/omars-designs.rst
+++ b/design-analysis-experiments/omars-designs.rst
@@ -122,65 +122,114 @@ second-order case, and the model itself is one of the choices rather than a fixe
 How many runs a second-order model needs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The scenario in this section is that the model is already fixed, and the only question is how
-many runs to buy. Take the full second-order model in :math:`k` factors: an intercept,
-:math:`k` main effects, :math:`k` pure quadratics, and :math:`k(k-1)/2` two-factor interactions,
-so
+The scenario is that the model is already fixed, and only the run count is open. Take the full
+second-order model in :math:`k` factors: an intercept, :math:`k` main effects, :math:`k` pure
+quadratics, and :math:`k(k-1)/2` two-factor interactions, so
 
 .. math::
 
 	p = 1 + 2k + \frac{k(k-1)}{2}
 
-parameters in total. The usual arithmetic stops there: count the parameters, and buy at least
-that many runs. For a foldover design that count is necessary but it is not sufficient, and the
-shortfall is large enough to change which design you order.
+parameters in total. Count the parameters and spend at least that many runs. That rule sizes
+factorial, central composite, Box-Behnken and optimal designs correctly, and it is how designs are
+sized elsewhere in this chapter. Foldover designs are the exception, and this section works out by
+how much.
 
-Recall how a foldover is built, since that is where the answer comes from. A half-design
-:math:`\mathbf{H}` of :math:`h` runs is stacked on its own sign-flipped copy, and a centre run
-is added:
+A foldover stacks a half-design :math:`\mathbf{H}` of :math:`h` runs on its own sign-flipped copy,
+then adds a centre run:
 
 .. math::
 
 	\mathbf{D} = \begin{bmatrix} \mathbf{H} \\ -\mathbf{H} \\ \mathbf{0} \end{bmatrix},
 	\qquad N = 2h + 1
 
-so :math:`N` is always odd. This is the construction behind the
-:ref:`definitive screening design <DOE-definitive-screening-designs>`, where :math:`\mathbf{H}`
-is a conference matrix, and behind most of the OMARS catalogue.
+so :math:`N` is always odd. A row of :math:`\mathbf{H}` and its sign-flipped copy are called a
+:index:`mirror-image pair <pair: mirror-image pair; experiments>`. This is the construction behind
+the :ref:`definitive screening design <DOE-definitive-screening-designs>`, where
+:math:`\mathbf{H}` is a conference matrix, and behind most of the OMARS catalogue.
 
-Now split the model terms by what happens to them when every factor changes sign. The :math:`k`
-main effects are *odd*: :math:`x_i` becomes :math:`-x_i`. Every other term is *even*: the
-intercept is constant, and both :math:`x_i^2` and :math:`x_i x_j` are unchanged when the signs of
-:math:`x_i` and :math:`x_j` are flipped together. So there are
+Sort the model terms by what a mirror-image pair does to them. Flip the sign of *every* factor at
+once: a term either changes sign or it does not. Terms that change sign are **odd**; terms that do
+not are **even**. A term of total degree :math:`d` picks up a factor :math:`(-1)^d`, so the split
+is simply the parity of the degree:
 
-.. math::
+.. list-table:: Model terms sorted by parity.
+	:header-rows: 1
+	:widths: 14 44 22 20
 
-	1 + k + \frac{k(k-1)}{2} = 1 + \frac{k(k+1)}{2}
+	*   - Degree
+	    - Terms
+	    - Under a full sign flip
+	    - Parity
+	*   - 0
+	    - Intercept
+	    - unchanged
+	    - even
+	*   - 1
+	    - Main effects, :math:`x_i`
+	    - changes sign
+	    - odd
+	*   - 2
+	    - Quadratics :math:`x_i^2` and interactions :math:`x_i x_j`
+	    - unchanged
+	    - even
 
-even terms, against :math:`k` odd ones. The consequence for the model matrix :math:`\mathbf{X}`
-is immediate: a run in :math:`\mathbf{H}` and its mirror in :math:`-\mathbf{H}` give *identical*
-rows in the even columns. Those columns therefore see only :math:`h + 1` distinct rows, the
-:math:`h` rows of the half plus the centre run, however large :math:`N` becomes. The odd columns
-contribute at most :math:`k` further directions. Hence, for every foldover design,
+This is the same odd/even split as the *odd design moments* named in the
+:ref:`introduction to OMARS designs <DOE-omars-designs>`, and it explains the "through order
+three" qualifier used there: degree three is odd again.
+
+One point to fix before going on, because the words invite a different reading. Odd and even here
+describe the *term*, not the factor. Both :math:`x_1` and :math:`x_2` are odd; :math:`x_1^2` and
+:math:`x_1 x_2` are both even. Relabelling the factors, or reversing the direction of any of them,
+changes nothing, which is why the constraint below holds for every foldover whatever
+:math:`\mathbf{H}` is.
+
+Now the consequence. A run and its mirror image differ only in sign, so they take *identical*
+values in every even term. Five runs in two factors show the whole effect:
+
+.. code-block:: text
+
+	 run     x1  x2 |   1   x1²  x2²  x1x2     <- the even columns
+	  H  1   +1  +1 |   1    1    1    +1
+	  H  2   +1  -1 |   1    1    1    -1
+	 -H  3   -1  -1 |   1    1    1    +1      identical to run 1
+	 -H  4   -1  +1 |   1    1    1    -1      identical to run 2
+	  0  5    0   0 |   1    0    0     0
+
+Runs 3 and 4 are the mirror images of runs 1 and 2. In the odd columns they change sign, which is
+what lets the design estimate main effects. In the even columns they repeat their partners exactly,
+and add nothing. The even terms therefore see only :math:`h + 1` distinct rows, the :math:`h` rows
+of :math:`\mathbf{H}` plus the centre run, no matter how many runs the foldover contains. Here that
+is three distinct rows against four even columns, and indeed :math:`x_1^2` and :math:`x_2^2` are
+the same column: those two quadratics cannot be told apart. More mirrors will never separate them;
+only more distinct rows in :math:`\mathbf{H}` will.
+
+Counting both parts, the even terms contribute at most :math:`\min\left(h + 1,\, 1 + k(k+1)/2\right)`
+independent directions and the odd terms at most :math:`k`, so for every foldover design
 
 .. math::
 	:label: eq-omars-rank-bound
 
 	\text{rank}(\mathbf{X}) \le k + \min\left(h + 1, \; 1 + \frac{k(k+1)}{2}\right)
 
-with equality when the half-design is in general position. It is an upper bound rather than an
-identity: a half-design with repeated or linearly dependent rows falls short of it.
+This is an upper bound rather than an identity. Reaching it requires the :math:`h + 1` even rows to
+be distinct and linearly independent, and :math:`\mathbf{H}` to have full column rank. A design
+that repeats a run falls short, and so does one whose runs all happen to satisfy a single
+second-degree equation: a two-level design is the standard example, since every run there has
+:math:`x_i^2 = 1`, which is why two levels can never separate the quadratics. The three levels of a
+foldover are what avoid this. Designs in the OMARS catalogue reach the bound.
 
-Equation :eq:`eq-omars-rank-bound` says the full second-order model becomes estimable only once
-:math:`h + 1 \ge 1 + k(k+1)/2`, which is :math:`h \ge k(k+1)/2`, and therefore only once
+Equation :eq:`eq-omars-rank-bound` puts the full second-order model out of reach until
+:math:`h + 1 \ge 1 + k(k+1)/2`, that is :math:`h \ge k(k+1)/2`, and therefore until
 
 .. math::
 	:label: eq-omars-frontier
 
 	N \; \ge \; k^2 + k + 1
 
-We will call :math:`N = k^2 + k + 1` the **estimability frontier**: the smallest foldover design
-in which all :math:`p` coefficients of the full second-order model can be estimated jointly.
+There is no established name for this threshold, so we will call it the **estimability frontier**:
+the smallest foldover design in which all :math:`p` coefficients of the full second-order model can
+be estimated jointly.
 
 .. list-table:: The estimability frontier, against the parameter count it has to clear.
 	:header-rows: 1
@@ -217,24 +266,27 @@ in which all :math:`p` coefficients of the full second-order model can be estima
 	    - 21
 	    - 21
 
-The last two columns hold the same number, and that is not a coincidence. Subtracting the
-parameter count from the frontier gives
+The last two columns hold the same number, and that is not a coincidence. Subtracting the parameter
+count from the frontier gives
 
 .. math::
 
 	\left(k^2 + k + 1\right) - \left(1 + 2k + \frac{k(k-1)}{2}\right) = \frac{k(k-1)}{2}
 
-which is exactly the number of two-factor interactions. There are two things to read from that.
-The first is that having more runs than parameters does not establish that a model can be
-fitted: at four factors, a nineteen-run foldover has four spare runs against a fifteen-parameter
-model, and still cannot estimate it. The second is that at the frontier the degrees of freedom
-left over for error also come to :math:`k(k-1)/2`, since the frontier *is* the parameter count
-plus that amount. The smallest design that can fit the full second-order model therefore arrives
-with enough spare runs to test it, which is not true of designs sized by parameter count alone.
+exactly the number of two-factor interactions. Two things follow from it.
 
-The four-factor case is worth running, because the arithmetic and the rank can be checked
-directly. Build the coded design at nineteen runs and again at twenty-one, form the full
-second-order model matrix, and take its rank:
+The first is the exception to the sizing rule. For a foldover, having more runs than the model has
+parameters does not establish that the model can be fitted. At four factors a
+nineteen-run foldover has four spare runs against a fifteen-parameter model and still cannot
+estimate it. Every other design family in this chapter sizes correctly on the parameter count; this
+one needs :math:`k(k-1)/2` runs beyond it.
+
+The second is that at the frontier the degrees of freedom left over for error also come to
+:math:`k(k-1)/2`. The smallest design that can fit the full second-order model therefore arrives
+with enough spare runs to test it, which is not true of a design sized on the parameter count.
+
+The four-factor case can be checked directly. Build the coded design at nineteen runs and again at
+twenty-one, form the full second-order model matrix, and take its rank:
 
 .. code-block:: python
 
@@ -261,11 +313,11 @@ second-order model matrix, and take its rank:
 	# 19 (19, 15) 14
 	# 21 (21, 15) 15
 
-Nineteen runs give a model matrix with fifteen columns and rank fourteen, one short, so the
-model cannot be fitted at all. Twenty-one runs, the frontier for four factors, give rank fifteen.
-Note that the designs here were asked for with ``model="main_quadratic"``: sizing for the full
-second-order model below its frontier is refused by ``generate_omars``, with a message naming the
-frontier.
+Nineteen runs give a model matrix with fifteen columns and rank fourteen, one short, so the model
+cannot be fitted. Twenty-one runs, the frontier for four factors, give rank fifteen. Judge
+estimability from the rank of the model matrix, not from the determinant of the information
+matrix. The designs here were asked for with ``model="main_quadratic"``, because ``generate_omars``
+refuses to size for the full second-order model below its frontier.
 
 .. code-block:: python
 
@@ -304,20 +356,46 @@ frontier.
 	and still cannot estimate it; the band is :math:`k(k-1)/2` runs deep. The marked point
 	is the four-factor case checked in the code above.
 
-One numerical caution goes with this, for anyone computing their own efficiency measures of the
-kind introduced in :ref:`Judging and comparing designs <DOE-judging-and-comparing-designs>`.
-Those measures are built from the determinant of the information matrix
-:math:`\mathbf{X}^T\mathbf{X}`, and for a rank-deficient design that determinant is exactly zero.
-Computed in floating point, however, a log-determinant routine returns a finite number instead,
-because rounding moves the value off zero. A design that cannot be fitted at all then reports a
-small D-efficiency, which reads as a poor design rather than an impossible one. Test the rank of
-the model matrix, as the code above does, rather than inferring estimability from a determinant
-that came back finite.
+.. _DOE-omars-inside-the-band:
 
-If the frontier is beyond the budget, the option is to change the model rather than to accept a
-design that cannot fit it. Main effects and pure quadratics alone need :math:`1 + 2k`
-parameters, which a foldover reaches at :math:`2k + 1` runs, and clears with degrees of freedom
-to spare at :math:`2k + 3`. That is the choice the next section lays out cell by cell.
+Running a design from inside the band
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Suppose the nineteen-run design is run anyway. At the bench nothing goes wrong: nineteen runs give
+nineteen measurements, and none of the data is wasted. What is missing appears at the analysis
+stage, and it is a question of uniqueness rather than of noise.
+
+Fitting the full second-order model to those nineteen runs leaves one direction in the coefficients
+that the data cannot see, a fixed combination of two of the quadratic terms and three of the
+interactions. Adding any amount of that combination changes the coefficients while leaving all
+nineteen fitted values exactly as they were. The situation is the one where two numbers are known
+to add up to ten and each is asked for separately: every pair that sums to ten agrees with what is
+known, so the information is not wrong, it simply does not single out an answer.
+
+Software asked for "the" answer will still return one. Two coefficient sets differing by up to 8.5
+units in individual terms give identical fitted values at all nineteen runs, the same residual sum
+of squares, and the same :math:`R^2`; the residual plots are identical too. Where they differ is in
+prediction away from the runs that were made: at three untried settings the two sets disagreed by
+8.5 units, by 3.2 units, and at the third by nothing at all. Some directions are unaffected and
+some are not, and the usual summaries do not indicate which one is in play.
+
+What stays sound is worth stating just as plainly. Predictions at the settings that were actually run
+are unaffected. The main effects remain orthogonal to every second-order term, so they are
+estimated cleanly. And the smaller model of main effects and pure quadratics is comfortably
+supported: nineteen runs fit its nine parameters with ten degrees of freedom left for error. The
+decision is therefore between answering the smaller question well with nineteen runs and spending
+two more to reach twenty-one, not between a good experiment and a ruined one.
+
+The literature usually states this capability the other way round, as a projection property: a
+definitive screening design in six or more factors supports a full second-order model in any three
+of its factors, and one of eighteen runs or more in any four. That is the same arithmetic asked
+from the other end, "how many factors can I get a full second-order model in?" rather than "how
+many runs until I get it in all :math:`k`?".
+
+If the frontier is beyond the budget, the remaining option is to fit a smaller model rather than
+accept a design that cannot fit the larger one. Main effects and pure quadratics need
+:math:`1 + 2k` parameters, which a foldover reaches at :math:`2k + 1` runs and clears with degrees
+of freedom to spare at :math:`2k + 3`. That is the choice the next section sets out cell by cell.
 
 .. _DOE-omars-trade-off-table:
 
@@ -361,10 +439,13 @@ report for a single cell, come from ``process_improve``:
 
 .. code-block:: python
 
-	from process_improve.experiments import omars_trade_off_table, omars_tradeoff
+	from process_improve.experiments import (
+	    get_omars_trade_off_table_entry,
+	    omars_trade_off_table,
+	)
 
-	table = omars_trade_off_table()   # the whole table: printed, and returned as a DataFrame
-	omars_tradeoff(17, 4)             # one cell, reported in words
+	omars_trade_off_table()                          # the whole table
+	get_omars_trade_off_table_entry(17, 4)           # one cell, reported in words
 
 .. code-block:: text
 
@@ -381,10 +462,7 @@ report for a single cell, come from ``process_improve``:
 	57    Full 47    Full 42    Full 36    Full 29    Full 21
 
 Each cell carries the capability class and the number of error degrees of freedom the budget
-leaves over, which is what the model is tested with. To keep the staircase legible, ``df =`` is
-printed once per column, on the first live cell; the returned DataFrame keeps the label
-self-contained, so ``table.loc[21, 4]`` is the string ``'Full df=6'``. Five things are worth
-reading off the table:
+leaves over, which is what the model is tested with. Five things are worth reading off the table:
 
 	*	**Down a column, capability only improves; across a row, it only worsens.** More runs
 		never buy less, and more factors never cost less, so the boundary between the classes
@@ -414,11 +492,11 @@ reading off the table:
 .. code-block:: python
 
 	import plotly.graph_objects as go
-	from process_improve.experiments import omars_tradeoff
-	from process_improve.experiments.omars_tradeoff import DEFAULT_FACTORS, DEFAULT_RUNS
+	from process_improve.experiments import get_omars_trade_off_table_entry
+	from process_improve.experiments.omars_trade_off import DEFAULT_FACTORS, DEFAULT_RUNS
 
 	shade = {"full": 3, "quad": 2, "satd": 1, "none": 0}
-	cells = [[omars_tradeoff(n, k, display=False) for k in DEFAULT_FACTORS] for n in DEFAULT_RUNS]
+	cells = [[get_omars_trade_off_table_entry(n, k, display=False) for k in DEFAULT_FACTORS] for n in DEFAULT_RUNS]
 
 	fig = go.Figure(go.Heatmap(
 	    z=[[shade[c.capability] for c in row] for row in cells],
@@ -445,24 +523,22 @@ thresholds are, so a cell that is not the one you wanted still tells you what it
 
 .. code-block:: text
 
-	>>> omars_tradeoff(17, 4)
+	>>> get_omars_trade_off_table_entry(17, 4)
 	OMARS: 17 runs, 4 factors
 	  Quad: main effects and pure quadratics, with error degrees of freedom to test them
 	  Model: main_quadratic (9 parameters), 8 error df
 	  Thresholds for 4 factors: Satd 9, Quad 11, Full 21 runs.
 	  4 more runs would reach Full (all two-factor interactions estimable).
 
-Every number in this table is closed-form, which is why it is worth having separately from the
-designs themselves. Nothing here is searched for: the classes come from
+Every number in this table is closed-form: the capability classes come from
 equation :eq:`eq-omars-frontier` and the degrees of freedom from a subtraction, so the table is
-exact and instant. Building an actual design at one of these sizes is a different matter, because
-the OMARS construction selects the half-design :math:`\mathbf{H}` with an integer program: at
-three factors a single search takes about 0.1 seconds, and at seven factors about 980 seconds.
-That is also why the table
-reports no quality metrics. D-efficiency, the largest correlation among the second-order effects,
-and the projection properties all describe *one particular design* at a given size rather than
-the size itself, so they belong to ``generate_omars`` and to
-:ref:`Judging and comparing designs <DOE-judging-and-comparing-designs>`, not to a cell here.
+exact and instant, while building an actual design at one of these sizes runs an integer program
+that takes about 0.1 seconds at three factors and about 980 seconds at seven.
+
+Quality metrics are absent for a related reason. D-efficiency, the largest correlation among the
+second-order effects and the projection properties all describe one particular design at a given
+size rather than the size itself, so they belong to ``generate_omars`` and to
+:ref:`Judging and comparing designs <DOE-judging-and-comparing-designs>`.
 
 Asking for the design at the four-factor frontier shows how the two fit together. With no run
 count given, ``generate_omars`` sizes the design at the frontier for the model it is asked for,

--- a/design-analysis-experiments/omars-designs.rst
+++ b/design-analysis-experiments/omars-designs.rst
@@ -117,6 +117,365 @@ Gaussian process or a spline fit, would call instead for a design optimal for th
 space-filling one. The spectrum here, and the measures that rank it, therefore describe the
 second-order case, and the model itself is one of the choices rather than a fixed backdrop.
 
+.. _DOE-omars-estimability-frontier:
+
+How many runs a second-order model needs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The scenario in this section is that the model is already fixed, and the only question is how
+many runs to buy. Take the full second-order model in :math:`k` factors: an intercept,
+:math:`k` main effects, :math:`k` pure quadratics, and :math:`k(k-1)/2` two-factor interactions,
+so
+
+.. math::
+
+	p = 1 + 2k + \frac{k(k-1)}{2}
+
+parameters in total. The usual arithmetic stops there: count the parameters, and buy at least
+that many runs. For a foldover design that count is necessary but it is not sufficient, and the
+shortfall is large enough to change which design you order.
+
+Recall how a foldover is built, since that is where the answer comes from. A half-design
+:math:`\mathbf{H}` of :math:`h` runs is stacked on its own sign-flipped copy, and a centre run
+is added:
+
+.. math::
+
+	\mathbf{D} = \begin{bmatrix} \mathbf{H} \\ -\mathbf{H} \\ \mathbf{0} \end{bmatrix},
+	\qquad N = 2h + 1
+
+so :math:`N` is always odd. This is the construction behind the
+:ref:`definitive screening design <DOE-definitive-screening-designs>`, where :math:`\mathbf{H}`
+is a conference matrix, and behind most of the OMARS catalogue.
+
+Now split the model terms by what happens to them when every factor changes sign. The :math:`k`
+main effects are *odd*: :math:`x_i` becomes :math:`-x_i`. Every other term is *even*: the
+intercept is constant, and both :math:`x_i^2` and :math:`x_i x_j` are unchanged when the signs of
+:math:`x_i` and :math:`x_j` are flipped together. So there are
+
+.. math::
+
+	1 + k + \frac{k(k-1)}{2} = 1 + \frac{k(k+1)}{2}
+
+even terms, against :math:`k` odd ones. The consequence for the model matrix :math:`\mathbf{X}`
+is immediate: a run in :math:`\mathbf{H}` and its mirror in :math:`-\mathbf{H}` give *identical*
+rows in the even columns. Those columns therefore see only :math:`h + 1` distinct rows, the
+:math:`h` rows of the half plus the centre run, however large :math:`N` becomes. The odd columns
+contribute at most :math:`k` further directions. Hence, for every foldover design,
+
+.. math::
+	:label: eq-omars-rank-bound
+
+	\text{rank}(\mathbf{X}) \le k + \min\left(h + 1, \; 1 + \frac{k(k+1)}{2}\right)
+
+with equality when the half-design is in general position. It is an upper bound rather than an
+identity: a half-design with repeated or linearly dependent rows falls short of it.
+
+Equation :eq:`eq-omars-rank-bound` says the full second-order model becomes estimable only once
+:math:`h + 1 \ge 1 + k(k+1)/2`, which is :math:`h \ge k(k+1)/2`, and therefore only once
+
+.. math::
+	:label: eq-omars-frontier
+
+	N \; \ge \; k^2 + k + 1
+
+We will call :math:`N = k^2 + k + 1` the **estimability frontier**: the smallest foldover design
+in which all :math:`p` coefficients of the full second-order model can be estimated jointly.
+
+.. list-table:: The estimability frontier, against the parameter count it has to clear.
+	:header-rows: 1
+	:widths: 26 18 18 20 18
+
+	*   - Factors, :math:`k`
+	    - Parameters, :math:`p`
+	    - Frontier, :math:`k^2+k+1`
+	    - Shortfall, :math:`k(k-1)/2`
+	    - Error df at the frontier
+	*   - 3
+	    - 10
+	    - 13
+	    - 3
+	    - 3
+	*   - 4
+	    - 15
+	    - 21
+	    - 6
+	    - 6
+	*   - 5
+	    - 21
+	    - 31
+	    - 10
+	    - 10
+	*   - 6
+	    - 28
+	    - 43
+	    - 15
+	    - 15
+	*   - 7
+	    - 36
+	    - 57
+	    - 21
+	    - 21
+
+The last two columns hold the same number, and that is not a coincidence. Subtracting the
+parameter count from the frontier gives
+
+.. math::
+
+	\left(k^2 + k + 1\right) - \left(1 + 2k + \frac{k(k-1)}{2}\right) = \frac{k(k-1)}{2}
+
+which is exactly the number of two-factor interactions. There are two things to read from that.
+The first is that having more runs than parameters does not establish that a model can be
+fitted: at four factors, a nineteen-run foldover has four spare runs against a fifteen-parameter
+model, and still cannot estimate it. The second is that at the frontier the degrees of freedom
+left over for error also come to :math:`k(k-1)/2`, since the frontier *is* the parameter count
+plus that amount. The smallest design that can fit the full second-order model therefore arrives
+with enough spare runs to test it, which is not true of designs sized by parameter count alone.
+
+The four-factor case is worth running, because the arithmetic and the rank can be checked
+directly. Build the coded design at nineteen runs and again at twenty-one, form the full
+second-order model matrix, and take its rank:
+
+.. code-block:: python
+
+	import itertools
+	import numpy as np
+	from process_improve.experiments import Factor, generate_omars
+
+	def second_order_matrix(levels):
+	    """Model matrix of the full second-order model: intercept, main effects,
+	    pure quadratics, then every two-factor interaction."""
+	    n_runs, k = levels.shape
+	    columns = [np.ones(n_runs)]
+	    columns += [levels[:, i] for i in range(k)]
+	    columns += [levels[:, i] ** 2 for i in range(k)]
+	    columns += [levels[:, i] * levels[:, j] for i, j in itertools.combinations(range(k), 2)]
+	    return np.column_stack(columns)
+
+	factors = [Factor(name=c, low=-1, high=1) for c in "ABCD"]
+	for n_runs in (19, 21):
+	    design = generate_omars(factors, n_runs=n_runs, model="main_quadratic", random_seed=42)
+	    X = second_order_matrix(design.design[design.factor_names].to_numpy(float))
+	    print(n_runs, X.shape, np.linalg.matrix_rank(X))
+
+	# 19 (19, 15) 14
+	# 21 (21, 15) 15
+
+Nineteen runs give a model matrix with fifteen columns and rank fourteen, one short, so the
+model cannot be fitted at all. Twenty-one runs, the frontier for four factors, give rank fifteen.
+Note that the designs here were asked for with ``model="main_quadratic"``: sizing for the full
+second-order model below its frontier is refused by ``generate_omars``, with a message naming the
+frontier.
+
+.. code-block:: python
+
+	import plotly.graph_objects as go
+
+	k = np.arange(3, 8)
+	series = [
+	    ("Estimability frontier, k² + k + 1", k**2 + k + 1, "#D55E00"),
+	    ("Parameters in the full second-order model", 1 + 2 * k + k * (k - 1) // 2, "#0072B2"),
+	    ("Definitive screening design, 2k + 1 runs", 2 * k + 1, "#E69F00"),
+	]
+	fig = go.Figure()
+	for name, values, colour in series:
+	    fig.add_trace(go.Scatter(x=k, y=values, name=name, mode="lines+markers",
+	                             line=dict(color=colour, width=3), marker=dict(size=10)))
+	# Shade the band between the parameter count and the frontier: k(k-1)/2 runs deep.
+	fig.add_trace(go.Scatter(x=np.r_[k, k[::-1]],
+	                         y=np.r_[k**2 + k + 1, (1 + 2 * k + k * (k - 1) // 2)[::-1]],
+	                         fill="toself", fillcolor="rgba(213, 94, 0, 0.13)",
+	                         line=dict(width=0), showlegend=False, hoverinfo="skip"))
+	fig.add_trace(go.Scatter(x=[4], y=[19], mode="markers", showlegend=False,
+	                         marker=dict(symbol="x", size=14, color="#666666"),
+	                         text=["19 runs, 15 parameters, model matrix rank 14"]))
+	fig.update_layout(xaxis_title="Number of factors, k", yaxis_title="Number of runs, N",
+	                  xaxis=dict(tickvals=k), legend=dict(x=0.02, y=0.98))
+	fig.show()
+
+.. figure:: ../figures/doe/omars-estimability-frontier.png
+	:align: center
+	:width: 700px
+	:alt: omars-estimability-frontier.py
+
+	The estimability frontier :math:`N = k^2 + k + 1` for a foldover design, against the
+	parameter count of the full second-order model and the size of a definitive screening
+	design. The shaded band is where a design has more runs than the model has parameters
+	and still cannot estimate it; the band is :math:`k(k-1)/2` runs deep. The marked point
+	is the four-factor case checked in the code above.
+
+One numerical caution goes with this, for anyone computing their own efficiency measures of the
+kind introduced in :ref:`Judging and comparing designs <DOE-judging-and-comparing-designs>`.
+Those measures are built from the determinant of the information matrix
+:math:`\mathbf{X}^T\mathbf{X}`, and for a rank-deficient design that determinant is exactly zero.
+Computed in floating point, however, a log-determinant routine returns a finite number instead,
+because rounding moves the value off zero. A design that cannot be fitted at all then reports a
+small D-efficiency, which reads as a poor design rather than an impossible one. Test the rank of
+the model matrix, as the code above does, rather than inferring estimability from a determinant
+that came back finite.
+
+If the frontier is beyond the budget, the option is to change the model rather than to accept a
+design that cannot fit it. Main effects and pure quadratics alone need :math:`1 + 2k`
+parameters, which a foldover reaches at :math:`2k + 1` runs, and clears with degrees of freedom
+to spare at :math:`2k + 3`. That is the choice the next section lays out cell by cell.
+
+.. _DOE-omars-trade-off-table:
+
+A trade-off table for OMARS designs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :ref:`two-level trade-off table <DOE_design_trade_off_BHH_272>` answers a question of the
+form "I can afford sixteen runs and I have seven factors, what do I give up?". Its currency is
+:ref:`resolution <DOE-design-resolution>`: what you surrender as more factors are squeezed into
+fewer runs is the ability to tell main effects apart from interactions.
+
+That currency does not carry over to OMARS designs. An OMARS design has its main effects
+orthogonal to each other *and* to every second-order term, at every size in the family: that is
+the defining property, and it is what the "orthogonal" in the name records. There is no smaller
+OMARS design in which the main effects are dirtier. Resolution is constant across the family, so
+it cannot be what the table reports.
+
+What varies instead is which model the run budget makes estimable, and
+:ref:`the previous section <DOE-omars-estimability-frontier>` is what sets it. Three capability
+classes follow, tagged with four characters so that they line up in a table:
+
+``Full``
+	:math:`N \ge k^2 + k + 1`, the estimability frontier. Main effects, pure quadratics and
+	every two-factor interaction are estimable jointly, so a response surface can be fitted
+	from this one design without a follow-up.
+
+``Quad``
+	:math:`N \ge 2k + 3`. Main effects and the pure quadratics are estimable, with degrees of
+	freedom left over to test them, so curvature can be judged factor by factor. The two-factor
+	interactions are present in the *design*, and they are still orthogonal to the main effects,
+	but they are not in the *model*.
+
+``Satd``
+	:math:`N = 2k + 1`. Saturated: the parameters of the main-effects-plus-quadratics model can
+	be estimated, but nothing is left with which to estimate :math:`\sigma^2`, so there are point
+	estimates and no standard errors, no tests, and no power.
+
+The three tags sort alphabetically in decreasing order of capability, ``Full`` before ``Quad``
+before ``Satd``, which makes the table easy to read down a column. The table itself, and the
+report for a single cell, come from ``process_improve``:
+
+.. code-block:: python
+
+	from process_improve.experiments import omars_trade_off_table, omars_tradeoff
+
+	table = omars_trade_off_table()   # the whole table: printed, and returned as a DataFrame
+	omars_tradeoff(17, 4)             # one cell, reported in words
+
+.. code-block:: text
+
+	runs  k=3        k=4        k=5        k=6        k=7
+	-------------------------------------------------------------
+	9     Quad df=2  Satd df=0
+	13    Full 3     Quad 4     Quad df=2  Satd df=0
+	17    Full 7     Quad 8     Quad 6     Quad 4     Quad df=2
+	21    Full 11    Full 6     Quad 10    Quad 8     Quad 6
+	25    Full 15    Full 10    Quad 14    Quad 12    Quad 10
+	31    Full 21    Full 16    Full 10    Quad 18    Quad 16
+	37    Full 27    Full 22    Full 16    Quad 24    Quad 22
+	43    Full 33    Full 28    Full 22    Full 15    Quad 28
+	57    Full 47    Full 42    Full 36    Full 29    Full 21
+
+Each cell carries the capability class and the number of error degrees of freedom the budget
+leaves over, which is what the model is tested with. To keep the staircase legible, ``df =`` is
+printed once per column, on the first live cell; the returned DataFrame keeps the label
+self-contained, so ``table.loc[21, 4]`` is the string ``'Full df=6'``. Five things are worth
+reading off the table:
+
+	*	**Down a column, capability only improves; across a row, it only worsens.** More runs
+		never buy less, and more factors never cost less, so the boundary between the classes
+		is a staircase.
+
+	*	**The step up to** ``Full`` **in each column is the estimability frontier**
+		:math:`N = k^2 + k + 1` of :ref:`How many runs a second-order model needs
+		<DOE-omars-estimability-frontier>`: 13, 21, 31, 43 and 57 runs for three to seven
+		factors. Every cell from there down the column is ``Full``.
+
+	*	**Blank cells are not designs at all**, rather than poor ones. A foldover has
+		:math:`N = 2h + 1` runs, so an even budget cannot be one, and a budget below
+		:math:`2k + 1` cannot hold the main effects and the quadratics.
+
+	*	**Error degrees of freedom are not comparable across the classes**, because the model
+		differs. At 43 runs, six factors show ``Full df=15`` and seven factors show
+		``Quad df=28``: the seven-factor cell has more spare runs precisely because it is
+		fitting the smaller model.
+
+	*	**The definitive screening design sits in the top live cell of each column.** For an
+		even number of factors a DSD has :math:`2k+1` runs and lands in ``Satd``, which is
+		another way of saying a nine-run, four-factor DSD is exactly saturated for main effects
+		and quadratics. For an odd number of factors the conference-matrix construction needs
+		:math:`2k+3` runs, so the three-, five- and seven-factor DSDs (nine, thirteen and
+		seventeen runs) arrive with two spare degrees of freedom and land in ``Quad df=2``.
+
+.. code-block:: python
+
+	import plotly.graph_objects as go
+	from process_improve.experiments import omars_tradeoff
+	from process_improve.experiments.omars_tradeoff import DEFAULT_FACTORS, DEFAULT_RUNS
+
+	shade = {"full": 3, "quad": 2, "satd": 1, "none": 0}
+	cells = [[omars_tradeoff(n, k, display=False) for k in DEFAULT_FACTORS] for n in DEFAULT_RUNS]
+
+	fig = go.Figure(go.Heatmap(
+	    z=[[shade[c.capability] for c in row] for row in cells],
+	    x=[f"k = {k}" for k in DEFAULT_FACTORS], y=[str(n) for n in DEFAULT_RUNS],
+	    text=[[f"{c.tag}<br>df = {c.error_df}" if c.exists else "" for c in row] for row in cells],
+	    texttemplate="%{text}", showscale=False, xgap=3, ygap=3,
+	    colorscale=[[0.0, "#F4F4F4"], [0.33, "#E69F00"], [0.67, "#56B4E9"], [1.0, "#0072B2"]]))
+	fig.update_layout(xaxis_title="Number of factors", yaxis_title="Number of runs",
+	                  xaxis=dict(side="top"), yaxis=dict(autorange="reversed"))
+	fig.show()
+
+.. figure:: ../figures/doe/omars-capability-staircase.png
+	:align: center
+	:width: 640px
+	:alt: omars-capability-staircase.py
+
+	The OMARS trade-off table, drawn as a capability staircase. Each cell gives the largest
+	model the run budget makes estimable and the error degrees of freedom left to test it.
+	The outlined cells are the estimability frontier :math:`N = k^2 + k + 1`, the first
+	``Full`` cell in each column. Blank cells are budgets that are not a foldover design.
+
+For a single budget the same information is reported in words, including what the neighbouring
+thresholds are, so a cell that is not the one you wanted still tells you what it would take:
+
+.. code-block:: text
+
+	>>> omars_tradeoff(17, 4)
+	OMARS: 17 runs, 4 factors
+	  Quad: main effects and pure quadratics, with error degrees of freedom to test them
+	  Model: main_quadratic (9 parameters), 8 error df
+	  Thresholds for 4 factors: Satd 9, Quad 11, Full 21 runs.
+	  4 more runs would reach Full (all two-factor interactions estimable).
+
+Every number in this table is closed-form, which is why it is worth having separately from the
+designs themselves. Nothing here is searched for: the classes come from
+equation :eq:`eq-omars-frontier` and the degrees of freedom from a subtraction, so the table is
+exact and instant. Building an actual design at one of these sizes is a different matter, because
+the OMARS construction selects the half-design :math:`\mathbf{H}` with an integer program: at
+three factors a single search takes about 0.1 seconds, and at seven factors about 980 seconds.
+That is also why the table
+reports no quality metrics. D-efficiency, the largest correlation among the second-order effects,
+and the projection properties all describe *one particular design* at a given size rather than
+the size itself, so they belong to ``generate_omars`` and to
+:ref:`Judging and comparing designs <DOE-judging-and-comparing-designs>`, not to a cell here.
+
+Asking for the design at the four-factor frontier shows how the two fit together. With no run
+count given, ``generate_omars`` sizes the design at the frontier for the model it is asked for,
+and reports the rank it achieved alongside the degrees of freedom that leaves:
+
+.. code-block:: python
+
+	design = generate_omars([Factor(name=c, low=-1, high=1) for c in "ABCD"], random_seed=42)
+	print(design.n_runs)                                  # 21
+	print(design.metadata["model_rank"])                  # 15, so the model is estimable
+	print(design.metadata["min_runs_for_model"])          # 21, the frontier
+	print(design.metadata["expected_error_df"])           # 6, which is k(k-1)/2
+
 .. _DOE-analysing-economical-designs:
 
 Analysing data from these designs
@@ -124,12 +483,15 @@ Analysing data from these designs
 
 One last point, and it is easy to get wrong. Because these designs are deliberately economical
 and carry structured aliasing, you should *not* simply throw the data at a least squares fit of
-the full second-order model. Two things go wrong if you do. The model often has more terms than
-the design has runs, so it is not estimable at all: the :math:`\mathbf{X}^T\mathbf{X}` matrix is
-singular and cannot be inverted. For four factors, for example, the full quadratic model has
-:math:`1 + 4 + 4 + 6 = 15` terms (an intercept, four main effects, four quadratics, and six
-two-factor interactions), while a definitive screening design has only nine runs and even the
-thirteen-run OMARS design has only thirteen, so neither can fit the full model. And even when it
+the full second-order model. Two things go wrong if you do. The model is often not estimable at
+all, so the :math:`\mathbf{X}^T\mathbf{X}` matrix is singular and cannot be inverted. For four
+factors, for example, the full quadratic model has :math:`1 + 4 + 4 + 6 = 15` terms (an
+intercept, four main effects, four quadratics, and six two-factor interactions), while the
+nine-run definitive screening design has nine runs and the thirteen-run OMARS design has
+thirteen, so neither can fit it. As :ref:`the estimability frontier
+<DOE-omars-estimability-frontier>` shows, the run count is not the binding constraint either: a
+nineteen-run foldover in four factors has four runs to spare against those fifteen terms and
+still cannot estimate them, because twenty-one runs are needed. And even when the model
 can be fitted, a generic stepwise or penalised
 regression treats every column alike and can let the entangled second-order effects leak into,
 and bias, the main-effect estimates, throwing away the very orthogonality the design worked so
@@ -146,9 +508,10 @@ be told apart. The workflow is:
     design matrix  +  measured responses
              |
              v
-    (0)  enough spare error degrees of freedom?
-         ( runs greater than the number of terms being fitted )
-         if not  ->  stop; replicate or add runs first
+    (0)  is the model ESTIMABLE, with error df to spare?
+         ( rank of the model matrix equals the number of terms
+           being fitted, and the run count exceeds it )
+         if not  ->  stop; shrink the model, replicate, or add runs
              |
              v
     (1)  estimate the MAIN EFFECTS
@@ -172,9 +535,12 @@ be told apart. The workflow is:
              v
     final model: the active main, quadratic, and interaction effects
 
-Step 0 is not a formality. A *saturated* design, one with no spare runs, leaves nothing with
-which to estimate the noise :math:`\sigma^2`, and without that estimate there are no standard
-errors, no tests, and no power: the analysis simply cannot start. Step 1 is possible only
+Step 0 is not a formality, and it has two parts. A *saturated* design, one with no spare runs,
+leaves nothing with which to estimate the noise :math:`\sigma^2`, and without that estimate there
+are no standard errors, no tests, and no power: the analysis cannot start. Below the
+:ref:`estimability frontier <DOE-omars-estimability-frontier>` the situation is more basic still,
+since the coefficients themselves have no unique solution, which is why the check is on the rank
+of the model matrix and not on the run count. Step 1 is possible only
 because of the orthogonality property: the main effects are unaliased with every second-order
 term, so their estimates are unbiased no matter which interactions or quadratics are truly
 active, which is what lets us analyse them on their own. Step 4 is where the design's one weakness is managed:


### PR DESCRIPTION
Adds the OMARS estimability frontier and the OMARS trade-off table to the Design and Analysis of Experiments chapter, and shows the two-level trade-off table being generated rather than only pictured.

Companion PRs: **kgdunn/figures#80** (merged) and **kgdunn/process-improve#491** (the API rename this depends on).

## 1. Generating the two-level trade-off table

`design-analysis-experiments/fractional-factorial-designs/design-resolution.rst`

The two-level trade-off table has only ever appeared as a scanned image adapted from Box, Hunter and Hunter. A new subsection shows it computed instead, by an exhaustive minimum-aberration search rather than a lookup. Two things follow: the table can be widened past the printed edge, and a single cell can be asked for its generators, defining relation and alias chains, where the image can only give a resolution. The worked cell is 16 runs in 7 factors, read back against the resolution rules stated earlier on the same page.

## 2. How many runs a second-order model needs

The chapter previously said these designs cannot fit the full second-order model because they have fewer runs than terms. True, but it understates the constraint.

A foldover is `[H; -H; 0]`. Every second-order term is an even function, so a run and its mirror image give identical rows in the quadratic and interaction columns. Those columns see only `h + 1` distinct rows however large `N` grows, which bounds the rank and puts the full second-order model out of reach until

```
N  >=  k^2 + k + 1        k=3: 13,  k=4: 21,  k=5: 31,  k=6: 43,  k=7: 57
```

Two consequences carry the section:

- **Having more runs than parameters does not establish that a model can be fitted.** At four factors a nineteen-run foldover has four spare runs against a fifteen-parameter model and still comes back rank fourteen. The section builds both designs and prints the ranks, so this is checkable rather than assertable. This is stated explicitly as the exception to a sizing rule that works everywhere else in the chapter.
- **The shortfall is exactly `k(k-1)/2`**, the number of two-factor interactions, so the smallest design that can fit the full second-order model arrives with just enough spare runs to test it.

A new subsection, **Running a design from inside the band**, answers what the first draft left open: what actually happens if you run one of these anyway. Nothing at the bench; the issue is uniqueness, not noise. One invisible direction in the coefficients means two coefficient sets differing by up to 8.5 units give identical fitted values, the same residual sum of squares and the same residual plots, while disagreeing by up to 8.5 units at settings that were never run. What stays sound is stated just as plainly, and it lands on a choice between two sound experiments rather than on alarm.

## 3. A trade-off table for OMARS designs

The counterpart of the two-level table, and the pivot is why it cannot look the same. Resolution is the two-level table's currency, but an OMARS design has clean main effects at every size in the family, so resolution is constant and cannot be what varies. What varies is which model the budget makes estimable: `Full`, `Quad` or `Satd`, each cell carrying the error degrees of freedom left over.

Five reading notes follow, including where the definitive screening designs land, which ties the section back to the DSD chapter: for an even number of factors a DSD is `2k+1` runs and exactly saturated, while for an odd number the conference-matrix construction needs `2k+3`, so it arrives with two spare degrees of freedom.

## Editing round

A second pass reworked the first draft against a list of specific objections:

- **The parity passage.** "Odd" and "even" naturally read as indexing the factor, which is not what they mean. It now defines parity by the sign-flip test, ties it to the parity of the term's total degree in a small table, says plainly what the words do not mean, and notes the invariance to relabelling. It also links back to the "odd design moments" sentence already in the OMARS introduction and explains its "through order three" qualifier.
- **A five-run worked example** in two factors, showing mirror images repeating their partners exactly in the even columns: three distinct even rows against four even columns, with the two quadratics collapsing onto one column.
- **"In general position"** was unexplained jargon. Replaced by the two conditions it stands for, with the two-level design named as the standard failure case, which also explains why three levels are needed.
- **"Estimability frontier"** is now flagged as a name being introduced rather than standard vocabulary, since it does not appear in the literature, and related to the projection-based statements that are standard.
- **Cuts.** The opening paragraphs roughly halved; the floating-point caution about log-determinants reduced to one sentence, since the book is not about numerical issues; the note on how the table lays out its printed output removed as implementation trivia; the closed-form paragraph halved.

## Knock-on edits

- The paragraph in "Analysing data from these designs" that motivated the staged analysis now points at the frontier and states the sharper fact.
- Step 0 of the analysis workflow was "runs greater than the number of terms being fitted", which the frontier shows is insufficient. It now checks the rank of the model matrix.
- Code blocks updated for the renamed API in kgdunn/process-improve#491: `get_trade_off_table_entry(n_runs, n_factors)` and `get_omars_trade_off_table_entry(n_runs, n_factors)`, and the module `experiments.omars_trade_off`.

## Figures

Two, both in kgdunn/figures#80, each with a matplotlib script beside the PNG and a plotly code block in the chapter. The frontier plot shades the band where a design has more runs than parameters and still cannot estimate the model. The capability staircase draws the trade-off table with the frontier cells outlined, so the same staircase appears in both figures; every value is read from the library, so it cannot drift.

## Verification

44 automated checks against the library, covering the five-run illustration, the rank results, the frontier table and its `k(k-1)/2` identity, the inside-the-band figures, the whole trade-off table, both monotonicity claims, the DSD placement by parity of `k`, and the two-level cell with its quoted alias chains.

`make text` and `make html` both succeed with **zero warnings**, and `grep -r goatcounter _build/html/contents` returns zero hits. `CITATION.cff` updated.

## One thing left for the author

`judging-and-comparing-designs.rst:324` contains the phrase "spends its four extra runs to buy two estimable two-factor interactions". The phrasing was flagged as not matching the author's voice, but it is pre-existing prose outside this change, so it has been left alone rather than edited unasked.